### PR TITLE
feat(monitoring): add browserless dashboard heartbeat fallback

### DIFF
--- a/scripts/dashboard/generate-data.py
+++ b/scripts/dashboard/generate-data.py
@@ -263,13 +263,13 @@ def generate_dashboard_data(db_path: Path, output_path: Path) -> None:
     for dates in tribunal_coverage.values():
         all_dates.update(dates)
         total_items += len(dates)
-    
+
     unique_days = len(all_dates)
     if all_dates:
         sorted_all = sorted(all_dates)
         oldest_date = sorted_all[0]
         newest_date = sorted_all[-1]
-    
+
     progress_pct = round((unique_days / target_days * 100), 2) if unique_days > 0 else 0
 
     tribunal_etas = {}
@@ -281,9 +281,12 @@ def generate_dashboard_data(db_path: Path, output_path: Path) -> None:
     # Actually, we should count missing days within the date range from target_start to today, or just total target_days
 
     # The set of tribunals to report on: either from DB or from the canonical list
-    all_tribunals = set(t for t, _ in coverage_rows) if coverage_rows else set(backfill_cursors.keys())
+    all_tribunals = (
+        set(t for t, _ in coverage_rows) if coverage_rows else set(backfill_cursors.keys())
+    )
     if not all_tribunals:
         from causaganha.config import TRIBUNAIS
+
         all_tribunals = set(TRIBUNAIS)
 
     today = date.today()
@@ -305,7 +308,11 @@ def generate_dashboard_data(db_path: Path, output_path: Path) -> None:
 
         # Determine the anchor date for this tribunal
         # Priority: Discovered Genesis > Hardcoded Start Date > Jan 1st 2024
-        start_date_str = discovered_start_dates.get(tribunal) or tribunal_start_dates.get(tribunal) or "2024-01-01"
+        start_date_str = (
+            discovered_start_dates.get(tribunal)
+            or tribunal_start_dates.get(tribunal)
+            or "2024-01-01"
+        )
 
         try:
             start_date_obj = datetime.strptime(start_date_str, "%Y-%m-%d").date()
@@ -333,7 +340,11 @@ def generate_dashboard_data(db_path: Path, output_path: Path) -> None:
             "empty_streak": cursor_info.get("empty_streak", 0),
             "genesis_date": start_date_str,
             "absent_days_count": absent_days_t,
-            "completion_pct": round(((unique_days_t + absent_days_t) / total_days_since_genesis) * 100, 1) if total_days_since_genesis > 0 else 0
+            "completion_pct": round(
+                ((unique_days_t + absent_days_t) / total_days_since_genesis) * 100, 1
+            )
+            if total_days_since_genesis > 0
+            else 0,
         }
 
     # Calculate Data Quality Scores

--- a/scripts/monitoring/README.md
+++ b/scripts/monitoring/README.md
@@ -246,3 +246,20 @@ scripts/monitoring/
 **Requested by:** Franklin  
 **Project:** causaganha backfill monitoring  
 **Date:** 2026-02-05
+
+### 4. Browserless Dashboard Heartbeat Fallback
+`verify_dashboard_status.py` - Lightweight public dashboard verification
+
+A small, reusable utility that verifies the status of the public Astro dashboard using only standard library HTTP tools (`urllib.request`). It extracts key indicators (like healthy tribunal counts, last collection timestamp, and global ETA) directly from the published static HTML without requiring a browser or Playwright dependencies.
+
+**Features:**
+- Analyzes published dashboard text/HTML.
+- Extracts status and returns structured JSON output.
+- Classifies operational status: `alive`, `alive_but_stale_looking`, `advancing`, or `fetch_failed`.
+- Useful as a quick heartbeat fallback to ensure the dashboard isn't just reachable, but actually progressing.
+
+**Usage:**
+```bash
+# Returns a JSON summary
+python scripts/monitoring/verify_dashboard_status.py
+```

--- a/scripts/monitoring/tests/test_fallback.html
+++ b/scripts/monitoring/tests/test_fallback.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CausaGanha Dashboard - Sistema de Monitoramento</title>
+</head>
+<body>
+    <header class="max-w-7xl mx-auto mb-8 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div>
+          <h1 class="text-xl font-semibold text-black dark:text-white tracking-tight">
+            CausaGanha
+          </h1>
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            0 of 91 tribunais saudáveis | última coleta: --:-- | Global ETA: Pending
+          </p>
+        </div>
+      </div>
+    </header>
+    <div>
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">System Status</h2>
+      <div class="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div class="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg">
+          <p class="text-xs text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wider">ZIPs Synchronized</p>
+          <p class="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">0 / 0</p>
+        </div>
+      </div>
+    </div>
+</body>
+</html>

--- a/scripts/monitoring/tests/test_healthy_fallback.html
+++ b/scripts/monitoring/tests/test_healthy_fallback.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CausaGanha Dashboard - Sistema de Monitoramento</title>
+</head>
+<body>
+    <header class="max-w-7xl mx-auto mb-8 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div>
+          <h1 class="text-xl font-semibold text-black dark:text-white tracking-tight">
+            CausaGanha
+          </h1>
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            50 of 91 tribunais saudáveis | última coleta: 14:30 | Global ETA: ~2 months
+          </p>
+        </div>
+      </div>
+    </header>
+    <div>
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-200">System Status</h2>
+      <div class="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div class="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg">
+          <p class="text-xs text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wider">ZIPs Synchronized</p>
+          <p class="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">100 / 200</p>
+        </div>
+      </div>
+    </div>
+</body>
+</html>

--- a/scripts/monitoring/tests/test_verify_dashboard_status.py
+++ b/scripts/monitoring/tests/test_verify_dashboard_status.py
@@ -1,0 +1,55 @@
+"""Tests for verify_dashboard_status.py."""
+
+from scripts.monitoring.verify_dashboard_status import analyze_html
+
+
+TOTAL_TRIBUNALS = 91
+
+def test_analyze_html_stale() -> None:
+    """Test stale HTML."""
+    with open("scripts/monitoring/tests/test_fallback.html") as f:
+        html = f.read()
+    result = analyze_html(html)
+    assert result["status"] == "alive_but_stale_looking"
+    assert result["healthy_tribunals"] == 0
+    assert result["total_tribunals"] == TOTAL_TRIBUNALS
+    assert result["last_collection"] == "--:--"
+    assert result["global_eta"] == "Pending"
+
+
+def test_analyze_html_healthy() -> None:
+    """Test healthy HTML."""
+    with open("scripts/monitoring/tests/test_healthy_fallback.html") as f:
+        html = f.read()
+    result = analyze_html(html)
+    assert result["status"] == "advancing"
+    assert result["healthy_tribunals"] == 50
+    assert result["total_tribunals"] == TOTAL_TRIBUNALS
+    assert result["last_collection"] == "14:30"
+    assert result["global_eta"] == "~2 months"
+
+
+def test_analyze_html_fetch_failed() -> None:
+    """Test fetch failure."""
+    result = analyze_html(None)
+    assert result["status"] == "fetch_failed"
+
+
+def test_analyze_html_invalid() -> None:
+    """Test invalid HTML."""
+    result = analyze_html("<html><body><h1>Hello World</h1></body></html>")
+    assert result["status"] == "alive_but_stale_looking"
+    assert result["healthy_tribunals"] == 0
+    assert result["total_tribunals"] == TOTAL_TRIBUNALS
+    assert result["last_collection"] == "--:--"
+    assert result["global_eta"] == "Pending"
+
+
+def test_analyze_html_alive_not_stale() -> None:
+    """Test alive but not stale HTML."""
+    result = analyze_html(
+        "<html><title>Title</title><body><h1>1 of 91 tribunais saudáveis</h1>última coleta: --:--<br>"
+        "Global ETA: Pending</body></html>"
+    )
+    assert result["status"] == "advancing"
+    assert result["healthy_tribunals"] == 1

--- a/scripts/monitoring/tests/test_verify_dashboard_status.py
+++ b/scripts/monitoring/tests/test_verify_dashboard_status.py
@@ -5,6 +5,7 @@ from scripts.monitoring.verify_dashboard_status import analyze_html
 
 TOTAL_TRIBUNALS = 91
 
+
 def test_analyze_html_stale() -> None:
     """Test stale HTML."""
     with open("scripts/monitoring/tests/test_fallback.html") as f:

--- a/scripts/monitoring/verify_dashboard_status.py
+++ b/scripts/monitoring/verify_dashboard_status.py
@@ -60,7 +60,9 @@ def analyze_html(html: str | None) -> dict[str, Any]:
     # Extract ZIPs Synced (from fallback structure like test_healthy_fallback.html)
     zips_synced_done = 0
     zips_synced_total = 0
-    zips_match = re.search(r"ZIPs Synchronized.*?>(\d+)\s*/\s*(\d+)<", html, re.DOTALL | re.IGNORECASE)
+    zips_match = re.search(
+        r"ZIPs Synchronized.*?>(\d+)\s*/\s*(\d+)<", html, re.DOTALL | re.IGNORECASE
+    )
     if zips_match:
         zips_synced_done = int(zips_match.group(1))
         zips_synced_total = int(zips_match.group(2))
@@ -88,6 +90,7 @@ def analyze_html(html: str | None) -> dict[str, Any]:
 
 if __name__ == "__main__":
     import sys
+
     html = fetch_html()
     if html:
         sys.stdout.write(json.dumps(analyze_html(html), indent=2) + "\n")

--- a/scripts/monitoring/verify_dashboard_status.py
+++ b/scripts/monitoring/verify_dashboard_status.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Browserless public dashboard status verification."""
+
+import json
+import logging
+import re
+import urllib.request
+from typing import Any
+
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+DASHBOARD_URL = "https://franklinbaldo.github.io/causaganha/"
+
+
+def fetch_html(url: str = DASHBOARD_URL) -> str | None:
+    """Fetch dashboard HTML."""
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})  # noqa: S310
+        with urllib.request.urlopen(req, timeout=10) as response:  # noqa: S310
+            return response.read().decode("utf-8")
+    except Exception as e:
+        logger.exception("Failed to fetch %s: %s", url, e)
+        return None
+
+
+def analyze_html(html: str | None) -> dict[str, Any]:
+    """Analyze the given HTML content and return status summary."""
+    if not html:
+        return {
+            "status": "fetch_failed",
+            "layer": "browserless text fetch",
+            "title": None,
+            "healthy_tribunals": 0,
+            "total_tribunals": 0,
+            "last_collection": None,
+            "global_eta": None,
+            "zips_synced_done": 0,
+            "zips_synced_total": 0,
+        }
+
+    # Extract title
+    title_match = re.search(r"<title>(.*?)</title>", html, re.IGNORECASE)
+    title = title_match.group(1).strip() if title_match else "Unknown"
+
+    # Extract healthy tribunals count
+    healthy_match = re.search(r"(\d+)\s+of\s+(\d+)\s+tribunais saudáveis", html)
+    healthy = int(healthy_match.group(1)) if healthy_match else 0
+    total_tribs = int(healthy_match.group(2)) if healthy_match else 91
+
+    # Extract last collection time
+    collection_match = re.search(r"última coleta:\s*([0-9:]+|--:--)", html)
+    last_collection = collection_match.group(1) if collection_match else "--:--"
+
+    # Extract global ETA
+    eta_match = re.search(r"Global ETA:\s*([^<]+)", html)
+    global_eta = eta_match.group(1).strip() if eta_match else "Pending"
+
+    # Extract ZIPs Synced (from fallback structure like test_healthy_fallback.html)
+    zips_synced_done = 0
+    zips_synced_total = 0
+    zips_match = re.search(r"ZIPs Synchronized.*?>(\d+)\s*/\s*(\d+)<", html, re.DOTALL | re.IGNORECASE)
+    if zips_match:
+        zips_synced_done = int(zips_match.group(1))
+        zips_synced_total = int(zips_match.group(2))
+
+    # Determine Status
+    if healthy == 0 and last_collection == "--:--" and global_eta == "Pending":
+        status = "alive_but_stale_looking"
+    elif healthy > 0 or last_collection != "--:--" or global_eta != "Pending":
+        status = "advancing"
+    else:
+        status = "alive"
+
+    return {
+        "status": status,
+        "layer": "browserless text fetch",
+        "title": title,
+        "healthy_tribunals": healthy,
+        "total_tribunals": total_tribs,
+        "last_collection": last_collection,
+        "global_eta": global_eta,
+        "zips_synced_done": zips_synced_done,
+        "zips_synced_total": zips_synced_total,
+    }
+
+
+if __name__ == "__main__":
+    import sys
+    html = fetch_html()
+    if html:
+        sys.stdout.write(json.dumps(analyze_html(html), indent=2) + "\n")
+    else:
+        sys.stdout.write(json.dumps(analyze_html(None), indent=2) + "\n")

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -118,7 +118,6 @@ def _resolve_ia_auth(*, dry_run: bool) -> str:
     default=False,
     help="Log actions without uploading.",
 )
-
 @click.pass_context
 def main(  # noqa: PLR0913
     ctx: click.Context,

--- a/src/djen_backup/archive.py
+++ b/src/djen_backup/archive.py
@@ -181,7 +181,6 @@ async def upload_zip(
     return resp
 
 
-
 # ── Circuit breaker ──────────────────────────────────────────────────
 
 

--- a/src/djen_backup/backfill.py
+++ b/src/djen_backup/backfill.py
@@ -503,13 +503,15 @@ async def backfill_tribunal(
 
     # Determine per-tribunal dynamic lower bound (Genesis)
     genesis_str = config.genesis_dates.get(tribunal)
-    genesis_date = date.fromisoformat(genesis_str) if genesis_str and genesis_str != "None" else None
+    genesis_date = (
+        date.fromisoformat(genesis_str) if genesis_str and genesis_str != "None" else None
+    )
 
     while True:
         # Check against global lower bound
         if config.lower_bound and prog.cursor_date < config.lower_bound:
             break
-            
+
         # Check against discovered Genesis (discovery script)
         if genesis_date and prog.cursor_date < genesis_date:
             log.info(


### PR DESCRIPTION
This PR implements a new "Browserless Heartbeat Fallback Report" utility for monitoring the CausaGanha dashboard.

When browser-based verification (like Playwright) is unavailable or too heavy to run, this script (`scripts/monitoring/verify_dashboard_status.py`) acts as a lightweight fallback. It fetches the public dashboard using the standard library `urllib.request` and parses the HTML with regular expressions to determine its actual status (e.g., healthy tribunals count, global ETA, last collection time). 

This helps heartbeat automation loops clearly distinguish between a dashboard that is "merely alive" (responsive but reporting 0 data or Pending ETAs) versus one that is "advancing" (reflecting successful backfills).

- Adds `scripts/monitoring/verify_dashboard_status.py`
- Adds `pytest` test suite covering status scenarios
- Updates `scripts/monitoring/README.md`

Resolves the user's explicit request to improve heartbeat accuracy.

---
*PR created automatically by Jules for task [6811847471181333834](https://jules.google.com/task/6811847471181333834) started by @franklinbaldo*