### PR TITLE
Fix jules1 tests and docs

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -6,6 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import sys
+
 project = 'CausaGanha'
 copyright = '2025, CausaGanha Team'
 author = 'CausaGanha Team'
@@ -13,8 +16,7 @@ author = 'CausaGanha Team'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-import os
-import sys
+
 sys.path.insert(0, os.path.abspath('../..'))
 
 extensions = [

--- a/tests/test_ia_discovery.py
+++ b/tests/test_ia_discovery.py
@@ -12,7 +12,7 @@ SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from ia_discovery import main, IADiscovery
+from ia_discovery import main  # noqa: E402
 
 
 class TestIADiscoveryCLI(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix Sphinx conf imports
- make test utilities create real PDFs using fitz when PyPDF2 is absent
- skip benchmark if a valid PDF can't be created
- simplify extractor fallback test
- lint all tests and docs

## Testing
- `uv sync --dev`
- `uv pip install -e .[dev]`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f84a03a7c83258b621f857246258d