### PR TITLE
feat: implement DJEN hybrid live fetching for publication details

### DIFF
--- a/dashboard/src/components/DateDetail.svelte
+++ b/dashboard/src/components/DateDetail.svelte
@@ -2,6 +2,7 @@
   import PublicationCard from './PublicationCard.svelte';
   import {
     parseDjenPublicationCollectionSafely,
+    fetchLivePublicationDetail,
     type DjenPublication,
   } from '../lib/djen';
 
@@ -11,6 +12,8 @@
     pub: DjenPublication;
     seq: number;
     page: number;
+    source?: "djen" | "ia";
+    usedFallback?: boolean;
   }
 
   function getItemId(tribunal: string, year: number): string {
@@ -142,7 +145,14 @@
           if (pubs) {
             const idx = _initialSeq - ((targetPage - 1) * PUBS_PER_PAGE) - 1;
             if (idx >= 0 && idx < pubs.length) {
-              featuredPub = { pub: pubs[idx], seq: _initialSeq, page: targetPage };
+              const liveData = await fetchLivePublicationDetail(pubs[idx]);
+              featuredPub = {
+                pub: liveData.publication || pubs[idx],
+                seq: _initialSeq,
+                page: targetPage,
+                source: liveData.source,
+                usedFallback: liveData.usedFallback
+              };
             }
             publications = pubs;
             currentPage = targetPage;
@@ -194,7 +204,14 @@
       }
       const idx = newSeq - ((newPage - 1) * PUBS_PER_PAGE) - 1;
       if (idx >= 0 && idx < pubs.length) {
-        featuredPub = { pub: pubs[idx], seq: newSeq, page: newPage };
+        const liveData = await fetchLivePublicationDetail(pubs[idx]);
+        featuredPub = {
+          pub: liveData.publication || pubs[idx],
+          seq: newSeq,
+          page: newPage,
+          source: liveData.source,
+          usedFallback: liveData.usedFallback
+        };
       }
     })();
   }
@@ -237,6 +254,8 @@
         page={featuredPub.page}
         totalSeq={publications.length || totalPages * PUBS_PER_PAGE}
         onNavigate={handleNavigate}
+        source={featuredPub.source}
+        usedFallback={featuredPub.usedFallback}
       />
       <button
         class="btn"

--- a/dashboard/src/components/PublicationCard.svelte
+++ b/dashboard/src/components/PublicationCard.svelte
@@ -201,6 +201,8 @@
     compact = false,
     totalSeq,
     onNavigate,
+    source,
+    usedFallback,
   }: {
     pub: DjenPublication;
     seq: number;
@@ -209,6 +211,8 @@
     compact?: boolean;
     totalSeq?: number;
     onNavigate?: (newSeq: number) => void;
+    source?: "djen" | "ia";
+    usedFallback?: boolean;
   } = $props();
 
   let isReaderMode = $state(false);
@@ -285,6 +289,11 @@
             {#if pub.tipoComunicacao}
               <span class="badge publication-badge">{pub.tipoComunicacao}</span>
             {/if}
+            {#if source}
+              <span class="badge {source === 'djen' ? 'badge-info' : 'badge-warning'}" title={usedFallback ? 'Falha ao conectar no DJEN, usando arquivo IA' : ''}>
+                Fonte: {source === 'djen' ? 'DJEN' : 'Arquivo IA'}
+              </span>
+            {/if}
             <small class="date-label">{dateStr}</small>
           </div>
           {#if processNumber}
@@ -353,6 +362,11 @@
           <div class="header-meta">
             <span class="seq-number seq-bold">#{seq}</span>
             <span class="badge publication-badge">Modo Leitura</span>
+            {#if source}
+              <span class="badge {source === 'djen' ? 'badge-info' : 'badge-warning'}" title={usedFallback ? 'Falha ao conectar no DJEN, usando arquivo IA' : ''}>
+                Fonte: {source === 'djen' ? 'DJEN' : 'Arquivo IA'}
+              </span>
+            {/if}
             <small class="date-label">{dateStr}</small>
           </div>
           {#if processNumber}
@@ -461,6 +475,11 @@
             <span class="seq-number seq-bold">#{seq}</span>
             {#if pub.tipoComunicacao}
               <span class="badge publication-badge">{pub.tipoComunicacao}</span>
+            {/if}
+            {#if source}
+              <span class="badge {source === 'djen' ? 'badge-info' : 'badge-warning'}" title={usedFallback ? 'Falha ao conectar no DJEN, usando arquivo IA' : ''}>
+                Fonte: {source === 'djen' ? 'DJEN' : 'Arquivo IA'}
+              </span>
             {/if}
             <small class="date-label">{dateStr}</small>
           </div>

--- a/dashboard/src/components/__steps__/detail-fetch.steps.ts
+++ b/dashboard/src/components/__steps__/detail-fetch.steps.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchLivePublicationDetail } from '../../lib/djen';
+
+describe('fetchLivePublicationDetail', () => {
+  it('should return djen source on success', async () => {
+    // Mock fetch to succeed
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [{ id: 1, numeroComunicacao: 123, siglaTribunal: 'TJSP', texto: 'live data' }]
+      })
+    });
+
+    const mockPub = { numeroComunicacao: 123, siglaTribunal: 'TJSP', texto: 'old data' } as any;
+
+    const result = await fetchLivePublicationDetail(mockPub);
+    expect(result.source).toBe('djen');
+    expect(result.usedFallback).toBe(false);
+    expect(result.publication?.texto).toBe('live data');
+  });
+
+  it('should fallback to ia source on fetch failure', async () => {
+    // Mock fetch to fail
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const mockPub = { numeroComunicacao: 123, siglaTribunal: 'TJSP', texto: 'old data' } as any;
+
+    const result = await fetchLivePublicationDetail(mockPub);
+    expect(result.source).toBe('ia');
+    expect(result.usedFallback).toBe(true);
+    expect(result.publication?.texto).toBe('old data');
+  });
+
+  it('should fallback to ia source when returning no items', async () => {
+    // Mock fetch to succeed but return empty items
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: []
+      })
+    });
+
+    const mockPub = { numeroComunicacao: 123, siglaTribunal: 'TJSP', texto: 'old data' } as any;
+
+    const result = await fetchLivePublicationDetail(mockPub);
+    expect(result.source).toBe('ia');
+    expect(result.usedFallback).toBe(true);
+    expect(result.publication?.texto).toBe('old data');
+  });
+});

--- a/dashboard/src/lib/djen.ts
+++ b/dashboard/src/lib/djen.ts
@@ -518,3 +518,59 @@ export function parseDjenPublicationCollectionSafely(input: unknown): DjenPublic
 
   return publications;
 }
+
+export async function fetchLivePublicationDetail(
+  pubFromIa: DjenPublication
+): Promise<{ publication: DjenPublication | null; source: "djen" | "ia"; usedFallback: boolean; error?: string }> {
+  if (!pubFromIa.numeroComunicacao || !pubFromIa.siglaTribunal) {
+    return { publication: pubFromIa, source: "ia", usedFallback: true, error: "Missing identity fields" };
+  }
+
+  const queryParams = `?numeroComunicacao=${pubFromIa.numeroComunicacao}&siglaTribunal=${pubFromIa.siglaTribunal}`;
+  const publicUrl = `https://comunicaapi.pje.jus.br/api/v1/comunicacao${queryParams}`;
+  const proxyUrl = `https://djen-proxy-mhgmawcn3a-rj.a.run.app/api/v1/comunicacao${queryParams}`;
+
+  const tryFetch = async (url: string) => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const data = await res.json();
+    const items = parseDjenPublicationCollectionSafely(data);
+    if (items.length > 0) {
+      return items[0];
+    }
+    return null;
+  };
+
+  try {
+    // Try public API first
+    const pub = await tryFetch(publicUrl);
+    if (pub) {
+      return { publication: pub, source: "djen", usedFallback: false };
+    }
+  } catch {
+    // If public API fails (CORS, 403, timeout), try proxy
+    try {
+      const pubProxy = await tryFetch(proxyUrl);
+      if (pubProxy) {
+        return { publication: pubProxy, source: "djen", usedFallback: false };
+      }
+    } catch (proxyErr: unknown) {
+      return {
+        publication: pubFromIa,
+        source: "ia",
+        usedFallback: true,
+        error: proxyErr instanceof Error ? proxyErr.message : String(proxyErr)
+      };
+    }
+  }
+
+  // Fallback if requests complete but return nothing
+  return { publication: pubFromIa, source: "ia", usedFallback: true };
+}


### PR DESCRIPTION
Implemented a hybrid fetching strategy where single-item publications attempt to fetch live data from DJEN first, while preserving the existing IA-first infrastructure for list discovery and catalog data.

### Changes
1. Added `fetchLivePublicationDetail` in `djen.ts` which uses `numeroComunicacao` and `siglaTribunal` as the robust identity keys. It first probes the unproxied PDPJ API to save bandwidth, then falls back to the backend proxy for cases like strict CORS or AWS Cloudfront geo-blocks, and finally falls back to the provided IA object.
2. Intercepted `DateDetail` deep linking and featured item selection to initiate the live fetch for `featuredPub`.
3. Updated `PublicationCard.svelte` to receive and display `source` (`djen` or `ia`) and `usedFallback` state via discrete UI badges.
4. Covered logic with `vitest` unit tests in `detail-fetch.steps.ts` ensuring resilient fallback logic.

### Architectural Alignment
- Existing `DjenPublication` Zod schemas were completely reused. No duplicate interfaces were created.
- The overarching discovery UI continues to leverage IA archive structures securely while only individual items proactively request fresh updates.

---
*PR created automatically by Jules for task [12416016520806282710](https://jules.google.com/task/12416016520806282710) started by @franklinbaldo*