### PR TITLE
fix: add start/stop to DataRefreshStore, Svelte state components, typ…

### DIFF
--- a/web/src/components/AlertBanner.svelte
+++ b/web/src/components/AlertBanner.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  interface Props {
+    title: string;
+    message: string;
+    level?: 'info' | 'success' | 'warning' | 'error';
+  }
+
+  let { title, message, level = 'info' }: Props = $props();
+</script>
+
+<div class="alert level-{level}">
+  <div>
+    <strong>{title}</strong>
+    <div class="alert-message">{message}</div>
+  </div>
+</div>
+
+<style>
+  .alert {
+    padding: 1rem;
+    border-radius: var(--radius-box);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .alert-message {
+    font-size: var(--font-size-sm);
+  }
+
+  .level-info {
+    background: color-mix(in srgb, var(--color-info) 15%, transparent);
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+
+  .level-success {
+    background: color-mix(in srgb, var(--color-success) 15%, transparent);
+    border: 1px solid var(--color-success);
+    color: var(--color-success);
+  }
+
+  .level-warning {
+    background: color-mix(in srgb, var(--color-warning) 15%, transparent);
+    border: 1px solid var(--color-warning);
+    color: var(--color-warning);
+  }
+
+  .level-error {
+    background: color-mix(in srgb, var(--color-error) 15%, transparent);
+    border: 1px solid var(--color-error);
+    color: var(--color-error);
+  }
+</style>

--- a/web/src/components/EmptyState.svelte
+++ b/web/src/components/EmptyState.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  interface Props {
+    title: string;
+    message: string;
+    actionHref?: string;
+    actionLabel?: string;
+  }
+
+  let { title, message, actionHref, actionLabel }: Props = $props();
+</script>
+
+<div class="card">
+  <div class="card-body">
+    <h3 class="card-heading">{title}</h3>
+    <p class="card-message">{message}</p>
+    {#if actionHref && actionLabel}
+      <div class="card-actions">
+        <a href={actionHref} class="btn btn-primary">{actionLabel}</a>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .card-heading {
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  .card-message {
+    opacity: 0.7;
+  }
+
+  .card-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5rem;
+  }
+</style>

--- a/web/src/components/PipelineRunHistory.svelte
+++ b/web/src/components/PipelineRunHistory.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import AlertBanner from './AlertBanner.svelte';
+  import EmptyState from './EmptyState.svelte';
 
   interface WorkflowRun {
     id: number;
@@ -48,13 +50,11 @@
 
     {#if loading}
       <div>Loading run history...</div>
-    {/if}
-
-    {#if error}
-      <div>Error: {error}</div>
-    {/if}
-
-    {#if !loading && !error}
+    {:else if error}
+      <AlertBanner level="error" title="Erro ao carregar histórico" message={error} />
+    {:else if runs.length === 0}
+      <EmptyState title="Nenhuma execução encontrada" message="Não foram encontradas execuções recentes do pipeline." />
+    {:else}
       <div class="table-responsive">
         <table class="data-table">
           <thead>
@@ -86,11 +86,6 @@
                 </td>
               </tr>
             {/each}
-            {#if runs.length === 0}
-              <tr>
-                <td colspan="3">No runs found.</td>
-              </tr>
-            {/if}
           </tbody>
         </table>
       </div>
@@ -99,7 +94,6 @@
 </div>
 
 <style>
-
   .table-responsive {
     overflow-x: auto;
   }

--- a/web/src/lib/dataRefreshStore.ts
+++ b/web/src/lib/dataRefreshStore.ts
@@ -53,6 +53,8 @@ export interface DataRefreshState {
 
 export interface DataRefreshStore extends Readable<DataRefreshState> {
   refresh: (isInitial?: boolean) => Promise<void>;
+  start: () => void;
+  stop: () => void;
 }
 
 /**
@@ -105,10 +107,5 @@ export function createDataRefresh(
     }
   }
 
-  return {
-    subscribe,
-    refresh,
-    start,
-    stop,
-  } as DataRefreshStore & { start: () => void; stop: () => void };
+  return { subscribe, refresh, start, stop };
 }

--- a/web/src/lib/fetchData.ts
+++ b/web/src/lib/fetchData.ts
@@ -63,8 +63,8 @@ export interface DerivedData {
   hasAnyData: boolean;
   effectiveBackfill: any;
   backfillProgress: any;
-  calendarData: any[];
-  timelineData: any[];
+  calendarData: { date: string; count: number }[];
+  timelineData: { date: string; count: number }[];
   progressByYear: any;
   enrichedStats: Record<string, any>;
   tribunalCoverage: Record<string, any>;


### PR DESCRIPTION
…e narrowing

dataRefreshStore.ts: declare start() and stop() on DataRefreshStore interface; remove the as-cast that worked around their absence.

EmptyState.svelte + AlertBanner.svelte: Svelte 5 equivalents of the existing .astro components, using $props() rune and the same CSS tokens. Islands can now import these directly without crossing the .astro/.svelte boundary.

PipelineRunHistory.svelte: swap inline loading/error/empty markup for the new components; flatten the three separate {#if} blocks into a single if/else-if/else-if/else chain.

fetchData.ts: narrow calendarData and timelineData from any[] to { date: string; count: number }[] — the shape is fully determined by the derivation logic in deriveData().

https://claude.ai/code/session_01RiMwPeRby94Ud9Tg7wzGgV

## Description

<!-- Describe the changes in this PR. -->

## Checklist

- [ ] I have read and followed the contributing guidelines.
- [ ] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main.
