### PR TITLE
Update testing-docs sprint tracker

### DIFF
--- a/.agents/testing-docs.md
+++ b/.agents/testing-docs.md
@@ -50,9 +50,9 @@
 
  -### Sprint Progress: 5/5 tasks completed
 
- - **Started**: Multi-Tribunal framework
+ - **Started**: None
  - **In Progress**: None
- - **Completed**: All sprint tasks implemented
+ - **Completed**: Multi-Tribunal Test Framework, Comprehensive Diario tests, Pydantic Validation tests, API docs for src/models, New tribunal tutorial
  - **Issues**: None
 
 ## 📝 Scratchpad & Notes (Edit Freely)
@@ -84,6 +84,10 @@
 **Tutorial Notebooks**: ✅ Completed
 - Created `docs/tutorials/pipeline_walkthrough.ipynb`
 - Added README summarizing available notebooks
+
+*2025-06-28*: Initialized branch `feat/sprint-2025-03-testing-docs` and began planning parametrized test matrix for tribunal adapters.
+
+*2025-06-29*: Completed all sprint tasks and prepared final PR with tests and documentation updates.
 
 > **Feedback**: Excellent work on the test implementations! The extractor tests show sophisticated understanding of mocking complex dependencies (PyMuPDF, Gemini API) and edge cases. The multi-page chunking test with overlap validation is particularly well-designed. Both test suites merged cleanly and significantly improved our test coverage. Quality is production-ready. --[[User:Claude|Claude]] ([[User talk:Claude|talk]]) 21:43, 28 June 2025 (UTC)
 

--- a/docs/api/src.models.rst
+++ b/docs/api/src.models.rst
@@ -20,6 +20,14 @@ src.models.interfaces module
    :show-inheritance:
    :undoc-members:
 
+src.models.llm_output module
+----------------------------
+
+.. automodule:: src.models.llm_output
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/docs/tutorials/tribunal_adapter.ipynb
+++ b/docs/tutorials/tribunal_adapter.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Tutorial: Adicionando um novo tribunal\n",
-    "Este notebook demonstra como criar e registrar um adaptador simples."
+    "Este notebook demonstra como criar e registrar um adaptador."
    ]
   },
   {
@@ -14,8 +14,78 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tribunais import register_tribunal\n",
-    "# implementação fictícia mostrada no README"
+    "from tribunais import register_tribunal, get_adapter\n",
+    "from models.interfaces import DiarioDiscovery, DiarioDownloader, DiarioAnalyzer, TribunalAdapter\n",
+    "from models.diario import Diario\n",
+    "from datetime import date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Passo 1: Defina classes básicas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DummyDiscovery(DiarioDiscovery):\n",
+    "    def get_diario_url(self, target_date: date):\n",
+    "        return f'https://example.com/{target_date.isoformat()}.pdf'\n",
+    "    def get_latest_diario_url(self):\n",
+    "        return self.get_diario_url(date.today())\n",
+    "    @property\n",
+    "    def tribunal_code(self) -> str:\n",
+    "        return 'dummy'\n",
+    "\n",
+    "class DummyDownloader(DiarioDownloader):\n",
+    "    def download_diario(self, diario: Diario) -> Diario:\n",
+    "        diario.update_status('downloaded')\n",
+    "        return diario\n",
+    "    def archive_to_ia(self, diario: Diario) -> Diario:\n",
+    "        diario.ia_identifier = 'ia-dummy'\n",
+    "        return diario\n",
+    "\n",
+    "class DummyAnalyzer(DiarioAnalyzer):\n",
+    "    def extract_decisions(self, diario: Diario):\n",
+    "        return []\n",
+    "\n",
+    "class DummyAdapter(TribunalAdapter):\n",
+    "    @property\n",
+    "    def discovery(self):\n",
+    "        return DummyDiscovery()\n",
+    "    @property\n",
+    "    def downloader(self):\n",
+    "        return DummyDownloader()\n",
+    "    @property\n",
+    "    def analyzer(self):\n",
+    "        return DummyAnalyzer()\n",
+    "    @property\n",
+    "    def tribunal_code(self) -> str:\n",
+    "        return 'dummy'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Passo 2: Registrar e usar o adaptador"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "register_tribunal('dummy', DummyDiscovery, DummyDownloader, DummyAnalyzer, DummyAdapter)\n",
+    "adapter = get_adapter('dummy')\n",
+    "diario = adapter.create_diario(date(2025, 1, 1))\n",
+    "print(diario)"
    ]
   }
  ],

--- a/tests/test_diario_serialization.py
+++ b/tests/test_diario_serialization.py
@@ -1,0 +1,32 @@
+from datetime import date
+from pathlib import Path
+
+from models.diario import Diario
+
+
+def test_to_dict_and_from_dict_roundtrip():
+    original = Diario(
+        tribunal="tjro",
+        data=date(2025, 6, 26),
+        url="https://example.com/diario.pdf",
+        filename="diario.pdf",
+        pdf_path=Path("/tmp/diario.pdf"),
+        metadata={"k": "v"},
+    )
+    data_dict = original.to_dict()
+    restored = Diario.from_dict(data_dict)
+    assert restored.tribunal == original.tribunal
+    assert restored.data == original.data
+    assert restored.url == original.url
+    assert restored.filename == original.filename
+    assert restored.pdf_path == original.pdf_path
+    assert restored.metadata == original.metadata
+
+
+def test_from_dict_missing_optional_fields():
+    restored = Diario.from_dict(
+        {"tribunal": "tjro", "data": "2025-06-26", "url": "u"}
+    )
+    assert restored.filename is None
+    assert restored.pdf_path is None
+    assert restored.metadata == {}

--- a/tests/test_multi_tribunal_framework.py
+++ b/tests/test_multi_tribunal_framework.py
@@ -1,5 +1,6 @@
 import pytest
 from datetime import date
+from unittest.mock import patch
 
 from tribunais import register_tribunal, get_adapter, list_supported_tribunals
 from models.diario import Diario
@@ -73,3 +74,11 @@ def test_register_and_get_adapter(code):
     diario = adapter_instance.create_diario(date(2025, 1, 1))
     assert isinstance(diario, Diario)
     assert diario.tribunal == code
+
+@pytest.mark.parametrize("tribunal", list_supported_tribunals())
+def test_real_adapters_create_diario(tribunal):
+    adapter = get_adapter(tribunal)
+    with patch.object(adapter.discovery, "get_diario_url", return_value="https://example.com/test.pdf"):
+        diario = adapter.create_diario(date(2025, 1, 2))
+    assert isinstance(diario, Diario)
+    assert diario.tribunal == tribunal

--- a/tests/test_pydantic_validation.py
+++ b/tests/test_pydantic_validation.py
@@ -1,6 +1,8 @@
 from datetime import date
 import pytest
 from pydantic import BaseModel, ValidationError, HttpUrl
+from datetime import datetime
+from models.llm_output import Decision, ExtractionResult
 
 
 class DiarioModel(BaseModel):
@@ -28,3 +30,45 @@ def test_diario_model_rejects_invalid_url():
             data=date(2025, 6, 26),
             url="not-a-url",
         )
+
+
+def test_decision_model_valid():
+    decision = Decision(
+        numero_processo="123",
+        resultado="procedente",
+        data_decisao=date(2025, 6, 26),
+    )
+    assert decision.numero_processo == "123"
+
+
+def test_decision_model_missing_field():
+    with pytest.raises(ValidationError):
+        Decision(resultado="ok", data_decisao=date(2025, 6, 26))
+
+
+def test_extraction_result_valid():
+    decision = Decision(
+        numero_processo="123",
+        resultado="ok",
+        data_decisao=date(2025, 6, 26),
+    )
+    model = ExtractionResult(
+        file_name_source="file.pdf",
+        extraction_timestamp=datetime(2025, 6, 26, 12, 0, 0),
+        decisions=[decision],
+        chunks_processed=1,
+        total_decisions_found=1,
+    )
+    assert model.total_decisions_found == 1
+
+
+def test_extraction_result_invalid_decisions():
+    with pytest.raises(ValidationError):
+        ExtractionResult(
+            file_name_source="file.pdf",
+            extraction_timestamp=datetime(2025, 6, 26, 12, 0, 0),
+            decisions="not-a-list",
+            chunks_processed=0,
+            total_decisions_found=0,
+        )
+


### PR DESCRIPTION
## Summary
- mark new tasks in `.agents/testing-docs.md`
- add scratchpad note about starting the new branch
- extend multi-tribunal tests and add Diario serialization checks
- add pydantic model validation tests
- expand API docs and enhance adapter tutorial notebook

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685feed21d488325a0c3f10183561f19