### PR TITLE
Introduce MatchResult enum

### DIFF
--- a/causaganha/core/pipeline.py
+++ b/causaganha/core/pipeline.py
@@ -14,11 +14,12 @@ from .extractor import GeminiExtractor as _RealGeminiExtractor
 try:
     from .utils import normalize_lawyer_name, validate_decision
     from .trueskill_rating import (
-        ENV as TRUESKILL_ENV, # Renomeado para evitar conflito com ENV de configuração do pipeline
+        ENV as TRUESKILL_ENV,  # Renomeado para evitar conflito com ENV de configuração do pipeline
+        MatchResult,
         create_new_rating,
         update_ratings as update_trueskill_ratings,
-        trueskill, # To create Rating objects from stored mu/sigma
-        TS_CONFIG # Acessar a configuração carregada do toml
+        trueskill,  # To create Rating objects from stored mu/sigma
+        TS_CONFIG,  # Acessar a configuração carregada do toml
     )
 except ImportError as e:
     # This might happen if script is run directly and not as part of the package.
@@ -34,6 +35,13 @@ except ImportError as e:
         return False
 
     # Dummy TrueSkill related functions if import fails
+    from enum import Enum
+
+    class MatchResult(Enum):
+        WIN_A = "win_a"
+        WIN_B = "win_b"
+        DRAW = "draw"
+
     class DummyRating:
         def __init__(self, mu=25.0, sigma=8.33):
             self.mu = mu
@@ -282,16 +290,16 @@ def _update_trueskill_ratings_logic(logger: logging.Logger, dry_run: bool):
                 continue
 
             resultado_str_raw = decision_data.get("resultado", "").lower()
-            trueskill_match_result = "draw" # Default
+            trueskill_match_result = MatchResult.DRAW
             if resultado_str_raw in ["procedente", "provido", "confirmada"]:
-                trueskill_match_result = "win_a"
+                trueskill_match_result = MatchResult.WIN_A
             elif resultado_str_raw in ["improcedente", "negado_provimento", "reformada"]:
-                trueskill_match_result = "win_b"
+                trueskill_match_result = MatchResult.WIN_B
             elif resultado_str_raw in [
                 "parcialmente procedente", "parcialmente_procedente",
                 "extinto sem resolução de mérito", "extinto", "não_definido",
             ]:
-                trueskill_match_result = "draw"
+                trueskill_match_result = MatchResult.DRAW
             else:
                 logger.warning(
                     f"Unknown 'resultado' ('{resultado_str_raw}') for {decision_data.get('numero_processo')}. Treating as a draw."
@@ -326,7 +334,10 @@ def _update_trueskill_ratings_logic(logger: logging.Logger, dry_run: bool):
             }
 
             new_team_a_ratings, new_team_b_ratings = update_trueskill_ratings(
-                TRUESKILL_ENV, team_a_ratings_before, team_b_ratings_before, trueskill_match_result
+                TRUESKILL_ENV,
+                team_a_ratings_before,
+                team_b_ratings_before,
+                trueskill_match_result,
             )
 
             # Update ratings_df for Team A
@@ -365,7 +376,7 @@ def _update_trueskill_ratings_logic(logger: logging.Logger, dry_run: bool):
                 "equipe_b_ids": ",".join(team_b_ids),
                 "ratings_equipe_a_antes": json.dumps(partida_team_a_ratings_before_dict),
                 "ratings_equipe_b_antes": json.dumps(partida_team_b_ratings_before_dict),
-                "resultado_partida": trueskill_match_result,
+                "resultado_partida": trueskill_match_result.value,
                 "ratings_equipe_a_depois": json.dumps(partida_team_a_ratings_after_dict),
                 "ratings_equipe_b_depois": json.dumps(partida_team_b_ratings_after_dict),
                 "numero_processo": decision_data.get("numero_processo"),

--- a/causaganha/tests/test_trueskill_rating.py
+++ b/causaganha/tests/test_trueskill_rating.py
@@ -13,7 +13,10 @@ sys.path.insert(
 
 # Importar o módulo e as constantes/funções a serem testadas
 from causaganha.core import trueskill_rating as ts_rating
-from causaganha.core.trueskill_rating import trueskill # Para criar Rating objects diretamente para comparação
+from causaganha.core.trueskill_rating import (
+    trueskill,  # Para criar Rating objects diretamente para comparação
+    MatchResult,
+)
 
 class TestTrueSkillRatingCalculations(unittest.TestCase):
 
@@ -38,7 +41,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         """Testa se update_ratings levanta ValueError para um resultado inválido."""
         team_a = [self.r_alpha]
         team_b = [self.r_beta]
-        with self.assertRaisesRegex(ValueError, "Resultado desconhecido: non_existent_result"):
+        with self.assertRaisesRegex(
+            ValueError, "Resultado desconhecido: non_existent_result"
+        ):
             ts_rating.update_ratings(self.env, team_a, team_b, "non_existent_result")
 
     def test_update_ratings_1v1_win_a(self):
@@ -46,7 +51,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha]
         team_b_before = [self.r_beta] # r_beta tem o mesmo rating que r_alpha
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, MatchResult.WIN_A
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -73,7 +80,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [r_alpha_custom]
         team_b_before = [r_beta_custom]
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "draw")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, MatchResult.DRAW
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -89,7 +98,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha, self.r_beta] # Ambos com rating padrão
         team_b_before = [self.r_gamma]             # Rating padrão
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, MatchResult.WIN_A
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_a[1]
@@ -120,7 +131,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_b_before = [b1, b2]
 
         new_team_a, new_team_b = ts_rating.update_ratings(
-            self.env, team_a_before, team_b_before, "win_a"
+            self.env, team_a_before, team_b_before, MatchResult.WIN_A
         )
 
         a1_after, a2_after = new_team_a
@@ -143,7 +154,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_delta_expert] # Experiente
         team_b_before = [self.r_alpha]        # Novato (rating padrão)
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_b")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, MatchResult.WIN_B
+        )
 
         r_delta_after = new_team_a[0]
         r_alpha_after = new_team_b[0]
@@ -165,7 +178,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         r_std2_before = self.env.create_rating() # Jogador B padrão
 
         # Jogo padrão: Jogador B (std2) vence Jogador A (std1)
-        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(self.env, [r_std1_before], [r_std2_before], "win_b")
+        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(
+            self.env, [r_std1_before], [r_std2_before], MatchResult.WIN_B
+        )
         r_std1_after = r_std1_after_list[0]
         r_std2_after = r_std2_after_list[0]
 
@@ -190,13 +205,17 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         initial_sigma = r_player1.sigma
 
         # Partida 1: P1 vs P2
-        p1_after_match1_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player2], "win_a")
+        p1_after_match1_list, _ = ts_rating.update_ratings(
+            self.env, [r_player1], [r_player2], MatchResult.WIN_A
+        )
         r_player1 = p1_after_match1_list[0]
         self.assertLess(r_player1.sigma, initial_sigma)
         sigma_after_1_match = r_player1.sigma
 
         # Partida 2: P1 vs P3
-        p1_after_match2_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player3], "win_a")
+        p1_after_match2_list, _ = ts_rating.update_ratings(
+            self.env, [r_player1], [r_player3], MatchResult.WIN_A
+        )
         r_player1 = p1_after_match2_list[0]
         self.assertLess(r_player1.sigma, sigma_after_1_match)
         sigma_after_2_matches = r_player1.sigma
@@ -216,7 +235,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_p1_p2 = [r_player1, p2_rating_from_match1] # r_player1 (após partida 2) em equipe com r_player1 (após partida 1)
         team_p3_p4 = [r_player3, r_player4] # r_player3 e r_player4 ainda com ratings iniciais
 
-        p1_p2_after_match3_list, _ = ts_rating.update_ratings(self.env, team_p1_p2, team_p3_p4, "draw")
+        p1_p2_after_match3_list, _ = ts_rating.update_ratings(
+            self.env, team_p1_p2, team_p3_p4, MatchResult.DRAW
+        )
         r_player1 = p1_p2_after_match3_list[0]
         self.assertLess(r_player1.sigma, sigma_after_2_matches)
 


### PR DESCRIPTION
## Summary
- add `MatchResult` enum in `trueskill_rating`
- update pipeline to use the enum instead of raw strings
- adjust tests for enum API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c28fda6748325acd0e12d023e8aab