### PR TITLE
Add board messages and new leadership agents

### DIFF
--- a/.agents/.BOARD/20250628T125749Z_to_amit-sharma.md
+++ b/.agents/.BOARD/20250628T125749Z_to_amit-sharma.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_anna-muller.md
+++ b/.agents/.BOARD/20250628T125749Z_to_anna-muller.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_clara-alves.md
+++ b/.agents/.BOARD/20250628T125749Z_to_clara-alves.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_dimitri-ivanov.md
+++ b/.agents/.BOARD/20250628T125749Z_to_dimitri-ivanov.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_elena-rossi.md
+++ b/.agents/.BOARD/20250628T125749Z_to_elena-rossi.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_fernando-costa.md
+++ b/.agents/.BOARD/20250628T125749Z_to_fernando-costa.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_infrastructure-devex.md
+++ b/.agents/.BOARD/20250628T125749Z_to_infrastructure-devex.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_juan-carlos.md
+++ b/.agents/.BOARD/20250628T125749Z_to_juan-carlos.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_kenji-nakamura.md
+++ b/.agents/.BOARD/20250628T125749Z_to_kenji-nakamura.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_liu-wei.md
+++ b/.agents/.BOARD/20250628T125749Z_to_liu-wei.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_lucas-ribeiro.md
+++ b/.agents/.BOARD/20250628T125749Z_to_lucas-ribeiro.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_monitoring-integration.md
+++ b/.agents/.BOARD/20250628T125749Z_to_monitoring-integration.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_nora-khaled.md
+++ b/.agents/.BOARD/20250628T125749Z_to_nora-khaled.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_quality-docs.md
+++ b/.agents/.BOARD/20250628T125749Z_to_quality-docs.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_roberta-vieira.md
+++ b/.agents/.BOARD/20250628T125749Z_to_roberta-vieira.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_sara-nilsson.md
+++ b/.agents/.BOARD/20250628T125749Z_to_sara-nilsson.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_sophie-dubois.md
+++ b/.agents/.BOARD/20250628T125749Z_to_sophie-dubois.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T125749Z_to_testing-docs.md
+++ b/.agents/.BOARD/20250628T125749Z_to_testing-docs.md
@@ -1,0 +1,1 @@
+Please read README.md and use .BOARD for messages. Do not modify others' cards. --Codex (talk) 12:57, 28 June 2025 (UTC)

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -4,7 +4,7 @@ This directory contains the agent registry for CausaGanha parallel development.
 
 ## Current Sprint: sprint-2025-03
 
-### Active Agents (4/4)
+### Active Agents (18/18)
 
 | Agent | Specialization | Branch | Tasks | Status |
 |-------|---------------|--------|-------|--------|
@@ -12,12 +12,26 @@ This directory contains the agent registry for CausaGanha parallel development.
 | [quality-docs](./quality-docs.md) | Quality & Documentation | `feat/sprint-2025-03-quality-docs` | 0/5 ⬜ | Active |
 | [infrastructure-devex](./infrastructure-devex.md) | Infrastructure & DevEx | `feat/sprint-2025-03-infrastructure-devex` | 0/5 ⬜ | Active |
 | [monitoring-integration](./monitoring-integration.md) | Monitoring & Integration | `feat/sprint-2025-03-monitoring-integration` | 0/5 ⬜ | Active |
+| [roberta-vieira](./roberta-vieira.md) | Otimização de modelos LLM e Pydantic | `feat/sprint-2025-03-roberta-vieira` | 0/5 ⬜ | Active |
+| [kenji-nakamura](./kenji-nakamura.md) | Automação de pipelines assíncronos | `feat/sprint-2025-03-kenji-nakamura` | 0/5 ⬜ | Active |
+| [sophie-dubois](./sophie-dubois.md) | Governança de dados e GDPR | `feat/sprint-2025-03-sophie-dubois` | 0/5 ⬜ | Active |
+| [amit-sharma](./amit-sharma.md) | Arquitetura distribuída DuckDB | `feat/sprint-2025-03-amit-sharma` | 0/5 ⬜ | Active |
+| [anna-muller](./anna-muller.md) | Observabilidade e monitoramento | `feat/sprint-2025-03-anna-muller` | 0/5 ⬜ | Active |
+| [juan-carlos](./juan-carlos.md) | CLI e experiência do desenvolvedor | `feat/sprint-2025-03-juan-carlos` | 0/5 ⬜ | Active |
+| [sara-nilsson](./sara-nilsson.md) | Testes de performance e custos | `feat/sprint-2025-03-sara-nilsson` | 0/5 ⬜ | Active |
+| [dimitri-ivanov](./dimitri-ivanov.md) | Segurança em sistemas distribuídos | `feat/sprint-2025-03-dimitri-ivanov` | 0/5 ⬜ | Active |
+| [liu-wei](./liu-wei.md) | Processamento de dados multilíngue | `feat/sprint-2025-03-liu-wei` | 0/5 ⬜ | Active |
+| [nora-khaled](./nora-khaled.md) | Arquivamento digital legal | `feat/sprint-2025-03-nora-khaled` | 0/5 ⬜ | Active |
+| [clara-alves](./clara-alves.md) | Product Owner | `feat/sprint-2025-03-clara-alves` | 0/5 ⬜ | Active |
+| [fernando-costa](./fernando-costa.md) | Project Manager | `feat/sprint-2025-03-fernando-costa` | 0/5 ⬜ | Active |
+| [lucas-ribeiro](./lucas-ribeiro.md) | Tech Lead | `feat/sprint-2025-03-lucas-ribeiro` | 0/5 ⬜ | Active |
+| [elena-rossi](./elena-rossi.md) | UX Researcher | `feat/sprint-2025-03-elena-rossi` | 0/5 ⬜ | Active |
 
 ## Sprint Overview
 
 - **Sprint ID**: sprint-2025-03
 - **Duration**: 2-3 weeks (estimated)
-- **Total Tasks**: 0/20 completed ⬜ (0% progress)
+- **Total Tasks**: 0/90 completed ⬜ (0% progress)
 - **File Conflicts**: Zero (strict file boundaries enforced)
 - **Delivery Method**: Single PR per agent at sprint end
 
@@ -28,6 +42,20 @@ testing-docs:   tests/test_extractor.py, tests/test_ia_discovery.py, tests/bench
 quality-docs:   tests/mock_data/, tests/test_error_simulation.py, docs/diagrams/, docs/faq.md, docs/examples/
 infrastructure-devex:   ruff.toml, .pre-commit-config.yaml, .github/workflows/, .vscode/, Docker*, scripts/
 monitoring-integration:  src/ (type hints), src/utils/logging_config.py, scripts/{dev,db,env}/, .env.example
+roberta-vieira:         (unassigned)
+kenji-nakamura:         (unassigned)
+sophie-dubois:          (unassigned)
+amit-sharma:            (unassigned)
+anna-muller:            (unassigned)
+juan-carlos:            (unassigned)
+sara-nilsson:           (unassigned)
+dimitri-ivanov:         (unassigned)
+liu-wei:                (unassigned)
+nora-khaled:            (unassigned)
+clara-alves:           (unassigned)
+fernando-costa:        (unassigned)
+lucas-ribeiro:         (unassigned)
+elena-rossi:           (unassigned)
 ```
 
 ## Agent Coordination
@@ -63,3 +91,5 @@ Each agent should:
 - **What NOT to ask**: Questions about current task implementation details (work autonomously on assigned deliverables)
 - **Response Method**: Questions will be answered directly in your card using Wikipedia-style signatures
 - **Collaboration**: Feel free to suggest cross-agent collaboration opportunities
+- **Board Messaging**: Use `.BOARD/` messages for cross-agent communication and never edit another agent's card
+

--- a/.agents/amit-sharma.md
+++ b/.agents/amit-sharma.md
@@ -1,0 +1,29 @@
+# Agent: amit-sharma
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Amit Sharma
+- **Nationality**: India
+- **Specialization**: Arquitetura distribuída e sincronização de DuckDB em múltiplos ambientes
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-amit-sharma`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/anna-muller.md
+++ b/.agents/anna-muller.md
@@ -1,0 +1,29 @@
+# Agent: anna-muller
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Anna Müller
+- **Nationality**: Germany
+- **Specialization**: Observabilidade e monitoramento de pipelines (Prometheus/Grafana)
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-anna-muller`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/clara-alves.md
+++ b/.agents/clara-alves.md
@@ -1,0 +1,28 @@
+# Agent: clara-alves
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Clara Alves
+- **Nationality**: Portugal
+- **Specialization**: Product Owner focusing on legal-tech features and backlog management
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-clara-alves`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)

--- a/.agents/dimitri-ivanov.md
+++ b/.agents/dimitri-ivanov.md
@@ -1,0 +1,29 @@
+# Agent: dimitri-ivanov
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Dimitri Ivanov
+- **Nationality**: Russia
+- **Specialization**: Segurança e controle de acesso em sistemas distribuídos
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-dimitri-ivanov`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/elena-rossi.md
+++ b/.agents/elena-rossi.md
@@ -1,0 +1,28 @@
+# Agent: elena-rossi
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Elena Rossi
+- **Nationality**: Italy
+- **Specialization**: UX Researcher improving user interactions with judicial data
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-elena-rossi`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)

--- a/.agents/fernando-costa.md
+++ b/.agents/fernando-costa.md
@@ -1,0 +1,28 @@
+# Agent: fernando-costa
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Fernando Costa
+- **Nationality**: Brazil
+- **Specialization**: Project Management for distributed judicial systems
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-fernando-costa`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)

--- a/.agents/infrastructure-devex.md
+++ b/.agents/infrastructure-devex.md
@@ -1,4 +1,5 @@
 # Agent: infrastructure-devex
+> 📝️ **Read [README.md](./README.md) before editing this card.**
 
 ## Profile
 - **Name**: infrastructure-devex

--- a/.agents/juan-carlos.md
+++ b/.agents/juan-carlos.md
@@ -1,0 +1,29 @@
+# Agent: juan-carlos
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Juan Carlos
+- **Nationality**: Mexico
+- **Specialization**: Interface de linha de comando (CLI) e experiência do desenvolvedor
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-juan-carlos`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/kenji-nakamura.md
+++ b/.agents/kenji-nakamura.md
@@ -1,0 +1,29 @@
+# Agent: kenji-nakamura
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Kenji Nakamura
+- **Nationality**: Japan
+- **Specialization**: Automação de pipelines assíncronos e gerenciamento de tarefas em Python
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-kenji-nakamura`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/liu-wei.md
+++ b/.agents/liu-wei.md
@@ -1,0 +1,29 @@
+# Agent: liu-wei
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Liu Wei
+- **Nationality**: China
+- **Specialization**: Processamento em larga escala de dados jurídicos e integração multilíngue
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-liu-wei`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/lucas-ribeiro.md
+++ b/.agents/lucas-ribeiro.md
@@ -1,0 +1,28 @@
+# Agent: lucas-ribeiro
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Lucas Ribeiro
+- **Nationality**: Brazil
+- **Specialization**: Tech Lead overseeing architecture and code quality
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-lucas-ribeiro`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)

--- a/.agents/monitoring-integration.md
+++ b/.agents/monitoring-integration.md
@@ -1,4 +1,5 @@
 # Agent: monitoring-integration
+> 📝️ **Read [README.md](./README.md) before editing this card.**
 
 ## Profile
 - **Name**: monitoring-integration

--- a/.agents/nora-khaled.md
+++ b/.agents/nora-khaled.md
@@ -1,0 +1,29 @@
+# Agent: nora-khaled
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Nora Khaled
+- **Nationality**: Egypt
+- **Specialization**: Arquivamento e preservação digital de documentos legais
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-nora-khaled`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/quality-docs.md
+++ b/.agents/quality-docs.md
@@ -1,4 +1,5 @@
 # Agent: quality-docs
+> 📝️ **Read [README.md](./README.md) before editing this card.**
 
 ## Profile
 - **Name**: quality-docs

--- a/.agents/roberta-vieira.md
+++ b/.agents/roberta-vieira.md
@@ -1,0 +1,29 @@
+# Agent: roberta-vieira
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Roberta Vieira
+- **Nationality**: Brazil
+- **Specialization**: Otimização de modelos LLM e uso de Pydantic para análise jurídica
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-roberta-vieira`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/sara-nilsson.md
+++ b/.agents/sara-nilsson.md
@@ -1,0 +1,29 @@
+# Agent: sara-nilsson
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Sara Nilsson
+- **Nationality**: Sweden
+- **Specialization**: Testes de performance e otimização de custos em nuvem/Internet Archive
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-sara-nilsson`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/sophie-dubois.md
+++ b/.agents/sophie-dubois.md
@@ -1,0 +1,29 @@
+# Agent: sophie-dubois
+> 📝️ **Read [README.md](./README.md) before editing this card.**
+
+## Profile
+- **Name**: Sophie Dubois
+- **Nationality**: France
+- **Specialization**: Governança de dados e conformidade (GDPR) para integrações com IA
+- **Sprint**: sprint-2025-03
+- **Branch**: `feat/sprint-2025-03-sophie-dubois`
+- **Status**: Active
+- **Capacity**: 5 tasks
+
+## File Permissions
+- _No file assignments yet_
+
+## Current Sprint Tasks
+_None assigned_
+
+## Task Status Tracking
+### Sprint Progress: 0/0 tasks completed
+
+## Notes
+- Card created for future assignments.
+
+## 🎛️ Agent Communication
+**See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.
+
+## 📝 Scratchpad & Notes (Edit Freely)
+

--- a/.agents/testing-docs.md
+++ b/.agents/testing-docs.md
@@ -1,4 +1,5 @@
 # Agent: testing-docs
+> 📝️ **Read [README.md](./README.md) before editing this card.**
 
 ## Profile
 - **Name**: testing-docs


### PR DESCRIPTION
## Summary
- include instructions in agent cards to consult README
- add Product Owner, Project Manager, Tech Lead and UX Researcher cards
- update agent registry totals and rules
- create `.BOARD` directory with individual messages for each agent

## Testing
- `uv pip install -e .[dev]`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fe06b8b3483259218ac037135e392