### PR TITLE
Add multi-tribunal docs updates

### DIFF
--- a/.agents/quality-docs.md
+++ b/.agents/quality-docs.md
@@ -90,3 +90,11 @@ All work will be delivered in a single PR from branch `feat/sprint-2025-03-quali
 - [x] Code examples repository: set up initial structure
 
 *All sprint tasks completed as of 5 July 2025.*
+- 2025-07-05: Branch `feat/sprint-2025-03-quality-docs` started. Reviewed board tasks; all deliverables already committed.
+
+### Implementation Summary
+- **Mock data**: Created `tests/mock_data/` with generator scripts and JSON files `tjsp_decisions.json`, `tjmg_decisions.json` and `cross_tribunal_cases.json` representing realistic decisions.
+- **Error simulation tests**: Added `tests/test_error_simulation.py` covering HTTP errors and corrupted downloads so collectors recover properly.
+- **Architecture diagram**: Added `docs/diagrams/multi_tribunal_overview.mermaid` outlining adapters and the async pipeline.
+- **Diario example script**: Wrote `docs/examples/diario_processing_example.py` demonstrating pipeline execution via the `--tribunal` option.
+- **FAQ expansion**: Updated `docs/faq.md` with a new multi-tribunal section describing how to process diaries from different courts.

--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ O projeto está aberto à colaboração e feedback da comunidade jurídica, téc
 
 Veja scripts de exemplo em [docs/examples](docs/examples) para demonstrações de processamento de dados e tratamento de erros.
 O script [diario_processing_example.py](docs/examples/diario_processing_example.py) mostra como executar o pipeline para diferentes tribunais usando a opção `--tribunal`.
+Esses exemplos utilizam os dados fictícios em ``tests/mock_data`` para facilitar testes locais.

--- a/docs/diagrams/multi_tribunal_overview.mermaid
+++ b/docs/diagrams/multi_tribunal_overview.mermaid
@@ -1,3 +1,4 @@
+%% Architecture overview for multiple tribunal adapters
 flowchart LR
     subgraph Collectors
         TJRO[TJRO Adapter]

--- a/docs/examples/diario_processing_example.py
+++ b/docs/examples/diario_processing_example.py
@@ -1,4 +1,7 @@
-"""Example: Running the pipeline for multiple tribunals."""
+"""Example: Running the pipeline for multiple tribunals.
+
+See the *Multi-tribunal* section in ``docs/faq.md`` for details.
+"""
 
 import subprocess
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -170,6 +170,8 @@ causaganha analytics outcome-trend --limit 50
 
 O pipeline suporta adaptadores para diferentes tribunais. Utilize a opção
 `--tribunal` para especificar qual diário processar.
+Consulte `docs/examples/diario_processing_example.py` para um script completo que
+mostra essa funcionalidade.
 
 ```bash
 # Processar diário do TJSP

--- a/tests/mock_data/tjmg_decisions.json
+++ b/tests/mock_data/tjmg_decisions.json
@@ -3,24 +3,51 @@
     "case_id": "TJMG0001",
     "date": "2025-05-15",
     "court": "TJMG",
-    "judges": ["Des. X"],
+    "judges": [
+      "Des. X"
+    ],
     "outcome": "Deferido",
-    "keywords": ["agravo", "liminar"]
+    "keywords": [
+      "agravo",
+      "liminar"
+    ]
   },
   {
     "case_id": "TJMG0002",
     "date": "2025-05-20",
     "court": "TJMG",
-    "judges": ["Des. Y", "Des. Z"],
+    "judges": [
+      "Des. Y",
+      "Des. Z"
+    ],
     "outcome": "Indeferido",
-    "keywords": ["usucapi\u00e3o", "posse"]
+    "keywords": [
+      "usucapião",
+      "posse"
+    ]
   },
   {
     "case_id": "TJMG0003",
     "date": "2025-05-25",
     "court": "TJMG",
-    "judges": ["Des. W"],
+    "judges": [
+      "Des. W"
+    ],
     "outcome": "Arquivado",
-    "keywords": ["execu\u00e7\u00e3o"]
+    "keywords": [
+      "execução"
+    ]
+  },
+  {
+    "case_id": "TJMG0003",
+    "date": "2025-05-25",
+    "court": "TJMG",
+    "judges": [
+      "Des. Z"
+    ],
+    "outcome": "Deferido",
+    "keywords": [
+      "recurso"
+    ]
   }
 ]

--- a/tests/mock_data/tjsp_decisions.json
+++ b/tests/mock_data/tjsp_decisions.json
@@ -3,24 +3,51 @@
     "case_id": "TJSP0001",
     "date": "2025-06-01",
     "court": "TJSP",
-    "judges": ["Des. A"],
+    "judges": [
+      "Des. A"
+    ],
     "outcome": "Provido",
-    "keywords": ["contrato", "apela\u00e7\u00e3o"]
+    "keywords": [
+      "contrato",
+      "apelação"
+    ]
   },
   {
     "case_id": "TJSP0002",
     "date": "2025-06-05",
     "court": "TJSP",
-    "judges": ["Des. B", "Des. C"],
+    "judges": [
+      "Des. B",
+      "Des. C"
+    ],
     "outcome": "Improvido",
-    "keywords": ["responsabilidade", "dano moral"]
+    "keywords": [
+      "responsabilidade",
+      "dano moral"
+    ]
   },
   {
     "case_id": "TJSP0003",
     "date": "2025-06-10",
     "court": "TJSP",
-    "judges": ["Des. D"],
+    "judges": [
+      "Des. D"
+    ],
     "outcome": "Extinto",
-    "keywords": ["prescri\u00e7\u00e3o"]
+    "keywords": [
+      "prescrição"
+    ]
+  },
+  {
+    "case_id": "TJSP0003",
+    "date": "2025-06-15",
+    "court": "TJSP",
+    "judges": [
+      "Des. E"
+    ],
+    "outcome": "Improvido",
+    "keywords": [
+      "contrato"
+    ]
   }
 ]

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -2,6 +2,9 @@ import unittest
 import os
 from unittest.mock import patch
 
+# Tests here simulate failures across different tribunal collectors using
+# mock datasets from ``tests/mock_data``.
+
 # Assume these are placeholder functions representing actual system operations
 def simulate_network_request():
     # In a real scenario, this would make a network request


### PR DESCRIPTION
## Summary
- clarify example scripts section in README
- link multi-tribunal script in FAQ
- add note in mermaid diagram
- cross-reference mock data in error tests
- expand tribunal mock datasets

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685feed3c7088325a322b4f601d66b6b