### PR TITLE
[codex] Fail-soft DJEN publication parsing

### DIFF
--- a/dashboard/src/components/DateDetail.svelte
+++ b/dashboard/src/components/DateDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import PublicationCard from './PublicationCard.svelte';
   import {
-    parseDjenPublicationCollection,
+    parseDjenPublicationCollectionSafely,
     type DjenPublication,
   } from '../lib/djen';
 
@@ -88,7 +88,7 @@
     const res = await cachedFetch(jsonUrl(pageNum));
     if (!res.ok) return null;
     const data = await res.json();
-    return parseDjenPublicationCollection(data);
+    return parseDjenPublicationCollectionSafely(data);
   }
 
   $effect(() => {

--- a/dashboard/src/lib/djen.ts
+++ b/dashboard/src/lib/djen.ts
@@ -467,3 +467,31 @@ export function parseDjenPublication(input: unknown): DjenPublication {
 export function parseDjenPublicationCollection(input: unknown): DjenPublication[] {
   return DjenPublicationCollectionSchema.parse(input);
 }
+
+export function parseDjenPublicationCollectionSafely(input: unknown): DjenPublication[] {
+  const collectionResult = z
+    .union([
+      z.array(z.unknown()),
+      z.object({ items: z.array(z.unknown()) }).passthrough(),
+    ])
+    .safeParse(input);
+
+  if (!collectionResult.success) {
+    return [];
+  }
+
+  const items = Array.isArray(collectionResult.data)
+    ? collectionResult.data
+    : collectionResult.data.items;
+
+  const publications: DjenPublication[] = [];
+
+  for (const item of items) {
+    const parsed = DjenPublicationSchema.safeParse(item);
+    if (parsed.success) {
+      publications.push(parsed.data);
+    }
+  }
+
+  return publications;
+}


### PR DESCRIPTION
## Summary
- parse DJEN publication collections in a fail-soft way for date pages
- keep valid publications renderable even when a single external record is malformed
- preserve strict single-record parsing for callers that want fail-fast behavior

## Validation
- bun run lint
- manual parser smoke test with mixed valid/invalid entries
