### PR TITLE
[codex] Stabilize djen-backup sync and default to direct DJEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,14 @@ IA_SECRET_KEY=your_ia_secret_key_here
 # =============================================================================
 # PIPELINE CONFIGURATION
 # =============================================================================
+# DJEN access mode
+# Local runs in Brazil should use the direct URL by default.
+DJEN_DIRECT_URL=https://comunicaapi.pje.jus.br
+# Set DJEN_USE_PROXY=true only when you need the Cloud Run proxy (for example in GitHub Actions).
+DJEN_USE_PROXY=false
+# Optional proxy URL override when DJEN_USE_PROXY=true
+DJEN_PROXY_URL=https://djen-proxy-mhgmawcn3a-rj.a.run.app
+
 # Maximum concurrent downloads from TJRO (default: 3)
 # Lower values are more respectful to TJRO servers
 MAX_CONCURRENT_DOWNLOADS=3

--- a/.github/workflows/collect-today.yml
+++ b/.github/workflows/collect-today.yml
@@ -30,6 +30,7 @@ jobs:
     environment: dev
 
     env:
+      DJEN_USE_PROXY: "1"
       DJEN_PROXY_URL: https://djen-proxy-mhgmawcn3a-rj.a.run.app
       IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
@@ -81,6 +82,7 @@ jobs:
           CMD="$CMD --workers 20"
           CMD="$CMD --state-file data/ia-state.json"
           CMD="$CMD --backfill-state-file data/backfill-state.json"
+          CMD="$CMD --use-proxy"
           # Skip absent markers to avoid IA spam detection
           CMD="$CMD --skip-absent-markers"
           CMD="$CMD --publish-live-status"

--- a/.github/workflows/collect-zips.yml
+++ b/.github/workflows/collect-zips.yml
@@ -59,6 +59,7 @@ jobs:
     environment: dev
 
     env:
+      DJEN_USE_PROXY: "1"
       DJEN_PROXY_URL: https://djen-proxy-mhgmawcn3a-rj.a.run.app
       IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
@@ -131,6 +132,7 @@ jobs:
           CMD="$CMD --backfill-state-file data/backfill-state.json"
           CMD="$CMD --state-file data/ia-state.json"
           CMD="$CMD --start-date $START_DATE"
+          CMD="$CMD --use-proxy"
           # Skip absent markers to avoid IA spam detection (hundreds of tiny files in sequence)
           # The 60-day stop rule still works — empty streak increments normally
           CMD="$CMD --skip-absent-markers"
@@ -252,5 +254,4 @@ jobs:
           echo '```text' >> $GITHUB_STEP_SUMMARY
           uv run --no-dev causaganha backfill status --backfill-state-file data/backfill-state.json >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ If your change touches archival code, validate the affected path carefully.
 
 ## DJEN access rule
 
-DJEN access can be geo-restricted. The repository supports a Cloud Run proxy through `DJEN_PROXY_URL`. Do not hardcode environment-specific URLs into application logic.
+DJEN direct access is the default for local runs in Brazil. Use the Cloud Run proxy only when `--use-proxy` or `DJEN_USE_PROXY=1` is explicitly set, such as in GitHub Actions. Do not hardcode environment-specific URLs into application logic.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The main GitHub Actions workflows in [.github/workflows](/Users/frank/workspace/
 ## Key constraints
 
 - Internet Archive uploads must use `httpx`-based logic. Do not migrate IA uploads to `boto3`.
-- DJEN access is geo-restricted, so the project supports a Cloud Run proxy through `DJEN_PROXY_URL`.
+- Local runs in Brazil should use direct DJEN access by default. Use the Cloud Run proxy only when `--use-proxy` or `DJEN_USE_PROXY=1` is explicitly set, such as in GitHub Actions.
 - The repository is mid-refactor. Some legacy scripts and older docs still exist, but the source of truth is the current code and workflows in this repo.
 
 ## Quick start
@@ -143,7 +143,9 @@ Start from [.env.example](/Users/frank/workspace/causaganha/.env.example). Commo
 - `GEMINI_API_KEY`
 - `IA_ACCESS_KEY` / `IA_SECRET_KEY`
 - `IAS3_ACCESS_KEY` / `IAS3_SECRET_KEY`
+- `DJEN_DIRECT_URL`
 - `DJEN_PROXY_URL`
+- `DJEN_USE_PROXY`
 - `ENABLED_TRIBUNALS`
 - `LOG_LEVEL`
 

--- a/src/causaganha/cli/commands/backfill.py
+++ b/src/causaganha/cli/commands/backfill.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from causaganha.config import DJEN_DIRECT_URL, DJEN_PROXY_URL
 from djen_backup.credentials import get_ia_s3_auth
 from djen_backup.engine import SyncConfig, SyncState, run_sync
 
@@ -26,9 +27,6 @@ app = typer.Typer(
 console = Console()
 
 _DEFAULT_STATE_FILE = Path("data/backfill-state.json")
-_DEFAULT_DJEN_PROXY = "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
-
-
 def _format_duration(seconds: float) -> str:
     if seconds < 60:
         return f"{seconds:.1f}s"
@@ -47,8 +45,11 @@ def _resolve_ia_auth(*, dry_run: bool = False) -> str:
         raise
 
 
-def _resolve_djen_url() -> str:
-    return os.environ.get("DJEN_PROXY_URL", _DEFAULT_DJEN_PROXY)
+def _resolve_djen_url(*, use_proxy: bool) -> str:
+    """Get the DJEN URL. Direct by default, proxy when outside Brazil."""
+    if use_proxy:
+        return os.environ.get("DJEN_PROXY_URL", DJEN_PROXY_URL)
+    return os.environ.get("DJEN_DIRECT_URL", DJEN_DIRECT_URL)
 
 
 def _preflight_checks() -> None:
@@ -106,6 +107,11 @@ def run(
     *,
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Logs detalhados."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Simular sem executar uploads."),
+    use_proxy: bool = typer.Option(
+        False,
+        "--use-proxy",
+        help="Usar proxy Cloud Run para DJEN (necessário fora do Brasil).",
+    ),
 ) -> None:
     """Run the DJEN ZIP backup sync against the Internet Archive."""
     # Load .env if present
@@ -154,7 +160,9 @@ def run(
         max_items=max_items,
         workers=workers,
         state_file=state_file,
-        djen_proxy_url=_resolve_djen_url(),
+        djen_proxy_url=_resolve_djen_url(
+            use_proxy=use_proxy or os.environ.get("DJEN_USE_PROXY", "").lower() in ("1", "true", "yes", "on")
+        ),
         ia_auth=_resolve_ia_auth(dry_run=dry_run),
         dry_run=dry_run,
     )

--- a/src/causaganha/cli/commands/backfill.py
+++ b/src/causaganha/cli/commands/backfill.py
@@ -27,6 +27,8 @@ app = typer.Typer(
 console = Console()
 
 _DEFAULT_STATE_FILE = Path("data/backfill-state.json")
+
+
 def _format_duration(seconds: float) -> str:
     if seconds < 60:
         return f"{seconds:.1f}s"
@@ -77,7 +79,7 @@ def _preflight_checks() -> None:
 
 
 @app.command()
-def run(
+def run(  # noqa: PLR0913
     target_date: str = typer.Option(
         "",
         "--date",
@@ -161,7 +163,8 @@ def run(
         workers=workers,
         state_file=state_file,
         djen_proxy_url=_resolve_djen_url(
-            use_proxy=use_proxy or os.environ.get("DJEN_USE_PROXY", "").lower() in ("1", "true", "yes", "on")
+            use_proxy=use_proxy
+            or os.environ.get("DJEN_USE_PROXY", "").lower() in ("1", "true", "yes", "on")
         ),
         ia_auth=_resolve_ia_auth(dry_run=dry_run),
         dry_run=dry_run,

--- a/src/causaganha/config.py
+++ b/src/causaganha/config.py
@@ -127,7 +127,8 @@ TRIBUNAIS: list[str] = [
     "TRE-TO",
 ]
 
-# DJEN Proxy URL for accessing DJEN communications API
+# DJEN URLs: direct is the default for local runs in Brazil; proxy is opt-in.
+DJEN_DIRECT_URL = os.environ.get("DJEN_DIRECT_URL", "https://comunicaapi.pje.jus.br")
 DJEN_PROXY_URL = os.environ.get("DJEN_PROXY_URL", "https://djen-proxy-mhgmawcn3a-rj.a.run.app")
 
 

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import UTC, date, datetime, timedelta
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 from typing import NamedTuple
 
 import structlog
@@ -29,6 +29,7 @@ from djen_backup.engine import (
     SyncState,
     run_sync,
 )
+
 
 DJEN_DIRECT_URL = "https://comunicaapi.pje.jus.br"
 DJEN_PROXY_FALLBACK_URL = "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
@@ -119,7 +120,9 @@ class RichSyncObserver:
         self.progress.console.log(msg)
 
     def on_periodic_sync_start(self) -> None:
-        self.progress.console.log("[yellow][Sync][/yellow] Periodic sync to Internet Archive starting...")
+        self.progress.console.log(
+            "[yellow][Sync][/yellow] Periodic sync to Internet Archive starting..."
+        )
 
     def on_periodic_sync_complete(self) -> None:
         self.progress.console.log("[green][OK][/green] Periodic sync complete.")
@@ -128,7 +131,9 @@ class RichSyncObserver:
         self.progress.console.log(f"[bold blue][Upload][/bold blue] {item_id} ({count} files)")
 
     def on_batch_upload_complete(self, item_id: str, count: int) -> None:
-        self.progress.console.log(f"[bold green][OK][/bold green] Batch upload complete: {item_id} ({count} files)")
+        self.progress.console.log(
+            f"[bold green][OK][/bold green] Batch upload complete: {item_id} ({count} files)"
+        )
 
 
 # ── CLI Helpers ─────────────────────────────────────────────────────
@@ -189,7 +194,9 @@ def _show_env_hint(env_result: EnvLoadResult | None) -> None:
         console.print(f"[dim]Using existing environment; {env_result.path} was not applied[/dim]")
 
 
-def _show_run_summary(exit_code: int, *, dry_run: bool, tribunal: str | None, max_items: int) -> None:
+def _show_run_summary(
+    exit_code: int, *, dry_run: bool, tribunal: str | None, max_items: int
+) -> None:
     title = "Run Complete" if exit_code == 0 else "Run Finished With Errors"
     border = "green" if exit_code == 0 else "red"
     rows = Table.grid(padding=(0, 2))
@@ -200,7 +207,9 @@ def _show_run_summary(exit_code: int, *, dry_run: bool, tribunal: str | None, ma
     rows.add_row("Tribunal:", tribunal or "All")
     rows.add_row("Item Limit:", str(max_items) if max_items else "Unlimited")
     if exit_code == 0 and not dry_run:
-        rows.add_row("Note:", "Completed cleanly. Zero uploads can still mean nothing new was found.")
+        rows.add_row(
+            "Note:", "Completed cleanly. Zero uploads can still mean nothing new was found."
+        )
     elif exit_code == 0:
         rows.add_row("Note:", "Dry run completed cleanly.")
     else:

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path  # noqa: TC003
+from typing import NamedTuple
 
 import structlog
 import typer
@@ -15,7 +16,6 @@ from rich.panel import Panel
 from rich.progress import (
     BarColumn,
     Progress,
-    SpinnerColumn,
     TaskID,
     TaskProgressColumn,
     TextColumn,
@@ -29,6 +29,14 @@ from djen_backup.engine import (
     SyncState,
     run_sync,
 )
+
+DJEN_DIRECT_URL = "https://comunicaapi.pje.jus.br"
+DJEN_PROXY_FALLBACK_URL = "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
+
+
+class EnvLoadResult(NamedTuple):
+    path: Path
+    loaded_keys: list[str]
 
 
 # ── Setup ───────────────────────────────────────────────────────────
@@ -75,7 +83,7 @@ class RichSyncObserver:
             task_id = self.progress.add_task(f"[cyan]{tribunal} {year}", total=count, visible=True)
             self.tribunal_tasks[f"{tribunal}-{year}"] = task_id
         else:
-            self.progress.console.log(f"[green]✓ {tribunal} {year} is up to date.[/green]")
+            self.progress.console.log(f"[green][OK][/green] {tribunal} {year} is up to date.")
 
     def on_item_start(self, tribunal: str, d: date) -> None:
         pass
@@ -84,7 +92,7 @@ class RichSyncObserver:
         # Log successful uploads/hits with URL
         if status == "hit" and url:
             self.progress.console.log(
-                f"[green]✓[/green] {tribunal} {d.isoformat()} [dim]({url})[/dim]"
+                f"[green][OK][/green] {tribunal} {d.isoformat()} [dim]({url})[/dim]"
             )
 
         # Find the task for this tribunal-year
@@ -103,7 +111,7 @@ class RichSyncObserver:
         body: str | None = None,
     ) -> None:
         msg = (
-            f"[bold yellow]⚠ Retry {attempt}[/bold yellow] for {tribunal} {d.isoformat()} "
+            f"[bold yellow][Retry {attempt}][/bold yellow] for {tribunal} {d.isoformat()} "
             f"(Status: {status}). Waiting {wait_s:.1f}s..."
         )
         if body:
@@ -111,22 +119,16 @@ class RichSyncObserver:
         self.progress.console.log(msg)
 
     def on_periodic_sync_start(self) -> None:
-        self.progress.console.log(
-            "[yellow]⟳ Periodic sync to Internet Archive starting...[/yellow]"
-        )
+        self.progress.console.log("[yellow][Sync][/yellow] Periodic sync to Internet Archive starting...")
 
     def on_periodic_sync_complete(self) -> None:
-        self.progress.console.log("[green]✓ Periodic sync complete.[/green]")
+        self.progress.console.log("[green][OK][/green] Periodic sync complete.")
 
     def on_batch_upload_start(self, item_id: str, count: int) -> None:
-        self.progress.console.log(
-            f"[bold blue]↑ Batch Upload Starting:[/bold blue] {item_id} ({count} files)"
-        )
+        self.progress.console.log(f"[bold blue][Upload][/bold blue] {item_id} ({count} files)")
 
     def on_batch_upload_complete(self, item_id: str, count: int) -> None:
-        self.progress.console.log(
-            f"[bold green]✓ Batch Upload Complete:[/bold green] {item_id} ({count} files)"
-        )
+        self.progress.console.log(f"[bold green][OK][/bold green] Batch upload complete: {item_id} ({count} files)")
 
 
 # ── CLI Helpers ─────────────────────────────────────────────────────
@@ -136,10 +138,35 @@ def _parse_date(value: str) -> date:
     return date.fromisoformat(value)
 
 
-def _resolve_proxy_url() -> str:
-    return (
-        os.environ.get("DJEN_PROXY_URL", "").strip() or "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
-    )
+def _load_local_env(path: Path = Path(".env")) -> EnvLoadResult | None:
+    if not path.exists():
+        return None
+
+    loaded_keys: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if not key or key in os.environ:
+            continue
+        os.environ[key] = value
+        loaded_keys.append(key)
+
+    return EnvLoadResult(path=path.resolve(), loaded_keys=loaded_keys)
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_djen_url(*, use_proxy: bool) -> str:
+    if use_proxy:
+        return os.environ.get("DJEN_PROXY_URL", "").strip() or DJEN_PROXY_FALLBACK_URL
+    return os.environ.get("DJEN_DIRECT_URL", "").strip() or DJEN_DIRECT_URL
 
 
 def _resolve_ia_auth(*, dry_run: bool) -> str:
@@ -150,6 +177,35 @@ def _resolve_ia_auth(*, dry_run: bool) -> str:
             return "LOW dry-run:dry-run"
         console.print(f"[bold red]Error:[/bold red] {exc}")
         raise typer.Exit(code=1) from exc
+
+
+def _show_env_hint(env_result: EnvLoadResult | None) -> None:
+    if not env_result:
+        return
+    if env_result.loaded_keys:
+        joined = ", ".join(env_result.loaded_keys)
+        console.print(f"[dim]Loaded environment from {env_result.path} ({joined})[/dim]")
+    else:
+        console.print(f"[dim]Using existing environment; {env_result.path} was not applied[/dim]")
+
+
+def _show_run_summary(exit_code: int, *, dry_run: bool, tribunal: str | None, max_items: int) -> None:
+    title = "Run Complete" if exit_code == 0 else "Run Finished With Errors"
+    border = "green" if exit_code == 0 else "red"
+    rows = Table.grid(padding=(0, 2))
+    rows.add_column(style="bold cyan")
+    rows.add_column()
+    rows.add_row("Status:", "[green]OK[/green]" if exit_code == 0 else "[red]Error[/red]")
+    rows.add_row("Mode:", "Dry run" if dry_run else "Live upload")
+    rows.add_row("Tribunal:", tribunal or "All")
+    rows.add_row("Item Limit:", str(max_items) if max_items else "Unlimited")
+    if exit_code == 0 and not dry_run:
+        rows.add_row("Note:", "Completed cleanly. Zero uploads can still mean nothing new was found.")
+    elif exit_code == 0:
+        rows.add_row("Note:", "Dry run completed cleanly.")
+    else:
+        rows.add_row("Note:", "See warnings above for the failing stage.")
+    console.print(Panel(rows, title=f"[bold white]{title}[/bold white]", border_style=border))
 
 
 def show_banner():
@@ -205,15 +261,24 @@ def main(  # noqa: PLR0913
         "--skip-if-mostly-complete",
         help="Skip collection if today is already mostly complete.",
     ),
+    use_proxy: bool = typer.Option(
+        False,
+        "--use-proxy",
+        help="Use the Cloud Run DJEN proxy. Default is direct access.",
+    ),
 ):
     """Main backup and sync command."""
     if ctx.invoked_subcommand:
         return
+    env_result = _load_local_env()
     show_banner()
+    _show_env_hint(env_result)
 
     today = datetime.now(tz=UTC).date()
     resolved_end = _parse_date(end_date) if end_date else today - timedelta(days=1)
     resolved_start = _parse_date(start_date) if start_date else date(2020, 1, 1)
+    resolved_use_proxy = use_proxy or _env_truthy("DJEN_USE_PROXY")
+    resolved_djen_url = _resolve_djen_url(use_proxy=resolved_use_proxy)
 
     resolved_state_file = backfill_state_file or state_file
 
@@ -226,8 +291,12 @@ def main(  # noqa: PLR0913
         "Start Date:", resolved_start.isoformat() if resolved_start else "2013-01-01 (Auto)"
     )
     config_table.add_row("Tribunal:", tribunal or "All")
+    config_table.add_row("Deadline:", f"{deadline_minutes} min")
+    config_table.add_row("Max Items:", str(max_items) if max_items else "Unlimited")
     config_table.add_row("Workers:", str(workers))
     config_table.add_row("Dry Run:", "[yellow]Yes[/yellow]" if dry_run else "[green]No[/green]")
+    config_table.add_row("DJEN Mode:", "Proxy" if resolved_use_proxy else "Direct")
+    config_table.add_row("DJEN URL:", resolved_djen_url)
 
     console.print(
         Panel(config_table, title="[bold white]Run Configuration[/bold white]", border_style="blue")
@@ -235,7 +304,6 @@ def main(  # noqa: PLR0913
 
     # Prepare Rich components
     progress = Progress(
-        SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         TaskProgressColumn(),
@@ -254,7 +322,7 @@ def main(  # noqa: PLR0913
         max_items=max_items,
         workers=workers,
         state_file=resolved_state_file,
-        djen_proxy_url=_resolve_proxy_url(),
+        djen_proxy_url=resolved_djen_url,
         ia_auth=_resolve_ia_auth(dry_run=dry_run),
         dry_run=dry_run,
         skip_absent_markers=skip_absent_markers,
@@ -266,6 +334,12 @@ def main(  # noqa: PLR0913
     with Live(Group(progress), console=console, refresh_per_second=4):
         exit_code = asyncio.run(run_sync(config))
 
+    _show_run_summary(
+        exit_code,
+        dry_run=dry_run,
+        tribunal=tribunal,
+        max_items=max_items,
+    )
     raise typer.Exit(code=exit_code)
 
 

--- a/src/djen_backup/archive.py
+++ b/src/djen_backup/archive.py
@@ -98,6 +98,21 @@ def get_ia_item_id(tribunal: str, d: date) -> str:
     return f"djen-{tribunal.lower()}-{d.year}"
 
 
+def get_ia_item_tribunal(item_id: str) -> str:
+    """Extract the tribunal code from ``djen-{tribunal}-{year}`` item ids."""
+    prefix = "djen-"
+    if not item_id.startswith(prefix):
+        msg = f"Invalid IA item id: {item_id!r}"
+        raise ValueError(msg)
+
+    body = item_id[len(prefix) :]
+    tribunal, sep, year = body.rpartition("-")
+    if not sep or not tribunal or not year.isdigit():
+        msg = f"Invalid IA item id: {item_id!r}"
+        raise ValueError(msg)
+    return tribunal.upper()
+
+
 def _content_md5(data: bytes) -> str:
     """Return base64-encoded MD5 digest per the S3 Content-MD5 spec."""
     digest = hashlib.md5(data, usedforsecurity=False).digest()
@@ -120,6 +135,47 @@ def _build_upload_headers(
         "x-archive-meta-creator": "CausaGanha",
         "x-archive-meta-subject": "brazilian-law;djen;legal;judiciary",
     }
+
+
+async def put_ia_bytes(
+    client: httpx.AsyncClient,
+    url: str,
+    content: bytes,
+    headers: dict[str, str],
+    *,
+    max_retries: int = 7,
+) -> httpx.Response:
+    """Upload bytes to IA with the shared write lock and retry policy."""
+    last_resp: httpx.Response | None = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            async with _upload_lock:
+                resp = await client.request("PUT", url, content=content, headers=headers)
+                last_resp = resp
+                if resp.status_code == HTTP_OK or resp.status_code not in RETRIABLE_STATUS_CODES:
+                    await asyncio.sleep(_UPLOAD_COOLDOWN_S)
+                    break
+        except (httpx.TransportError, httpx.TimeoutException):
+            wait = max(5.0, float(2**attempt))
+            if attempt < max_retries:
+                await asyncio.sleep(wait)
+                continue
+            raise
+
+        if attempt < max_retries:
+            body_text = resp.text[:200] if resp.text else "No body"
+            if "SlowDown" in body_text or "bucket_tasks_queued" in body_text:
+                log.warning("upload_bucket_saturated", status=resp.status_code, url=url)
+                return resp
+
+            wait = _backoff(attempt, resp)
+            await asyncio.sleep(wait)
+            continue
+        break
+
+    assert last_resp is not None
+    return last_resp
 
 
 async def upload_zip(
@@ -147,52 +203,20 @@ async def upload_zip(
     log.info("upload_starting", date=d.isoformat(), tribunal=tribunal, size_mb=size_mb)
 
     max_retries = 7
-    last_resp: httpx.Response | None = None
+    try:
+        last_resp = await put_ia_bytes(
+            client,
+            url,
+            content,
+            headers,
+            max_retries=max_retries,
+        )
+    except (httpx.TransportError, httpx.TimeoutException):
+        wait = max(5.0, 1.0)
+        if observer:
+            observer.on_retry(tribunal, d, 1, 0, wait, body="Transport/Timeout")
+        raise
 
-    for attempt in range(max_retries + 1):
-        try:
-            async with _upload_lock:
-                resp = await client.request("PUT", url, content=content, headers=headers)
-                last_resp = resp
-                # If success or non-retriable, we still hold the lock for the cooldown
-                if resp.status_code == HTTP_OK or resp.status_code not in RETRIABLE_STATUS_CODES:
-                    await asyncio.sleep(_UPLOAD_COOLDOWN_S)
-                    break
-        except (httpx.TransportError, httpx.TimeoutException):
-            wait = max(5.0, float(2**attempt))
-            if attempt < max_retries:
-                if observer:
-                    observer.on_retry(tribunal, d, attempt + 1, 0, wait, body="Transport/Timeout")
-                await asyncio.sleep(wait)
-                continue
-            raise
-
-        if attempt < max_retries:
-            body_text = resp.text[:200] if resp.text else "No body"
-
-            # If the error is a specific "Slow Down" or "Bucket Queued" from IA,
-            # we don't just wait; we return so the engine can switch to a different tribunal.
-            if "SlowDown" in body_text or "bucket_tasks_queued" in body_text:
-                log.warning("upload_bucket_saturated", tribunal=tribunal, status=resp.status_code)
-                if observer:
-                    observer.on_retry(
-                        tribunal,
-                        d,
-                        attempt + 1,
-                        resp.status_code,
-                        0,
-                        body="Bucket Saturated - Switching",
-                    )
-                return resp
-
-            wait = _backoff(attempt, resp)
-            if observer:
-                observer.on_retry(tribunal, d, attempt + 1, resp.status_code, wait, body=body_text)
-            await asyncio.sleep(wait)
-            continue
-        break
-
-    assert last_resp is not None
     elapsed = round(time.monotonic() - start_time, 1)
     body = last_resp.content or b""
     if last_resp.status_code == HTTP_OK:

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -15,8 +15,8 @@ import httpx
 import structlog
 
 from djen_backup.archive import (
-    get_ia_item_tribunal,
     get_ia_item_id,
+    get_ia_item_tribunal,
     put_ia_bytes,
     upload_zip,
 )
@@ -499,7 +499,7 @@ async def run_sync(config: SyncConfig) -> int:
 
             last_ia_sync = time.monotonic()
             sync_interval_s = 180
-            items_processed: dict[str, int] = {t: 0 for t in tribunals}
+            items_processed: dict[str, int] = dict.fromkeys(tribunals, 0)
 
             for year in years:
                 if time.monotonic() > deadline - year_buffer_s:
@@ -552,8 +552,7 @@ async def run_sync(config: SyncConfig) -> int:
                                     await state.advance_cursor(t, d)
 
                                 has_remaining_capacity = (
-                                    config.max_items == 0
-                                    or items_processed[t] < config.max_items
+                                    config.max_items == 0 or items_processed[t] < config.max_items
                                 )
                                 if pending_gaps[t] and has_remaining_capacity:
                                     tribunal_queue.put_nowait(t)

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -15,7 +15,9 @@ import httpx
 import structlog
 
 from djen_backup.archive import (
+    get_ia_item_tribunal,
     get_ia_item_id,
+    put_ia_bytes,
     upload_zip,
 )
 from djen_backup.djen import DJENNotFoundError, download_zip, get_caderno_url
@@ -235,7 +237,7 @@ async def upload_state_to_ia(filename: str, data: dict, auth: str) -> bool:
     }
     try:
         async with httpx.AsyncClient(timeout=60) as client:
-            resp = await client.put(url, content=content, headers=headers)
+            resp = await put_ia_bytes(client, url, content, headers)
             if resp.status_code < 400:
                 log.info("state_uploaded_to_ia", filename=filename)
                 return True
@@ -306,6 +308,12 @@ async def download_to_staging(
     summary: SyncSummary,
 ) -> str:
     """Download a single ZIP from DJEN and place it in staging."""
+    targeted_single_day = (
+        config.tribunal is not None
+        and config.lower_bound is not None
+        and config.lower_bound == config.start_date
+    )
+
     # 1. Check inventory
     status = inventory.get_status(tribunal, d)
     if status == "uploaded":
@@ -313,10 +321,13 @@ async def download_to_staging(
         await summary.inc_cache_hit()
         if config.observer:
             item_id = get_ia_item_id(tribunal, d)
-            url = f"https://archive.org/download/{item_id}"
+            filename = f"djen-{d.isoformat()}-{tribunal.upper()}.zip"
+            url = f"https://archive.org/download/{item_id}/{filename}"
             config.observer.on_item_complete(tribunal, d, "hit", url=url)
         return "hit"
-    if status in ("absent", "staged"):
+    if status == "staged":
+        return status
+    if status == "absent" and not targeted_single_day:
         if status == "absent":
             await state.record_empty(tribunal)
             await summary.inc_empty()
@@ -379,17 +390,12 @@ async def batch_uploader(
             if len(dates) >= BATCH_SIZE or (
                 len(dates) > 0 and time.monotonic() % 300 < 10
             ):  # Batch of 10 or every 5 mins
+                tribunal = get_ia_item_tribunal(item_id)
                 if config.observer:
                     config.observer.on_batch_upload_start(item_id, len(dates))
 
-                # Prepare file list
-                files = []
-                for d in dates:
-                    filename = f"djen-{d.isoformat()}-{item_id.split('-')[1].upper()}.zip"
-                    files.append(str(STAGING_DIR / item_id / filename))
-
                 try:
-                    tribunal = item_id.split("-")[1].upper()
+                    tribunal = get_ia_item_tribunal(item_id)
                     for d in dates:
                         filename = f"djen-{d.isoformat()}-{tribunal}.zip"
                         path = STAGING_DIR / item_id / filename
@@ -426,6 +432,8 @@ async def run_sync(config: SyncConfig) -> int:
     """The unified sync entry point with Producer-Consumer Batching."""
     start_time = time.monotonic()
     deadline = start_time + config.deadline_minutes * 60
+    year_buffer_s = min(60.0, max(10.0, config.deadline_minutes * 10.0))
+    item_buffer_s = min(30.0, max(5.0, config.deadline_minutes * 5.0))
     STAGING_DIR.mkdir(parents=True, exist_ok=True)
 
     # 0. Initial state & inventory
@@ -482,6 +490,7 @@ async def run_sync(config: SyncConfig) -> int:
                 tribunals = [config.tribunal.upper()]
 
             for t in tribunals:
+                await state.get_or_init(t, config.start_date)
                 await state.ensure_cursor_at_least(t, config.start_date)
 
             upper = config.start_date
@@ -490,14 +499,17 @@ async def run_sync(config: SyncConfig) -> int:
 
             last_ia_sync = time.monotonic()
             sync_interval_s = 180
+            items_processed: dict[str, int] = {t: 0 for t in tribunals}
 
             for year in years:
-                if time.monotonic() > deadline - 60:
+                if time.monotonic() > deadline - year_buffer_s:
                     break
                 log.info("sync_year_starting", year=year)
 
                 tribunal_queue = asyncio.Queue()
                 for t in sorted(tribunals):
+                    if config.max_items and items_processed[t] >= config.max_items:
+                        continue
                     if not inventory.is_year_complete(t, year, upper, lower):
                         tribunal_queue.put_nowait(t)
 
@@ -507,13 +519,13 @@ async def run_sync(config: SyncConfig) -> int:
                 async def downloader_task() -> None:
                     nonlocal last_ia_sync
                     while not tribunal_queue.empty():
-                        if time.monotonic() > deadline - 30:
+                        if time.monotonic() > deadline - item_buffer_s:
                             break
 
                         # Back-pressure: if staging is too full, wait
                         while inventory.count_staged() >= MAX_STAGED_FILES:
                             await asyncio.sleep(30)
-                            if time.monotonic() > deadline - 30:
+                            if time.monotonic() > deadline - item_buffer_s:
                                 return
 
                         t = await tribunal_queue.get()
@@ -533,11 +545,17 @@ async def run_sync(config: SyncConfig) -> int:
                                 res = await download_to_staging(
                                     client, t, d, config, state, inventory, summary
                                 )
+                                if res in ("hit", "empty", "staged", "error"):
+                                    items_processed[t] += 1
 
                                 if res in ("hit", "empty"):
                                     await state.advance_cursor(t, d)
 
-                                if pending_gaps[t]:
+                                has_remaining_capacity = (
+                                    config.max_items == 0
+                                    or items_processed[t] < config.max_items
+                                )
+                                if pending_gaps[t] and has_remaining_capacity:
                                     tribunal_queue.put_nowait(t)
 
                             # Periodic sync
@@ -566,7 +584,7 @@ async def run_sync(config: SyncConfig) -> int:
             # Final upload of anything left in staging
             staged_items = inventory.get_staged_by_item()
             for item_id, dates in staged_items.items():
-                tribunal = item_id.split("-")[1].upper()
+                tribunal = get_ia_item_tribunal(item_id)
                 try:
                     for d in dates:
                         filename = f"djen-{d.isoformat()}-{tribunal}.zip"
@@ -582,6 +600,8 @@ async def run_sync(config: SyncConfig) -> int:
                             continue
 
                         await inventory.add(tribunal, d)
+                        await state.record_hit(tribunal, d)
+                        await summary.inc_hit()
                         path.unlink(missing_ok=True)
                 except Exception:
                     log.exception("final_flush_failed", item_id=item_id)

--- a/src/djen_backup/inventory.py
+++ b/src/djen_backup/inventory.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import structlog
 
+from djen_backup.archive import put_ia_bytes
+
 
 log = structlog.get_logger()
 
@@ -48,7 +50,7 @@ async def upload_text_to_ia(filename: str, content: str, auth: str) -> bool:
     }
     try:
         async with httpx.AsyncClient(timeout=60) as client:
-            resp = await client.put(url, content=content.encode("utf-8"), headers=headers)
+            resp = await put_ia_bytes(client, url, content.encode("utf-8"), headers)
             if resp.status_code < 400:
                 log.info("text_uploaded_to_ia", filename=filename)
                 return True

--- a/tests/djen_backup/test_cli_helpers.py
+++ b/tests/djen_backup/test_cli_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from djen_backup.__main__ import (
+    DJEN_DIRECT_URL,
+    DJEN_PROXY_FALLBACK_URL,
+    _env_truthy,
+    _load_local_env,
+    _resolve_djen_url,
+)
+
+
+def test_load_local_env_reads_missing_keys_only(tmp_path: Path, monkeypatch) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "IAS3_ACCESS_KEY=from-file\nIAS3_SECRET_KEY='secret-value'\nEXISTING=ignored\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("IAS3_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("IAS3_SECRET_KEY", raising=False)
+    monkeypatch.setenv("EXISTING", "already-set")
+
+    result = _load_local_env(env_file)
+
+    assert result is not None
+    assert result.loaded_keys == ["IAS3_ACCESS_KEY", "IAS3_SECRET_KEY"]
+    assert result.path == env_file.resolve()
+
+
+def test_resolve_djen_url_defaults_to_direct(monkeypatch) -> None:
+    monkeypatch.delenv("DJEN_DIRECT_URL", raising=False)
+    monkeypatch.delenv("DJEN_PROXY_URL", raising=False)
+
+    assert _resolve_djen_url(use_proxy=False) == DJEN_DIRECT_URL
+
+
+def test_resolve_djen_url_uses_proxy_when_requested(monkeypatch) -> None:
+    monkeypatch.delenv("DJEN_PROXY_URL", raising=False)
+
+    assert _resolve_djen_url(use_proxy=True) == DJEN_PROXY_FALLBACK_URL
+
+
+def test_env_truthy_recognizes_proxy_flag(monkeypatch) -> None:
+    monkeypatch.setenv("DJEN_USE_PROXY", "true")
+
+    assert _env_truthy("DJEN_USE_PROXY") is True

--- a/tests/djen_backup/test_cli_helpers.py
+++ b/tests/djen_backup/test_cli_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from djen_backup.__main__ import (
     DJEN_DIRECT_URL,
@@ -9,6 +9,10 @@ from djen_backup.__main__ import (
     _load_local_env,
     _resolve_djen_url,
 )
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_load_local_env_reads_missing_keys_only(tmp_path: Path, monkeypatch) -> None:

--- a/tests/djen_backup/test_ia_contract.py
+++ b/tests/djen_backup/test_ia_contract.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+from djen_backup import archive as archive_module
+from djen_backup import engine as engine_module
+from djen_backup.archive import fetch_ia_existing, get_ia_item_id, get_ia_item_tribunal
+from djen_backup.inventory import ZipInventory
+
+
+@pytest.mark.asyncio
+async def test_fetch_ia_existing_reads_tribunal_year_bucket(mock_api) -> None:
+    mock_api.get("https://archive.org/metadata/djen-tre-sp-2024/files").respond(
+        200,
+        json={
+            "result": [
+                {"name": "djen-2024-03-15-TRE-SP.zip"},
+                {"name": "README.txt"},
+            ]
+        },
+    )
+
+    async with httpx.AsyncClient() as client:
+        existing = await fetch_ia_existing(client, "TRE-SP", 2024)
+
+    assert existing == {date(2024, 3, 15): "uploaded"}
+
+
+def test_inventory_url_matches_ia_contract_for_hyphenated_tribunal() -> None:
+    assert ZipInventory._url("TRE-SP", date(2024, 3, 15)) == (
+        "https://archive.org/download/djen-tre-sp-2024/djen-2024-03-15-TRE-SP.zip"
+    )
+
+
+def test_item_id_round_trip_preserves_hyphenated_tribunal() -> None:
+    item_id = get_ia_item_id("TRE-SP", date(2024, 1, 2))
+    assert item_id == "djen-tre-sp-2024"
+    assert get_ia_item_tribunal(item_id) == "TRE-SP"
+
+
+def test_item_id_parser_rejects_invalid_value() -> None:
+    with pytest.raises(ValueError):
+        get_ia_item_tribunal("backup-djen-2024-01-01")
+
+
+@pytest.mark.asyncio
+async def test_run_sync_respects_max_items_per_tribunal(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[date] = []
+
+    async def _load_from_ia(self: ZipInventory) -> int:
+        return 0
+
+    async def _load_from_snapshot(self: ZipInventory) -> int:
+        return 0
+
+    async def _fetch_ia_existing(
+        client: httpx.AsyncClient,
+        tribunal: str,
+        year: int,
+    ) -> dict[date, str]:
+        return {}
+
+    async def _download_state_from_ia(filename: str) -> dict | None:
+        return None
+
+    async def _get_tribunal_list(client: httpx.AsyncClient, url: str) -> list[str]:
+        return ["TJSP"]
+
+    async def _download_to_staging(
+        client: httpx.AsyncClient,
+        tribunal: str,
+        d: date,
+        config: engine_module.SyncConfig,
+        state: engine_module.SyncState,
+        inventory: ZipInventory,
+        summary: engine_module.SyncSummary,
+    ) -> str:
+        calls.append(d)
+        await summary.inc_hit()
+        return "hit"
+
+    monkeypatch.setattr(ZipInventory, "load_from_ia", _load_from_ia)
+    monkeypatch.setattr(ZipInventory, "load_from_disk", lambda self: 0)
+    monkeypatch.setattr(ZipInventory, "load_from_snapshot", _load_from_snapshot)
+    monkeypatch.setattr(engine_module, "download_state_from_ia", _download_state_from_ia)
+    monkeypatch.setattr(engine_module, "get_tribunal_list", _get_tribunal_list)
+    monkeypatch.setattr(archive_module, "fetch_ia_existing", _fetch_ia_existing)
+    monkeypatch.setattr(engine_module, "download_to_staging", _download_to_staging)
+
+    config = engine_module.SyncConfig(
+        start_date=date(2024, 1, 3),
+        lower_bound=date(2024, 1, 1),
+        tribunal="TJSP",
+        deadline_minutes=1,
+        max_items=1,
+        workers=1,
+        state_file=None,
+        djen_proxy_url="https://example.invalid",
+        ia_auth="LOW dry-run:dry-run",
+        dry_run=True,
+    )
+
+    exit_code = await engine_module.run_sync(config)
+
+    assert exit_code == 0
+    assert calls == [date(2024, 1, 3)]
+
+
+@pytest.mark.asyncio
+async def test_single_day_targeted_run_ignores_absent_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
+    inventory = ZipInventory()
+    await inventory.add_absent("TRF3", date(2024, 12, 26))
+    state = engine_module.SyncState()
+    await state.get_or_init("TRF3", date(2024, 12, 26))
+    summary = engine_module.SyncSummary()
+
+    calls: list[date] = []
+
+    async def _get_caderno_url(
+        client: httpx.AsyncClient,
+        base_url: str,
+        tribunal: str,
+        d: date,
+    ) -> str:
+        calls.append(d)
+        return "https://example.invalid/fake.zip"
+
+    async def _download_zip(client: httpx.AsyncClient, url: str) -> str:
+        return str(Path("C:/tmp/fake.zip"))
+
+    async def _to_thread(fn, *args):
+        return fn(*args)
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _get_caderno_url)
+    monkeypatch.setattr(engine_module, "download_zip", _download_zip)
+    monkeypatch.setattr(engine_module.shutil, "move", lambda src, dst: None)
+    monkeypatch.setattr(engine_module.asyncio, "to_thread", _to_thread)
+
+    config = engine_module.SyncConfig(
+        start_date=date(2024, 12, 26),
+        lower_bound=date(2024, 12, 26),
+        tribunal="TRF3",
+        deadline_minutes=1,
+        max_items=1,
+        workers=1,
+        state_file=None,
+        djen_proxy_url="https://example.invalid",
+        ia_auth="LOW dry-run:dry-run",
+        dry_run=False,
+    )
+
+    async with httpx.AsyncClient() as client:
+        result = await engine_module.download_to_staging(
+            client, "TRF3", date(2024, 12, 26), config, state, inventory, summary
+        )
+
+    assert result == "staged"
+    assert calls == [date(2024, 12, 26)]

--- a/tests/djen_backup/test_ia_contract.py
+++ b/tests/djen_backup/test_ia_contract.py
@@ -43,7 +43,7 @@ def test_item_id_round_trip_preserves_hyphenated_tribunal() -> None:
 
 
 def test_item_id_parser_rejects_invalid_value() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid IA item id"):
         get_ia_item_tribunal("backup-djen-2024-01-01")
 
 
@@ -55,6 +55,9 @@ async def test_run_sync_respects_max_items_per_tribunal(monkeypatch: pytest.Monk
         return 0
 
     async def _load_from_snapshot(self: ZipInventory) -> int:
+        return 0
+
+    def _load_from_disk(self: ZipInventory) -> int:
         return 0
 
     async def _fetch_ia_existing(
@@ -84,7 +87,7 @@ async def test_run_sync_respects_max_items_per_tribunal(monkeypatch: pytest.Monk
         return "hit"
 
     monkeypatch.setattr(ZipInventory, "load_from_ia", _load_from_ia)
-    monkeypatch.setattr(ZipInventory, "load_from_disk", lambda self: 0)
+    monkeypatch.setattr(ZipInventory, "load_from_disk", _load_from_disk)
     monkeypatch.setattr(ZipInventory, "load_from_snapshot", _load_from_snapshot)
     monkeypatch.setattr(engine_module, "download_state_from_ia", _download_state_from_ia)
     monkeypatch.setattr(engine_module, "get_tribunal_list", _get_tribunal_list)
@@ -111,7 +114,9 @@ async def test_run_sync_respects_max_items_per_tribunal(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
-async def test_single_day_targeted_run_ignores_absent_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_single_day_targeted_run_ignores_absent_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     inventory = ZipInventory()
     await inventory.add_absent("TRF3", date(2024, 12, 26))
     state = engine_module.SyncState()
@@ -135,9 +140,12 @@ async def test_single_day_targeted_run_ignores_absent_inventory(monkeypatch: pyt
     async def _to_thread(fn, *args):
         return fn(*args)
 
+    def _move(_src: str, _dst: str) -> None:
+        return None
+
     monkeypatch.setattr(engine_module, "get_caderno_url", _get_caderno_url)
     monkeypatch.setattr(engine_module, "download_zip", _download_zip)
-    monkeypatch.setattr(engine_module.shutil, "move", lambda src, dst: None)
+    monkeypatch.setattr(engine_module.shutil, "move", _move)
     monkeypatch.setattr(engine_module.asyncio, "to_thread", _to_thread)
 
     config = engine_module.SyncConfig(


### PR DESCRIPTION
## What changed
- defaulted DJEN access to the direct endpoint for local runs and made proxy usage opt-in via `--use-proxy` / `DJEN_USE_PROXY`
- stabilized `djen-backup` sync flow around short deadlines, targeted single-day runs, staged/final flush accounting, and shared IA write throttling
- improved local CLI UX with `.env` autoloading, clearer run configuration, and final status summaries
- updated GitHub Actions to opt into the Cloud Run proxy explicitly
- added coverage for URL resolution, max-items enforcement, targeted absent revalidation, and helper behavior

## Why
Local runs in Brazil should not depend on the proxy. While validating that change, several real execution issues showed up in the ZIP sync path:
- very short runs could exit before doing useful work
- targeted runs could skip valid dates due to stale `absent` markers
- final flush uploads were succeeding without updating hit counters consistently
- auxiliary IA writes were not using the same throttling path as ZIP uploads

## Impact
- local operators now hit DJEN directly by default
- GitHub Actions keeps using the proxy, but only because workflows opt in explicitly
- single-day targeted runs are more trustworthy for validating real ZIP download/upload behavior
- CLI output is clearer during local debugging

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/djen_backup -q`
- real local CLI runs that completed successfully with actual ZIP download and IA upload:
  - `djen-backup --tribunal TST --start-date 2024-12-26 --end-date 2024-12-26 --max-items 1 --deadline-minutes 5`
  - `djen-backup --tribunal TJPI --start-date 2024-12-26 --end-date 2024-12-26 --max-items 1 --deadline-minutes 5`
