### PR TITLE
Add Sphinx docs build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,5 @@ jobs:
           fi
       - name: Run tests
         run: uv run pytest tests/ --cov=src --cov-report=xml
+      - name: Build documentation
+        run: make docs

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ data/*
 coverage.xml
 .coverage
 htmlcov/
+docs/_build/
 data/causaganha.duckdb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: docs
+docs:
+	@sphinx-build -b html docs/api docs/_build

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ IA_SECRET_KEY=sua_chave_secreta_ia # Obrigatório para Internet Archive
 uv run pytest -q
 ```
 
+## Documentação
+
+Para gerar a documentação HTML localmente utilize o Sphinx:
+
+```bash
+sphinx-build -b html docs/api docs/_build
+```
+
 ## Status do Projeto
 
 **Status: 🔶 ALPHA DISTRIBUÍDO** - Sistema experimental operando com automação avançada, mudanças radicais esperadas.

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'CausaGanha'
+copyright = '2025, CausaGanha Team'
+author = 'CausaGanha Team'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+extensions = [
+    'sphinx.ext.autodoc',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,17 @@
+.. CausaGanha documentation master file, created by
+   sphinx-quickstart on Sat Jun 28 03:59:08 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+CausaGanha documentation
+========================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+src
+===
+
+.. toctree::
+   :maxdepth: 4
+
+   src

--- a/docs/api/src.models.rst
+++ b/docs/api/src.models.rst
@@ -1,0 +1,29 @@
+src.models package
+==================
+
+Submodules
+----------
+
+src.models.diario module
+------------------------
+
+.. automodule:: src.models.diario
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.models.interfaces module
+----------------------------
+
+.. automodule:: src.models.interfaces
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: src.models
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/src.rst
+++ b/docs/api/src.rst
@@ -1,0 +1,126 @@
+src package
+===========
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.models
+   src.tribunais
+
+Submodules
+----------
+
+src.archive\_db module
+----------------------
+
+.. automodule:: src.archive_db
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.async\_diario\_pipeline module
+----------------------------------
+
+.. automodule:: src.async_diario_pipeline
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.cli module
+--------------
+
+.. automodule:: src.cli
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.config module
+-----------------
+
+.. automodule:: src.config
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.database module
+-------------------
+
+.. automodule:: src.database
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.extractor module
+--------------------
+
+.. automodule:: src.extractor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.ia\_database\_sync module
+-----------------------------
+
+.. automodule:: src.ia_database_sync
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.ia\_discovery module
+------------------------
+
+.. automodule:: src.ia_discovery
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.ia\_helpers module
+----------------------
+
+.. automodule:: src.ia_helpers
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.openskill\_rating module
+----------------------------
+
+.. automodule:: src.openskill_rating
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.pii\_manager module
+-----------------------
+
+.. automodule:: src.pii_manager
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.pipeline module
+-------------------
+
+.. automodule:: src.pipeline
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.utils module
+----------------
+
+.. automodule:: src.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: src
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/src.tribunais.rst
+++ b/docs/api/src.tribunais.rst
@@ -1,0 +1,18 @@
+src.tribunais package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.tribunais.tjro
+
+Module contents
+---------------
+
+.. automodule:: src.tribunais
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/src.tribunais.tjro.rst
+++ b/docs/api/src.tribunais.tjro.rst
@@ -1,0 +1,69 @@
+src.tribunais.tjro package
+==========================
+
+Submodules
+----------
+
+src.tribunais.tjro.adapter module
+---------------------------------
+
+.. automodule:: src.tribunais.tjro.adapter
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.analyze\_adapter module
+------------------------------------------
+
+.. automodule:: src.tribunais.tjro.analyze_adapter
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.collect\_and\_archive module
+-----------------------------------------------
+
+.. automodule:: src.tribunais.tjro.collect_and_archive
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.diario\_processor module
+-------------------------------------------
+
+.. automodule:: src.tribunais.tjro.diario_processor
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.discovery module
+-----------------------------------
+
+.. automodule:: src.tribunais.tjro.discovery
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.download\_adapter module
+-------------------------------------------
+
+.. automodule:: src.tribunais.tjro.download_adapter
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+src.tribunais.tjro.downloader module
+------------------------------------
+
+.. automodule:: src.tribunais.tjro.downloader
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: src.tribunais.tjro
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=4.0.0",
     "ruff>=0.12.0",
+    "sphinx>=8.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- generate Sphinx config under `docs/api`
- document how to build docs in README
- add make target and CI step for docs
- include sphinx in dev extras

## Testing
- `uv run pytest -q`
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_685f68233ff08325b8f41bcaba36ba24