### PR TITLE
[codex] Add typed DJEN publication parsing and rendering

### DIFF
--- a/dashboard/src/components/DateDetail.svelte
+++ b/dashboard/src/components/DateDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import PublicationCard from './PublicationCard.svelte';
   import {
-    parseDjenPublicationCollection,
+    parseDjenPublicationCollectionSafely,
     type DjenPublication,
   } from '../lib/djen';
 
@@ -88,7 +88,7 @@
     const res = await cachedFetch(jsonUrl(pageNum));
     if (!res.ok) return null;
     const data = await res.json();
-    return parseDjenPublicationCollection(data);
+    return parseDjenPublicationCollectionSafely(data);
   }
 
   $effect(() => {

--- a/dashboard/src/lib/djen.ts
+++ b/dashboard/src/lib/djen.ts
@@ -467,3 +467,31 @@ export function parseDjenPublication(input: unknown): DjenPublication {
 export function parseDjenPublicationCollection(input: unknown): DjenPublication[] {
   return DjenPublicationCollectionSchema.parse(input);
 }
+
+export function parseDjenPublicationCollectionSafely(input: unknown): DjenPublication[] {
+  const collectionResult = z
+    .union([
+      z.array(z.unknown()),
+      z.object({ items: z.array(z.unknown()) }).passthrough(),
+    ])
+    .safeParse(input);
+
+  if (!collectionResult.success) {
+    return [];
+  }
+
+  const items = Array.isArray(collectionResult.data)
+    ? collectionResult.data
+    : collectionResult.data.items;
+
+  const publications: DjenPublication[] = [];
+
+  for (const item of items) {
+    const parsed = DjenPublicationSchema.safeParse(item);
+    if (parsed.success) {
+      publications.push(parsed.data);
+    }
+  }
+
+  return publications;
+}


### PR DESCRIPTION
## Summary
- add a central Zod schema for DJEN publication payloads used by the dashboard
- normalize field aliases and common format drift from DJEN and Internet Archive JSON pages
- render 	exto as HTML when markup is present and as plain text otherwise
- sanitize remote HTML before injecting it into the DOM
- make date-page parsing fail-soft so one malformed entry does not blank the whole page

## What changed
- add typed DJEN parsing in dashboard/src/lib/djen.ts
- switch publication views to consume normalized Zod-backed types
- support descriptive meio and polo variants during normalization
- preserve valid publications when one external record is malformed

## Validation
- tested parsing against real DJEN JSON files hosted on Internet Archive
- un run lint
- dashboard build passed earlier during development; current CI should be treated as source of truth
