### PR TITLE
Fix pydantic-ai RunResult access in decision analyzer

### DIFF
--- a/src/causaganha/infrastructure/ai/analyzer.py
+++ b/src/causaganha/infrastructure/ai/analyzer.py
@@ -126,7 +126,7 @@ class DecisionAnalyzer:
         for attempt in range(len(self.api_keys)):
             try:
                 result = await self.agent.run(payload)
-                return result.output
+                return result.data
             except Exception as e:
                 error_str = str(e)
                 # Check for 429 rate limit error
@@ -169,14 +169,14 @@ class DecisionAnalyzer:
             try:
                 result = await self.batch_agent.run(user_content)
 
-                if len(result.output.results) != len(texts_list):
+                if len(result.data.results) != len(texts_list):
                     logger.warning(
                         "batch_analysis_count_mismatch",
                         expected=len(texts_list),
-                        got=len(result.output.results),
+                        got=len(result.data.results),
                     )
 
-                return result.output.results
+                return result.data.results
             except Exception as e:
                 error_str = str(e)
                 # Check for 429 rate limit error


### PR DESCRIPTION
### Motivation
- The analyzer previously accessed `result.output` and `result.output.results` but `pydantic_ai.Agent.run()` exposes the parsed model on `RunResult.data`, which can raise `AttributeError` or return unexpected objects when integrated with the real library.

### Description
- Update `src/causaganha/infrastructure/ai/analyzer.py` to return `result.data` from `analyze_decision` and to read/return `result.data.results` in `analyze_bulk`, and adjust the batch-count mismatch logging to use `result.data.results`.

### Testing
- Ran `uv run pytest`, which failed during test collection with `ModuleNotFoundError: No module named 'causaganha'` (environment/test setup issue), so no repository tests were executed for the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dae031f608325843c7a3709b673ba)