### PR TITLE
Add VSCode defaults for Ruff and pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.defaultInterpreterPath": ".venv/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.ruffEnabled": true,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "tests"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ IA_SECRET_KEY=sua_chave_secreta_ia # Obrigatório para Internet Archive
 uv run pytest -q
 ```
 
+### Uso opcional no VSCode
+
+Para quem utiliza o VSCode, o diretório `.vscode/` contém configurações que:
+
+- Definem `.venv/bin/python` como interpretador padrão;
+- Ativam o linter **Ruff**;
+- Configuram a descoberta de testes em `tests/`.
+
+
 ## Status do Projeto
 
 **Status: 🔶 ALPHA DISTRIBUÍDO** - Sistema experimental operando com automação avançada, mudanças radicais esperadas.


### PR DESCRIPTION
## Summary
- add `.vscode/settings.json` configuring Python interpreter, Ruff, and test discovery
- document optional VSCode usage in `README.md`

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6828bb848325ade8495b42e52c1f