### PR TITLE
feat(BDD): Add BDD scenario for data collection and refactor steps

### DIFF
--- a/tests/features/data_pipeline.feature
+++ b/tests/features/data_pipeline.feature
@@ -7,3 +7,9 @@ Feature: Data Pipeline
     Given the system is in a clean state
     When I initialize the database
     Then the database should be created with the correct schema
+
+  Scenario: Collect data from the API
+    Given the system is in a clean state
+    And the PJe API will return mock data
+    When I run the collect command
+    Then the intimations table should contain the collected data

--- a/tests/step_defs/conftest.py
+++ b/tests/step_defs/conftest.py
@@ -1,0 +1,10 @@
+
+import os
+import pytest
+from pytest_bdd import given
+from causaganha.config import DB_PATH
+
+@given("the system is in a clean state")
+def clean_state():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)

--- a/tests/step_defs/test_data_pipeline.py
+++ b/tests/step_defs/test_data_pipeline.py
@@ -1,11 +1,14 @@
 
 import os
 import ibis
+import pytest
 from typer.testing import CliRunner
 from pytest_bdd import scenario, given, when, then
+from unittest.mock import AsyncMock
 
 from causaganha.config import DB_PATH
 from causaganha.cli import app
+from causaganha.domain.models import Intimation
 
 runner = CliRunner()
 
@@ -13,10 +16,10 @@ runner = CliRunner()
 def test_initialize_database():
     pass
 
-@given("the system is in a clean state")
-def clean_state():
-    if os.path.exists(DB_PATH):
-        os.remove(DB_PATH)
+@scenario('../features/data_pipeline.feature', 'Collect data from the API')
+def test_collect_data():
+    pass
+
 
 @when("I initialize the database")
 def initialize_database():
@@ -36,3 +39,57 @@ def verify_database_schema():
         'lawyer_ratings',
     }
     assert expected_tables.issubset(set(tables))
+
+@pytest.fixture
+def mock_pje_api(mocker):
+    mock_data = [
+        Intimation(
+            id=1,
+            numero_processo="12345-67.2024.8.22.0001",
+            data_disponibilizacao="2024-01-01",
+            sigla_tribunal="TJRO",
+            advogados=[],
+            tipo_comunicacao="Intimacao",
+            nome_orgao="1. VARA CIVEL",
+            texto="Fica V. Sa. intimado para tomar ciencia da sentenca proferida no processo.",
+            link="https://example.com/document",
+            tipo_documento="Sentenca",
+            nome_classe="PROCEDIMENTO COMUM CIVEL",
+            codigo_classe="7",
+            hash="mock_hash_123",
+            status="pending",
+        )
+    ]
+
+    async def fake_get_intimations(*args, **kwargs):
+        return mock_data
+
+    # Patch the PJeAPIClient class in the collect module where it is used
+    mocker.patch(
+        'causaganha.application.pipeline.collect.PJeAPIClient.get_intimations_by_court',
+        new=fake_get_intimations
+    )
+    mocker.patch(
+        'causaganha.application.pipeline.collect.PJeAPIClient.close',
+        new=AsyncMock(return_value=None)
+    )
+
+
+@given("the PJe API will return mock data")
+def pje_api_will_return_mock_data(mock_pje_api):
+    pass
+
+@when("I run the collect command")
+def run_collect_command():
+    # The database must be initialized before collecting
+    runner.invoke(app, ["db", "init"])
+    result = runner.invoke(app, ["collect", "--courts", "TJRO"])
+    assert result.exit_code == 0
+
+@then("the intimations table should contain the collected data")
+def verify_collected_data():
+    con = ibis.duckdb.connect(DB_PATH)
+    intimations = con.table('intimations').to_pandas()
+    assert len(intimations) == 1
+    assert intimations.iloc[0]['id'] == 1
+    assert intimations.iloc[0]['numero_processo'] == "12345-67.2024.8.22.0001"


### PR DESCRIPTION
This commit expands the BDD test suite by adding a new scenario for the `collect` command in the data pipeline. It also refactors the step definitions for better organization and reusability.

- Adds a new scenario to `data_pipeline.feature` to test the data collection process.
- Implements the corresponding step definitions, including a mock for the asynchronous `PJeAPIClient`.
- Refactors the `clean_state` given step into a shared `conftest.py` file to promote reusability across feature tests.
- Fixes a bug in the async mock that was discovered during refactoring.