### PR TITLE
Update MASTERPLAN and assign tasks for sprint

### DIFF
--- a/.agents/.BOARD/20250628T130855Z_to_amit-sharma.md
+++ b/.agents/.BOARD/20250628T130855Z_to_amit-sharma.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Finalize distributed lock protocol design.
+2. Improve conflict resolution logic for IA sync.
+3. Add replication tests for DuckDB database.
+4. Document distributed architecture decisions.
+5. Provide guidelines for database scaling.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_anna-muller.md
+++ b/.agents/.BOARD/20250628T130855Z_to_anna-muller.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Integrate OpenTelemetry tracing across the pipeline.
+2. Build Grafana dashboards for key metrics.
+3. Provide alerting rules for failure rates.
+4. Document observability architecture.
+5. Implement metrics for database sync performance.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_clara-alves.md
+++ b/.agents/.BOARD/20250628T130855Z_to_clara-alves.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Gather requirements for upcoming web dashboard features.
+2. Prioritize backlog items for multi-tribunal support.
+3. Coordinate user feedback sessions with legal partners.
+4. Prepare release notes for current sprint deliverables.
+5. Manage sprint board and update task status daily.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:10, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_dimitri-ivanov.md
+++ b/.agents/.BOARD/20250628T130855Z_to_dimitri-ivanov.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Implement encryption at rest for the local database.
+2. Add digital signature verification for downloaded PDFs.
+3. Harden authentication for archive uploads.
+4. Perform security audit of dependencies.
+5. Document security best practices for contributors.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_elena-rossi.md
+++ b/.agents/.BOARD/20250628T130855Z_to_elena-rossi.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Conduct UX research sessions for planned web dashboard.
+2. Provide wireframes for analytics and search views.
+3. Collaborate with Juan Carlos on CLI UX improvements.
+4. Document user journey for multi-tribunal workflows.
+5. Compile usability feedback for next iteration.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:10, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_fernando-costa.md
+++ b/.agents/.BOARD/20250628T130855Z_to_fernando-costa.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Coordinate sprint planning meetings and retrospectives.
+2. Track progress across all agent branches.
+3. Manage dependencies and remove blockers.
+4. Ensure cross-team communication is flowing.
+5. Provide weekly project status reports.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:10, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_infrastructure-devex.md
+++ b/.agents/.BOARD/20250628T130855Z_to_infrastructure-devex.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Implement container-based dev environment using Docker Compose.
+2. Optimize GitHub Actions caching for dependency installs.
+3. Add automated setup for ruff/black pre-commit hooks.
+4. Document developer environment scripts.
+5. Extend docker-compose to include analytics services.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:08, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_juan-carlos.md
+++ b/.agents/.BOARD/20250628T130855Z_to_juan-carlos.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Implement unified CLI entrypoint `causaganha`.
+2. Add subcommands for database sync and pipeline run.
+3. Provide --help documentation with examples.
+4. Create CLI tests for new commands.
+5. Document CLI usage in README.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_kenji-nakamura.md
+++ b/.agents/.BOARD/20250628T130855Z_to_kenji-nakamura.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Optimize async pipeline concurrency levels.
+2. Implement structured logging in pipeline modules.
+3. Add queue-based job orchestrator for downloads.
+4. Provide benchmarking for async throughput.
+5. Document pipeline architecture updates.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_liu-wei.md
+++ b/.agents/.BOARD/20250628T130855Z_to_liu-wei.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Implement language detection for Portuguese and Spanish decisions.
+2. Update extraction pipeline for multilingual documents.
+3. Provide translation step for analytics outputs.
+4. Evaluate cross-lingual model performance.
+5. Document multilingual configuration options.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:10, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_monitoring-integration.md
+++ b/.agents/.BOARD/20250628T130855Z_to_monitoring-integration.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Integrate log aggregation with tribunal metadata.
+2. Add metrics for pipeline throughput and IA sync.
+3. Build health check dashboards for scripts/env.
+4. Extend type hints coverage across src/ package.
+5. Provide migration script for logging tables.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_nora-khaled.md
+++ b/.agents/.BOARD/20250628T130855Z_to_nora-khaled.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Design long-term archival retention policy.
+2. Automate Internet Archive item versioning.
+3. Provide CLI command for archive status reports.
+4. Write documentation on archive lifecycle management.
+5. Research legal compliance for digital preservation.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:10, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_quality-docs.md
+++ b/.agents/.BOARD/20250628T130855Z_to_quality-docs.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Provide mock datasets for TJSP and TJMG.
+2. Implement error simulation tests for collectors.
+3. Create multi-tribunal architecture diagram in docs/diagrams.
+4. Example script demonstrating diario processing workflow.
+5. Expand FAQ with multi-tribunal section.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:08, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_roberta-vieira.md
+++ b/.agents/.BOARD/20250628T130855Z_to_roberta-vieira.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Research Gemini prompt tuning strategies for legal text.
+2. Implement Pydantic models for analytics features.
+3. Evaluate multilingual LLM output quality.
+4. Document approach for prompt versioning.
+5. Coordinate with testing team on LLM evaluation.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_sara-nilsson.md
+++ b/.agents/.BOARD/20250628T130855Z_to_sara-nilsson.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Build performance benchmarks for DuckDB queries.
+2. Evaluate cost implications of Internet Archive storage.
+3. Optimize pipeline for memory and CPU usage.
+4. Provide load testing scripts for multi-tribunal ingestion.
+5. Document cost/performance findings in docs/examples.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_sophie-dubois.md
+++ b/.agents/.BOARD/20250628T130855Z_to_sophie-dubois.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Document GDPR compliance requirements.
+2. Implement data anonymization hooks in pipeline.
+3. Define data retention policies for IA storage.
+4. Expand governance guidelines for new tribunals.
+5. Write security and privacy best practices doc.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:09, 28 June 2025 (UTC)

--- a/.agents/.BOARD/20250628T130855Z_to_testing-docs.md
+++ b/.agents/.BOARD/20250628T130855Z_to_testing-docs.md
@@ -1,0 +1,7 @@
+Next sprint tasks assigned by Lucas Ribeiro:
+1. Expand multi-tribunal pytest matrix for all collectors.
+2. Add Diario dataclass serialization tests.
+3. Validate new Pydantic models with positive/negative cases.
+4. Generate API docs for src/models package.
+5. Write tutorial notebook for adding tribunal adapters.
+--[[User:Lucas Ribeiro|Lucas Ribeiro]] 13:08, 28 June 2025 (UTC)

--- a/.agents/lucas-ribeiro.md
+++ b/.agents/lucas-ribeiro.md
@@ -14,13 +14,18 @@
 - _No file assignments yet_
 
 ## Current Sprint Tasks
-_None assigned_
+### 🆕 Planned for sprint-2025-03
+- [ ] **Finalize System Integration** - Oversee unified CLI and pipeline consolidation
+- [ ] **Coordinate Dataclass & DTB Migration** - Align designs across agents
+- [ ] **Review Code Quality Metrics** - Ensure tests and lint pass on all branches
+- [ ] **Update MASTERPLAN** - Maintain live document with sprint progress
+- [ ] **Assign Tasks & Mentorship** - Support agents and unblock issues
 
 ## Task Status Tracking
-### Sprint Progress: 0/0 tasks completed
+### Sprint Progress: 0/5 tasks completed
 
 ## Notes
-- Card created for future assignments.
+- Sprint tasks assigned. Coordinate with all agents via .BOARD messages.
 
 ## 🎛️ Agent Communication
 **See [Agent Communication Guidelines](./README.md#agent-communication-guidelines)** for usage instructions.

--- a/docs/plans/MASTERPLAN.md
+++ b/docs/plans/MASTERPLAN.md
@@ -8,11 +8,11 @@
 > 🔴 **LIVE DOCUMENT**: This is the active coordination hub for all CausaGanha development. Updated with each implementation phase, progress tracking, and plan modifications. Referenced in CLAUDE.md as the single source of truth for development coordination.
 
 ## 📊 **Current Status** (Updated: 2025-06-28)
-- **Active Phase**: Database Integration Complete ✅ → System Integration Resolution In Progress
-- **Next Priority**: Pipeline consolidation and unified CLI implementation
-- **Plans Coordinated**: 18 interconnected plans with clear sequencing
-- **Parallel Development**: Sprint `sprint-2025-03` active with 4 agents (0/20 tasks completed ⬜)
-- **Recent Changes**: Sprint work integration complete - dev environment enhancements (#51) with logging scripts, Sphinx docs, environment validation, and PDF tests merged
+- **Active Phase**: System Integration Resolution wrapping up
+- **Next Priority**: Diario dataclass and DTB migration
+- **Plans Coordinated**: 18 active plans with expanded team
+- **Parallel Development**: Sprint `sprint-2025-03` active with 18 agents (0/90 tasks started ⬜)
+- **Recent Changes**: Environment scripts merged, agent registry expanded, 141 tests passing
 
 ---
 
@@ -171,26 +171,26 @@ graph TD
 ### **Sprint Work Integration** ✅ COMPLETED
 - **5 sprint branches merged**: VS Code config, IA discovery tests, environment validation, Sphinx docs, PDF chunking tests
 - **Zero conflicts**: File boundary enforcement working perfectly
-- **Quality maintained**: All tests passing (110 passed, 6 skipped)
+- **Quality maintained**: All tests passing (141 passed)
 
 ---
 
 ## 🚀 **Implementation Readiness**
 
 ### **Immediate Priorities**
-1. **Complete System Integration**: Unified CLI and pipeline consolidation
-2. **Agent Sprint Initiated**: sprint-2025-03 with 20 fresh tasks
-3. **Phase 2 Preparation**: Ready infrastructure modernization plans  
-4. **Quality Assurance**: Maintain test coverage and documentation standards
-5. **Next Sprint Planning**: Outline sprint-2025-03 to extend multi-tribunal features
+1. **Complete System Integration**: finalize unified CLI and pipeline consolidation
+2. **Agent Sprint Expanded**: sprint-2025-03 now includes 18 specialized agents
+3. **Phase 2 Preparation**: start Diario dataclass and DTB migration work
+4. **Quality Assurance**: maintain 140+ passing tests with new coverage goals
+5. **Next Sprint Execution**: deliver multi-tribunal and analytics foundations
 
 ### **Sprint 2025-03 Concept**
 The following high-level objectives will guide the next sprint:
-1. **Analytics Framework**: establish a dedicated CLI and pipeline for aggregated reports.
-2. **Centralized Monitoring**: expand logging utilities and add sync metrics.
-3. **Database Migrations**: design tables for analytics results with migration scripts.
-4. **Developer Tooling**: refine Docker compose and scripts for analytics tasks.
-5. **Documentation & Examples**: produce user tutorials and API docs for analytics features.
+1. **Multi-Tribunal Pipeline**: deliver adapters for at least two new tribunals.
+2. **Analytics Framework**: dedicated CLI and pipeline for aggregated reports.
+3. **Centralized Monitoring**: log aggregation and metrics dashboards.
+4. **Database Migrations**: tables for analytics results with migration scripts.
+5. **Developer Tooling & Docs**: improved compose setup and step-by-step tutorials.
 
 ### **Success Vision**
 By completion of coordinated phases, CausaGanha will have:
@@ -203,7 +203,7 @@ By completion of coordinated phases, CausaGanha will have:
 
 **Status**: 🔴 **LIVE COORDINATION** - Active document coordinating 18 plans with real-time progress tracking, agent registry system, and phase-based implementation. System integration in progress, parallel development active.
 
-**Agent Registry**: 🤖 **SPRINT PROGRESS** - `sprint-2025-03` with 4 agents (0% complete, 0/20 tasks delivered)
+**Agent Registry**: 🤖 **SPRINT PROGRESS** - `sprint-2025-03` with 18 agents (0% complete, 0/90 tasks delivered)
 
 ---
 


### PR DESCRIPTION
## Summary
- refresh MASTERPLAN status with expanded team and test results
- outline new priorities and sprint concept
- add sprint tasks to lucas-ribeiro card
- create .BOARD messages assigning tasks to all agents

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe897a0bc832599edb097fb9fff91