### PR TITLE
Document deployment model, state management, and URL routing

### DIFF
--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -31,7 +31,40 @@ All frontend decisions must serve the principles in [`DESIGN.md`](DESIGN.md). Re
 | In-browser SQL | DuckDB WASM |
 | Sanitization | DOMPurify |
 | Testing | Vitest + Testing Library + vitest-cucumber |
-| Linting | ESLint (flat config) + TypeScript |
+| Linting | ESLint (flat config) |
+| Language | TypeScript (strict) |
+
+---
+
+## Deployment — GitHub Pages (SSG)
+
+This project is deployed as a **100% static site on GitHub Pages** via `output: 'static'` in `astro.config.mjs`. Key constraints that affect every frontend decision:
+
+- **No server at runtime.** There are no API routes, no SSR, no middleware. Every page is a `.html` file generated at build time.
+- **`readJson()` runs only at build time.** Any data loaded via `readJson()` must be present in the `public/` directory when `astro build` runs. Missing files fail the build, not the page.
+- **All dynamic routes must use `getStaticPaths()`.** There is no server fallback for unknown paths. If a path is not in `getStaticPaths()`, it does not exist.
+- **`404.astro` is the GitHub Pages 404 page.** GitHub Pages serves `404.html` for unknown paths automatically — no extra configuration needed.
+- **Always use `import.meta.env.BASE_URL`, never hardcode `/causaganha/`.** The base path is `/causaganha` in production; hardcoded paths break local dev.
+
+```ts
+// Correct
+const href = import.meta.env.BASE_URL + 'publicacoes';
+
+// Wrong — breaks on local dev, breaks if base path ever changes
+const href = '/causaganha/publicacoes';
+```
+
+- **`trailingSlash: 'never'`** — internal `href` values must not end with `/`. Write `href="/causaganha/publicacoes"`, not `href="/causaganha/publicacoes/"`.
+- **Prefetch is on by default (`defaultStrategy: 'hover'`).** Links prefetch on hover automatically. Do not add manual `<link rel="prefetch">` tags.
+- **Live data comes from Internet Archive, not a backend.** After the static page loads, `fetchData.ts` fetches live JSON from `archive.org`. This is the only "API" this project has.
+- **`.ts` endpoint files generate static files at build.** `robots.txt.ts` and `sitemap.xml.ts` run once at build time and output static files. They are not runtime API routes.
+
+### Anti-patterns — Deployment
+
+- **Do not** use `Astro.request`, `Astro.response`, or server middleware — they require SSR.
+- **Do not** use `client:server-only` or any Astro SSR-only feature.
+- **Do not** expect `readJson()` to work inside Svelte components (browser context). It is build-time only.
+- **Do not** hardcode `/causaganha/` — use `import.meta.env.BASE_URL`.
 
 ---
 
@@ -59,16 +92,32 @@ This is the most consequential decision in this codebase. Getting it wrong adds 
 - The code is **framework-agnostic** and could in principle be used by both `.astro` and `.svelte` files.
 - You are defining a **Zod schema**, a **store**, or a **utility function**.
 
+### `lib/` organisation
+
+`lib/` is intentionally flat — specific filenames convey purpose without needing sub-directories. Current logical groups:
+
+| Group | Files |
+|---|---|
+| Core data fetching | `fetchData.ts`, `readJson.ts`, `duckdbSingleton.ts` |
+| Svelte stores | `dataRefreshStore.ts`, `completedItemsStore.svelte.ts`, `workflowStatusStore.ts` |
+| Search & query | `djen.ts`, `searchQueryString.ts` |
+| Utilities | `colorUtils.ts`, `dateUtils.ts`, `velocityCalc.ts`, `iaMetadataFetcher.ts`, `stats-processing.ts` |
+| Reference data | `tribunais.ts`, `homepage-content.ts` |
+
+New files should fit into one of these groups by name. Sub-directories are not needed unless a group grows past ~6 files.
+
 ### Decision flowchart
 
 ```
 Does it render HTML?
 ├─ No  → lib/ (utility, store, schema)
-└─ Yes → Does it need reactive state after page load?
-         ├─ No  → Is interactivity trivial (one listener, no derived state)?
-         │        ├─ Yes → .astro with plain <script>
-         │        └─ No  → .svelte (client:load or client:visible)
-         └─ Yes → .svelte
+└─ Yes → Does it need ANY client-side JS?
+         ├─ No  → .astro with no <script> (zero JS — preferred default)
+         └─ Yes → Does it need reactive state after page load?
+                  ├─ No  → Is interactivity trivial (one listener, no derived state)?
+                  │        ├─ Yes → .astro with plain <script>
+                  │        └─ No  → .svelte (client:load or client:visible)
+                  └─ Yes → .svelte
 ```
 
 ---
@@ -127,7 +176,7 @@ Forgetting `astro:after-swap` is the most common bug with view transitions.
 - **Do not** add `client:load` to components that have no client-side interactivity. Static components ship zero JS by default; adding a directive breaks that.
 - **Do not** use Astro component `<script>` tags to manage complex state. Reach for Svelte instead.
 - **Do not** import server-only Node modules inside components used with SSG — the build will fail at deploy time.
-- **Do not** use `client:only` unless unavoidable (DuckDB WASM is a valid exception because it requires the browser environment). `client:only` skips server-side rendering entirely and hurts initial load.
+- **Do not** use `client:only` unless unavoidable. `client:only` skips server-side rendering entirely and hurts initial load. When you must use it, always include the framework string: `client:only="svelte"`. DuckDB WASM is the canonical valid exception because it requires the browser environment.
 
 ---
 
@@ -154,9 +203,29 @@ Svelte 5 introduces runes. Use them instead of the legacy `let` + reactive synta
 
 Do not mix the Svelte 4 `$:` reactive statements with Svelte 5 runes in the same component.
 
-### Three tiers of state
+### Four tiers of state
 
 Choose the right tier for each piece of state:
+
+**0. Build-time static seed** — Astro pages run at **build time** (not at request time, because this site is static). They read local JSON via `readJson()` and pass the result as typed `initialXxx` props to Svelte islands. The island derives live state from a `createDataRefresh` store with a fallback to the seed:
+
+```svelte
+// web/src/pages/[tribunal].astro (runs at BUILD TIME)
+const coverage = readJson<Record<string, string[]> | null>('cache/calendar.json');
+---
+<TribunalDetail initialCoverage={coverage} client:load />
+
+// web/src/components/TribunalDetail.svelte (runs in the BROWSER)
+let { initialCoverage } = $props();
+const store = createDataRefresh(null, null);
+onMount(() => store.start());
+onDestroy(() => store.stop());
+
+// Falls back to build-time seed until live refresh arrives
+let coverage = $derived($store.data?.tribunalCoverage ?? initialCoverage);
+```
+
+Always pass build-time data as `initialXxx` props. Never leave an island with `null` initial state when the Astro page can pre-populate it — the skeleton flash is user-visible and avoidable.
 
 **1. Component-local state** — `$state` / `$derived` inside a `<script>` block. Use for state that belongs entirely to one component instance.
 
@@ -271,6 +340,14 @@ Rules for contributors:
 - **Never add new Tailwind/utility classes.** Always write vanilla CSS using design tokens.
 - If you are editing a component that still has legacy utility classes, migrate those classes to CSS variables in the same PR. Do not leave mixed styles.
 - If you see `class="bg-gray-100 p-4"` in a file you are touching, replace it with a scoped CSS rule using `var(--color-base-100)` and `var(--space-4)`.
+
+**Done-state:** The migration is complete when this command returns no matches:
+
+```sh
+grep -rE 'class="[^"]*(bg-|text-|flex|p-|m-|gap-|grid|items-|justify-)' web/src/components/
+```
+
+At that point, `web/strip-tailwind-classes.mjs` can be deleted.
 
 ### Responsive design
 
@@ -407,6 +484,77 @@ Use a plain `writable` store when the data is local to one island or managed by 
 
 ---
 
+## URL State and Routing
+
+URL stability is a first-class concern in this project (DESIGN.md principle 8: "Prefer permanence over novelty. Stable URLs"). Every navigable state must be expressible as a URL.
+
+### Query-string state
+
+All search filter state is managed through `web/src/lib/searchQueryString.ts`. The library provides:
+- `queryToSearchParams(q)` — converts a typed filter object to `URLSearchParams`
+- `searchParamsToQuery(sp)` — parses `URLSearchParams` back to a typed filter object
+- `pushQueryToUrl(q)` — writes filter state to the URL via `replaceState` (no history entry)
+- `hasAnyQueryValue(q)` — returns `true` if any meaningful filter is set
+- `smartParseInput(text)` — detects CNJ process numbers and OAB codes from free text
+
+```ts
+import { pushQueryToUrl, searchParamsToQuery } from '../lib/searchQueryString';
+
+// On mount: restore state from URL
+const sp = new URLSearchParams(window.location.search);
+filters = searchParamsToQuery(sp);
+
+// After a successful search: write state to URL
+pushQueryToUrl(effectiveQuery);
+```
+
+Use `replaceState` (which `pushQueryToUrl` does internally) for filter changes — no history clutter. Only use history push when a navigation should create a back-button entry.
+
+Do not duplicate the OAB / CNJ regex logic — reuse `smartParseInput()`.
+
+### Hash-based navigation
+
+Use the URL hash for inline drill-down state within a single page (see `TribunalDetail.svelte` and `DateDetail.svelte`). The canonical format is `#YYYY-MM-DD/pg/2/seq/1050` with named key segments. Assignment to `location.hash` creates a history entry (back-button works). `replaceState` does not.
+
+Always listen to both `hashchange` and `popstate` for full back-button support:
+
+```ts
+onMount(() => {
+  hashState = parseHash();
+  const onNavigate = () => { hashState = parseHash(); };
+  window.addEventListener('hashchange', onNavigate);
+  window.addEventListener('popstate', onNavigate);
+  return () => {
+    window.removeEventListener('hashchange', onNavigate);
+    window.removeEventListener('popstate', onNavigate);
+  };
+});
+```
+
+### Dynamic routes (Astro SSG)
+
+Because this is a static site, all dynamic routes must pre-generate every path with `getStaticPaths()`. There is no server fallback:
+
+```ts
+// web/src/pages/publicacoes/[tribunal].astro
+export function getStaticPaths() {
+  return TRIBUNAIS.map(t => ({
+    params: { tribunal: t.toLowerCase() }, // URL is lowercase
+    props: { tribunalCode: t },             // component receives uppercase
+  }));
+}
+```
+
+### Anti-patterns — URL
+
+- **Do not** sync ephemeral UI state to the URL (accordion state, hover state). Only sync state the user would want to bookmark or share.
+- **Do not** call `pushQueryToUrl` on every keystroke — debounce (400 ms), then push after successful search.
+- **Do not** create history entries for filter changes — `replaceState` only.
+- **Do not** hardcode `/causaganha/` prefix — use `import.meta.env.BASE_URL`.
+- **Do not** duplicate CNJ or OAB parsing logic — reuse `smartParseInput()`.
+
+---
+
 ## Data Fetching
 
 All data fetching goes through `web/src/lib/fetchData.ts`, which implements retry logic and error handling. Do not call `fetch()` directly in components.
@@ -430,13 +578,82 @@ Pair every fetch with a Zod schema parse so that bad data surfaces immediately a
 
 ---
 
+## Loading, Error, and Empty States
+
+Three reusable components handle these states. Use them consistently — do not invent new patterns per component.
+
+| State | Component | When |
+|---|---|---|
+| No content | `EmptyState.astro` | Island has no data and nothing to show (empty result set, first load before seed) |
+| Error | `AlertBanner.astro` with `level="error"` | Fetch failures, validation errors surfaced to the user |
+| Loading | Skeleton shimmer (see `web/SKELETON_LOADERS.md`) | Async data is in flight |
+
+### Three-state template
+
+The canonical pattern for any island that fetches data:
+
+```svelte
+{#if $store.loading && !$store.data}
+  <!-- Skeleton — mirror the shape of the loaded content, not a generic spinner -->
+  <div class="skeleton skeleton-card"></div>
+{:else if $store.error}
+  <AlertBanner level="error" title="Erro ao carregar dados" message={$store.error} />
+{:else if !$store.data || Object.keys($store.data).length === 0}
+  <EmptyState title="Sem dados" message="Nenhum resultado encontrado." />
+{:else}
+  <!-- Happy path -->
+{/if}
+```
+
+### Multi-stage loading
+
+For complex initialisation flows (such as DuckDB), use a typed status enum instead of separate boolean flags:
+
+```ts
+type Status = 'loading-db' | 'loading-data' | 'ready' | 'error';
+let status = $state<Status>('loading-db');
+```
+
+This prevents invalid combinations (`loading: true` and `error` both truthy) and makes control flow explicit.
+
+### Error recovery
+
+Always provide a retry path for transient failures:
+
+```svelte
+{#if status === 'error'}
+  <div class="error-card">
+    <p>{errorMsg}</p>
+    <button onclick={() => { status = 'loading-db'; init(); }}>Tentar novamente</button>
+  </div>
+{/if}
+```
+
+### Anti-patterns — States
+
+- **Do not** show plain "Loading..." text for content that takes longer than ~200 ms. Use a skeleton that mirrors the loaded shape.
+- **Do not** swallow errors silently. Capture and display every failure.
+- **Do not** show `EmptyState` while data is still loading — check `loading` first.
+- **Do not** omit retry buttons on transient network failures.
+- **Do not** show the skeleton again once data has loaded, even during a background refresh — keep the stale data visible and refresh it in place.
+
+---
+
 ## DuckDB WASM
 
 DuckDB runs entirely in the browser via WASM. It is used for the SQL explorer interface and for client-side analytical queries over downloaded datasets.
 
 Because DuckDB requires the browser environment, any component that uses it must be a Svelte island with `client:only="svelte"`. There is no server-side counterpart.
 
-Keep DuckDB initialization in a single place (do not spin up multiple instances). The instance should be created once and shared via a module-level singleton.
+Keep DuckDB initialization in a single place. The singleton is implemented at `web/src/lib/duckdbSingleton.ts`. Import `getDuckDB()` from there — never call DuckDB init directly:
+
+```ts
+import { getDuckDB } from '../lib/duckdbSingleton';
+
+const { db, conn } = await getDuckDB(); // lazy, shared, safe to call multiple times
+```
+
+The singleton uses double-checked locking with an `initializationPromise` to prevent concurrent initialization. It also configures the httpfs extension for querying Parquet files hosted on the Internet Archive.
 
 ---
 
@@ -524,9 +741,16 @@ Keep step definitions thin — they should call the same Testing Library queries
 The project uses strict TypeScript (`astro/tsconfigs/strict`). All `.svelte` files use `<script lang="ts">`.
 
 - Prefer `type` over `interface` for data shapes derived from Zod schemas.
-- Use `interface` for things that may be extended (component prop shapes that other code might augment).
+- Use `interface` for things that may be extended (component prop shapes — including `$props()` declarations — that other code might augment).
 - Never use `any`. Use `unknown` when the type is genuinely unknown and then narrow it.
 - Do not use non-null assertion (`!`) except where the value is structurally guaranteed (e.g., immediately after a null-check guard at the top of a function).
+
+**Exception — data-layer boundary types:** `DerivedData` in `fetchData.ts` and the store state shape currently use `any` because data originates from heterogeneous JSON sources (Internet Archive, static cache files) whose schemas are not yet fully codified. This is a tracked gap; strict typing will replace them incrementally. Rules for working in this layer:
+
+- Do not spread `any` deeper than the boundary. Use `unknown` + type narrowing inside component and store logic.
+- When adding a new field to `DerivedData`, give it the most specific type you can.
+- Add a `// TODO: type this` comment on any new `any` field.
+- Never use `any` in component `$props()` declarations or in store APIs for data you control.
 
 ---
 

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -247,10 +247,12 @@ const data = deriveData(null, dashboardData, cacheData, tribunalStartDates, trib
 
 The seed and the live-refresh shape must match exactly — that is why the page derives both through `deriveData()` rather than passing raw JSON. Always pass build-time data as `initialXxx` props when the page has it. Never leave an island with `null` initial state when the page can pre-populate it — the skeleton flash is user-visible and avoidable.
 
-> **⚠️ Known inconsistency — source-of-truth drift.** The boilerplate above (hand-picking `readJson()` calls and passing them to `deriveData()`) is fragile: every page must pass the exact same arguments in the same order as `fetchAllData()` in `fetchData.ts`, or the seed shape will silently differ from the live-refresh shape. In practice, `[tribunal].astro` currently reads **6** JSON files while `fetchAllData()` reads **11** — so fields like `stats`, `perfMetrics`, and anything derived from `cache/calendar.json` are missing from the seed. This is a tracked consolidation target. **The correct direction** is a single helper `loadBuildTimeData()` in `fetchData.ts` that does the `readJson()` + `deriveData()` dance in one place and returns the full `DerivedData` shape. Pages should then call:
+> **⚠️ Known inconsistency — source-of-truth drift.** The boilerplate above (hand-picking `readJson()` calls and passing them to `deriveData()`) is fragile: every page must pass the exact same arguments in the same order as `fetchAllData()` in `fetchData.ts`, or the seed shape will silently differ from the live-refresh shape. In practice, `[tribunal].astro` currently reads **6** JSON files while `fetchAllData()` reads **11** — so fields like `stats`, `perfMetrics`, and anything derived from `cache/calendar.json` are missing from the seed. This is a tracked consolidation target. **The correct direction** is a single helper `loadBuildTimeData()` that does the `readJson()` + `deriveData()` dance in one place and returns the full `DerivedData` shape.
+>
+> **Where the helper must live — and must NOT live.** The helper **cannot** go in `fetchData.ts`. That module is imported by client-side code (`dataRefreshStore.ts`, many `.svelte` components via `fetchWithRetry`), and adding `readJson()` calls there would transitively pull `node:fs` and `node:path` into the browser bundle and break the build. Instead, create a dedicated server-only module, e.g. `web/src/lib/buildTimeData.ts`, that imports `readJson` from `readJson.ts` and `deriveData` from `fetchData.ts`. **Only `.astro` frontmatter may import this module** — never `.svelte` files, never `.svelte.ts` stores, never any `.ts` that is reachable from client code. Pages then call:
 > ```astro
 > ---
-> import { loadBuildTimeData } from '../../lib/fetchData';
+> import { loadBuildTimeData } from '../../lib/buildTimeData';
 > const data = loadBuildTimeData();
 > ---
 > <TribunalDetail initialCoverage={data.tribunalCoverage} ... />
@@ -374,10 +376,10 @@ Rules for contributors:
 **Done-state:** The migration is complete when this command returns no matches:
 
 ```sh
-grep -rnE 'class="[^"]*\b(bg-(white|black|[a-z]+-[0-9]+)|text-(xs|sm|base|lg|xl|[0-9]xl|white|black|center|left|right|[a-z]+-[0-9]+)|flex(-(row|col|wrap|nowrap))?\b|grid(-cols-[0-9])?\b|items-(start|center|end|stretch|baseline)|justify-(start|center|end|between|around|evenly)|gap(-[xy])?-[0-9]|p[xytrbl]?-[0-9]|m[xytrbl]?-[0-9])' web/src/components/
+rg -nP 'class="(?:[^"]*\s)?(bg-(?:white|black|[a-z]+-[0-9]+)|text-(?:xs|sm|base|lg|xl|[0-9]xl|white|black|center|left|right|[a-z]+-[0-9]+)|flex(?:-(?:row|col|wrap|nowrap))?|grid(?:-cols-[0-9]+)?|items-(?:start|center|end|stretch|baseline)|justify-(?:start|center|end|between|around|evenly)|gap(?:-[xy])?-[0-9]+|[pm][xytrbl]?-[0-9]+)(?=\s|")' web/src/components/
 ```
 
-The regex uses word boundaries and requires the telltale Tailwind suffix (color+shade, spacing number, directional keyword) to avoid false positives with custom class names that contain substrings like `grid` or `flex`. It is a heuristic — if you introduce a new class name containing one of these literal tokens, audit the hit manually. At that point, `web/strip-tailwind-classes.mjs` can be deleted.
+The regex uses PCRE (`rg -P`) with an explicit left boundary — the utility must be at the start of `class="..."` or preceded by whitespace — and a lookahead requiring whitespace or the closing quote on the right. This is what rules out custom class names that merely contain the substrings `grid`, `flex`, `items-...`, etc. (for example `mp-grid`, `summary-grid`, `story-grid` are correctly ignored). If you introduce a legitimate one-off class whose name collides with this pattern, audit the hit manually. Once the command returns zero matches, `web/strip-tailwind-classes.mjs` can be deleted.
 
 ### Responsive design
 
@@ -597,7 +599,9 @@ The file exports:
 
 ### Build-time hydration: a single source of truth
 
-The build-time seed pattern (Tier 0 under [Four tiers of state](#four-tiers-of-state)) currently has no central helper — every Astro page reimplements its own `readJson()` boilerplate and hand-assembles the arguments to `deriveData()`. This is fragile. The target is a single `loadBuildTimeData()` helper in `fetchData.ts` that mirrors `fetchAllData()` but uses `readJson()` synchronously and returns `DerivedData`. Pages would then call `loadBuildTimeData()` once and pass slices of its result as `initialXxx` props. Until that helper exists, align any new page with `fetchAllData()`'s input list exactly.
+The build-time seed pattern (Tier 0 under [Four tiers of state](#four-tiers-of-state)) currently has no central helper — every Astro page reimplements its own `readJson()` boilerplate and hand-assembles the arguments to `deriveData()`. This is fragile. The target is a single `loadBuildTimeData()` helper that mirrors `fetchAllData()` but uses `readJson()` synchronously and returns `DerivedData`. Pages would then call `loadBuildTimeData()` once and pass slices of its result as `initialXxx` props. Until that helper exists, align any new page with `fetchAllData()`'s input list exactly.
+
+**The helper must live in a server-only module — not in `fetchData.ts`.** `fetchData.ts` is imported by client code (`dataRefreshStore.ts` and many `.svelte` components via `fetchWithRetry`), so any `readJson()` call added there would transitively pull `node:fs` / `node:path` into the browser bundle. Create a dedicated file such as `web/src/lib/buildTimeData.ts` that imports `readJson` and `deriveData`, and document in a file-top comment that **it must only be imported from `.astro` frontmatter** (never from `.svelte`, never from a `.svelte.ts` store, never from anything reachable by client code).
 
 ```ts
 // Correct — use the exported helpers
@@ -801,7 +805,7 @@ These areas are not yet covered by existing infrastructure. Be aware before assu
 - **No end-to-end tests.** Playwright or a similar e2e framework is not set up. BDD tests run in jsdom only and do not test real browser behavior or full page navigation.
 - **No i18n.** All UI strings are hardcoded in Portuguese. There is no translation framework in place.
 - **Accessibility.** Guidelines and known gaps are documented in `web/ACCESSIBILITY.md` and `web/ACCESSIBILITY_IMPROVEMENTS_NEEDED.md`. Read both before modifying any UI component — do not introduce new accessibility regressions.
-- **Build-time hydration has no central source of truth.** Every Astro page that seeds a Svelte island reimplements its own `readJson()` + `deriveData()` boilerplate, and pages read different subsets of the underlying JSON files. This means the build-time seed shape silently differs from the `fetchAllData()` runtime shape on any page that forgets a source. The fix is a single `loadBuildTimeData()` helper in `fetchData.ts` (see [Data Fetching](#data-fetching)). Until it lands, always pass `deriveData()` the exact same arguments that `fetchAllData()` does.
+- **Build-time hydration has no central source of truth.** Every Astro page that seeds a Svelte island reimplements its own `readJson()` + `deriveData()` boilerplate, and pages read different subsets of the underlying JSON files. This means the build-time seed shape silently differs from the `fetchAllData()` runtime shape on any page that forgets a source. The fix is a single `loadBuildTimeData()` helper in a dedicated **server-only** module (e.g. `web/src/lib/buildTimeData.ts`) — **not** in `fetchData.ts`, which is imported by client code and would leak `node:fs` into the browser bundle (see [Data Fetching](#data-fetching)). Until it lands, always pass `deriveData()` the exact same arguments that `fetchAllData()` does.
 - **`DerivedData` is mostly `any`.** See the [TypeScript](#typescript) section's carve-out. Strict typing will be added incrementally as schemas are codified.
 
 ---

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -247,6 +247,16 @@ const data = deriveData(null, dashboardData, cacheData, tribunalStartDates, trib
 
 The seed and the live-refresh shape must match exactly — that is why the page derives both through `deriveData()` rather than passing raw JSON. Always pass build-time data as `initialXxx` props when the page has it. Never leave an island with `null` initial state when the page can pre-populate it — the skeleton flash is user-visible and avoidable.
 
+> **⚠️ Known inconsistency — source-of-truth drift.** The boilerplate above (hand-picking `readJson()` calls and passing them to `deriveData()`) is fragile: every page must pass the exact same arguments in the same order as `fetchAllData()` in `fetchData.ts`, or the seed shape will silently differ from the live-refresh shape. In practice, `[tribunal].astro` currently reads **6** JSON files while `fetchAllData()` reads **11** — so fields like `stats`, `perfMetrics`, and anything derived from `cache/calendar.json` are missing from the seed. This is a tracked consolidation target. **The correct direction** is a single helper `loadBuildTimeData()` in `fetchData.ts` that does the `readJson()` + `deriveData()` dance in one place and returns the full `DerivedData` shape. Pages should then call:
+> ```astro
+> ---
+> import { loadBuildTimeData } from '../../lib/fetchData';
+> const data = loadBuildTimeData();
+> ---
+> <TribunalDetail initialCoverage={data.tribunalCoverage} ... />
+> ```
+> Until that helper is added, new pages should copy the full argument list from `fetchAllData()` verbatim — do not reinvent the subset.
+
 **1. Component-local state** — `$state` / `$derived` inside a `<script>` block. Use for state that belongs entirely to one component instance.
 
 **2. Cross-island shared state** — a `writable` store exported from a `.ts` file in `lib/`. Use when two or more Svelte islands on the same page need to read from or write to the same value.
@@ -581,9 +591,13 @@ All data fetching goes through `web/src/lib/fetchData.ts`, which implements retr
 
 The file exports:
 - `fetchWithRetry(url)` — single URL fetch with exponential-backoff retry
-- `fetchAllData()` — fetches the full derived dataset (used by `createDataRefresh`)
+- `fetchAllData()` — fetches the full derived dataset (used by `createDataRefresh`). **This is the canonical list of inputs that feed `DerivedData`.** Any build-time seed assembled in an Astro page must pass the same inputs in the same order, or the seed shape will silently drift from the runtime shape.
 - `startLivePolling(onUpdate, intervalMs)` — starts a polling loop, returns a stop function
 - `deriveData(stats, dashboardData, cacheData, tribunalStartDates?, tribunalQualityScores?, perfMetrics?, iaSnapshot?)` — pure transformation that merges multiple data sources into the `DerivedData` shape; used in Astro pages at build time
+
+### Build-time hydration: a single source of truth
+
+The build-time seed pattern (Tier 0 under [Four tiers of state](#four-tiers-of-state)) currently has no central helper — every Astro page reimplements its own `readJson()` boilerplate and hand-assembles the arguments to `deriveData()`. This is fragile. The target is a single `loadBuildTimeData()` helper in `fetchData.ts` that mirrors `fetchAllData()` but uses `readJson()` synchronously and returns `DerivedData`. Pages would then call `loadBuildTimeData()` once and pass slices of its result as `initialXxx` props. Until that helper exists, align any new page with `fetchAllData()`'s input list exactly.
 
 ```ts
 // Correct — use the exported helpers
@@ -787,6 +801,8 @@ These areas are not yet covered by existing infrastructure. Be aware before assu
 - **No end-to-end tests.** Playwright or a similar e2e framework is not set up. BDD tests run in jsdom only and do not test real browser behavior or full page navigation.
 - **No i18n.** All UI strings are hardcoded in Portuguese. There is no translation framework in place.
 - **Accessibility.** Guidelines and known gaps are documented in `web/ACCESSIBILITY.md` and `web/ACCESSIBILITY_IMPROVEMENTS_NEEDED.md`. Read both before modifying any UI component — do not introduce new accessibility regressions.
+- **Build-time hydration has no central source of truth.** Every Astro page that seeds a Svelte island reimplements its own `readJson()` + `deriveData()` boilerplate, and pages read different subsets of the underlying JSON files. This means the build-time seed shape silently differs from the `fetchAllData()` runtime shape on any page that forgets a source. The fix is a single `loadBuildTimeData()` helper in `fetchData.ts` (see [Data Fetching](#data-fetching)). Until it lands, always pass `deriveData()` the exact same arguments that `fetchAllData()` does.
+- **`DerivedData` is mostly `any`.** See the [TypeScript](#typescript) section's carve-out. Strict typing will be added incrementally as schemas are codified.
 
 ---
 

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -41,7 +41,7 @@ All frontend decisions must serve the principles in [`DESIGN.md`](DESIGN.md). Re
 This project is deployed as a **100% static site on GitHub Pages** via `output: 'static'` in `astro.config.mjs`. Key constraints that affect every frontend decision:
 
 - **No server at runtime.** There are no API routes, no SSR, no middleware. Every page is a `.html` file generated at build time.
-- **`readJson()` runs only at build time.** Any data loaded via `readJson()` must be present in the `public/` directory when `astro build` runs. Missing files fail the build, not the page.
+- **`readJson()` runs only at build time and returns `null` on missing or malformed files.** It does not throw — it silently returns `null`. Always handle the null case in Astro pages; never assume the file exists.
 - **All dynamic routes must use `getStaticPaths()`.** There is no server fallback for unknown paths. If a path is not in `getStaticPaths()`, it does not exist.
 - **`404.astro` is the GitHub Pages 404 page.** GitHub Pages serves `404.html` for unknown paths automatically — no extra configuration needed.
 - **Always use `import.meta.env.BASE_URL`, never hardcode `/causaganha/`.** The base path is `/causaganha` in production; hardcoded paths break local dev.
@@ -54,7 +54,7 @@ const href = import.meta.env.BASE_URL + 'publicacoes';
 const href = '/causaganha/publicacoes';
 ```
 
-- **`trailingSlash: 'never'`** — internal `href` values must not end with `/`. Write `href="/causaganha/publicacoes"`, not `href="/causaganha/publicacoes/"`.
+- **`trailingSlash: 'never'`** — internal `href` values must not end with `/`. Write `href={BASE_URL + 'publicacoes'}`, not `href={BASE_URL + 'publicacoes/'}`.
 - **Prefetch is on by default (`defaultStrategy: 'hover'`).** Links prefetch on hover automatically. Do not add manual `<link rel="prefetch">` tags.
 - **Live data comes from Internet Archive, not a backend.** After the static page loads, `fetchData.ts` fetches live JSON from `archive.org`. This is the only "API" this project has.
 - **`.ts` endpoint files generate static files at build.** `robots.txt.ts` and `sitemap.xml.ts` run once at build time and output static files. They are not runtime API routes.

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -56,7 +56,7 @@ const href = '/causaganha/publicacoes';
 
 - **`trailingSlash: 'never'`** — internal `href` values must not end with `/`. Write `href={BASE_URL + 'publicacoes'}`, not `href={BASE_URL + 'publicacoes/'}`.
 - **Prefetch is on by default (`defaultStrategy: 'hover'`).** Links prefetch on hover automatically. Do not add manual `<link rel="prefetch">` tags.
-- **Live data comes from Internet Archive, not a backend.** After the static page loads, `fetchData.ts` fetches live JSON from `archive.org`. This is the only "API" this project has.
+- **The primary data source is Internet Archive, not a backend.** After the static page loads, `fetchData.ts` fetches live JSON from `archive.org`. Some components also call the GitHub API directly (e.g. `workflowStatusStore.ts`, `PipelineRunHistory.svelte`) for pipeline status — these are valid exceptions, not violations of this rule.
 - **`.ts` endpoint files generate static files at build.** `robots.txt.ts` and `sitemap.xml.ts` run once at build time and output static files. They are not runtime API routes.
 
 ### Anti-patterns — Deployment
@@ -582,24 +582,30 @@ Pair every fetch with a Zod schema parse so that bad data surfaces immediately a
 
 Three reusable components handle these states. Use them consistently — do not invent new patterns per component.
 
-| State | Component | When |
+| State | In `.astro` pages/layouts | In `.svelte` islands |
 |---|---|---|
-| No content | `EmptyState.astro` | Island has no data and nothing to show (empty result set, first load before seed) |
-| Error | `AlertBanner.astro` with `level="error"` | Fetch failures, validation errors surfaced to the user |
-| Loading | Skeleton shimmer (see `web/SKELETON_LOADERS.md`) | Async data is in flight |
+| No content | `<EmptyState title="..." message="..." />` | Inline `<div class="empty-state">` markup |
+| Error | `<AlertBanner level="error" ... />` | Inline `<div class="alert alert-error" role="alert">` markup |
+| Loading | Skeleton shimmer (see `web/SKELETON_LOADERS.md`) | Same — `<div class="skeleton skeleton-card">` |
 
 ### Three-state template
 
 The canonical pattern for any island that fetches data:
+
+> **Important:** `EmptyState.astro` and `AlertBanner.astro` are Astro components — they cannot be imported or rendered inside `.svelte` files. Use inline markup in Svelte islands. These Astro components are for use in `.astro` pages and layouts only.
 
 ```svelte
 {#if $store.loading && !$store.data}
   <!-- Skeleton — mirror the shape of the loaded content, not a generic spinner -->
   <div class="skeleton skeleton-card"></div>
 {:else if $store.error}
-  <AlertBanner level="error" title="Erro ao carregar dados" message={$store.error} />
+  <div class="alert alert-error" role="alert">
+    <strong>Erro ao carregar dados:</strong> {$store.error}
+  </div>
 {:else if !$store.data || Object.keys($store.data).length === 0}
-  <EmptyState title="Sem dados" message="Nenhum resultado encontrado." />
+  <div class="empty-state">
+    <p>Nenhum resultado encontrado.</p>
+  </div>
 {:else}
   <!-- Happy path -->
 {/if}

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -207,25 +207,45 @@ Do not mix the Svelte 4 `$:` reactive statements with Svelte 5 runes in the same
 
 Choose the right tier for each piece of state:
 
-**0. Build-time static seed** — Astro pages run at **build time** (not at request time, because this site is static). They read local JSON via `readJson()` and pass the result as typed `initialXxx` props to Svelte islands. The island derives live state from a `createDataRefresh` store with a fallback to the seed:
+**0. Build-time static seed** — Astro pages run at **build time** (not at request time, because this site is static). They read local JSON via `readJson()`, merge it through `deriveData()` to produce the canonical `DerivedData` shape, and pass specific fields of that shape as typed `initialXxx` props to Svelte islands. The island derives live state from a `createDataRefresh` store with a fallback to the seed:
 
-```svelte
-// web/src/pages/[tribunal].astro (runs at BUILD TIME)
-const coverage = readJson<Record<string, string[]> | null>('cache/calendar.json');
+```astro
 ---
-<TribunalDetail initialCoverage={coverage} client:load />
+// web/src/pages/publicacoes/[tribunal].astro (runs at BUILD TIME)
+import { deriveData } from '../../lib/fetchData';
+import { readJson } from '../../lib/readJson';
 
-// web/src/components/TribunalDetail.svelte (runs in the BROWSER)
-let { initialCoverage } = $props();
-const store = createDataRefresh(null, null);
-onMount(() => store.start());
-onDestroy(() => store.stop());
+const dashboardData       = readJson('dashboard-data.json');
+const tribunalStartDates  = readJson('tribunal_start_dates.json');
+const tribunalQualityScores = readJson('tribunal_quality_scores.json');
+const cacheData           = { today: readJson('cache/today.json'), backfill: readJson('cache/backfill.json') };
+const iaSnapshot          = readJson('ia-snapshot.json');
 
-// Falls back to build-time seed until live refresh arrives
-let coverage = $derived($store.data?.tribunalCoverage ?? initialCoverage);
+// deriveData() merges all sources into the DerivedData shape used by the store
+const data = deriveData(null, dashboardData, cacheData, tribunalStartDates, tribunalQualityScores, null, iaSnapshot);
+---
+<TribunalDetail
+  client:only="svelte"
+  tribunalCode={tribunalCode}
+  initialCoverage={data?.tribunalCoverage}
+  initialEtas={data?.tribunalEtas}
+/>
 ```
 
-Always pass build-time data as `initialXxx` props. Never leave an island with `null` initial state when the Astro page can pre-populate it — the skeleton flash is user-visible and avoidable.
+```svelte
+<!-- web/src/components/TribunalDetail.svelte (runs in the BROWSER) -->
+<script lang="ts">
+  let { initialCoverage } = $props();
+  const store = createDataRefresh(null, null);
+  onMount(() => store.start());
+  onDestroy(() => store.stop());
+
+  // Falls back to build-time seed until live refresh arrives
+  let coverage = $derived($store.data?.tribunalCoverage ?? initialCoverage);
+</script>
+```
+
+The seed and the live-refresh shape must match exactly — that is why the page derives both through `deriveData()` rather than passing raw JSON. Always pass build-time data as `initialXxx` props when the page has it. Never leave an island with `null` initial state when the page can pre-populate it — the skeleton flash is user-visible and avoidable.
 
 **1. Component-local state** — `$state` / `$derived` inside a `<script>` block. Use for state that belongs entirely to one component instance.
 
@@ -344,10 +364,10 @@ Rules for contributors:
 **Done-state:** The migration is complete when this command returns no matches:
 
 ```sh
-grep -rE 'class="[^"]*(bg-|text-|flex|p-|m-|gap-|grid|items-|justify-)' web/src/components/
+grep -rnE 'class="[^"]*\b(bg-(white|black|[a-z]+-[0-9]+)|text-(xs|sm|base|lg|xl|[0-9]xl|white|black|center|left|right|[a-z]+-[0-9]+)|flex(-(row|col|wrap|nowrap))?\b|grid(-cols-[0-9])?\b|items-(start|center|end|stretch|baseline)|justify-(start|center|end|between|around|evenly)|gap(-[xy])?-[0-9]|p[xytrbl]?-[0-9]|m[xytrbl]?-[0-9])' web/src/components/
 ```
 
-At that point, `web/strip-tailwind-classes.mjs` can be deleted.
+The regex uses word boundaries and requires the telltale Tailwind suffix (color+shade, spacing number, directional keyword) to avoid false positives with custom class names that contain substrings like `grid` or `flex`. It is a heuristic — if you introduce a new class name containing one of these literal tokens, audit the hit manually. At that point, `web/strip-tailwind-classes.mjs` can be deleted.
 
 ### Responsive design
 


### PR DESCRIPTION
## Description

This PR significantly expands `FRONTEND.md` with comprehensive documentation of three critical architectural areas:

### 1. **Deployment Model (GitHub Pages SSG)**
Added a new "Deployment" section explaining that this is a 100% static site with no runtime server. Documents key constraints:
- `readJson()` runs only at build time
- All dynamic routes require `getStaticPaths()`
- `404.astro` serves as the GitHub Pages 404 page
- Requirement to use `import.meta.env.BASE_URL` instead of hardcoding `/causaganha/`
- Prefetch behavior and static endpoint generation (`.ts` files)

Includes anti-patterns section warning against SSR-only features.

### 2. **State Management (Four Tiers)**
Restructured and expanded the state management section:
- Renamed from "Three tiers" to "Four tiers" to add **build-time static seed** as tier 0
- Explains the pattern of passing build-time data via `initialXxx` props to Svelte islands
- Shows how islands derive live state from stores with fallback to seed data
- Clarifies the distinction between Astro build-time execution and browser-time island execution

### 3. **URL State and Routing**
New comprehensive section covering:
- Query-string state management via `searchQueryString.ts` utilities
- Hash-based navigation for inline drill-down state
- Dynamic routes with `getStaticPaths()` for SSG
- Anti-patterns: no ephemeral UI state in URLs, debounce before pushing, use `replaceState` for filters

### 4. **Supporting Improvements**
- Reorganized `lib/` directory documentation with a table showing logical file groupings
- Updated decision flowchart to prioritize "zero JS" as the default
- Clarified `client:only` usage with framework string requirement
- Added "Loading, Error, and Empty States" section with reusable component patterns and three-state template
- Documented DuckDB singleton pattern at `duckdbSingleton.ts`
- Expanded TypeScript rules with exception for data-layer boundary types
- Added Tailwind migration completion criteria and cleanup command
- Clarified `client:only` anti-pattern with DuckDB as canonical exception

All changes are documentation-only; no source code modifications.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] Documentation changes only — no CLI or workflow modifications.

https://claude.ai/code/session_014gyP224m8nYvhc3gbQcYXZ