### PR TITLE
[codex] Fix FRONTEND.md violations

### DIFF
--- a/web/src/components/ActivePipelineStatus.svelte
+++ b/web/src/components/ActivePipelineStatus.svelte
@@ -19,8 +19,7 @@
   let error = $state<boolean>(false);
   let isMounted = $state<boolean>(false);
 
-  // Need to ensure absolute path from root via BASE_URL
-  const BASE_URL = import.meta.env?.BASE_URL || '/causaganha/';
+  const BASE_URL = import.meta.env.BASE_URL;
   // In dev/preview, BASE_URL might be different, let's make sure we hit the correct static path.
   const CACHE_RUNS_URL = `${BASE_URL.replace(/\/$/, '')}/cache/runs.json`;
   const CACHE_TODAY_URL = `${BASE_URL.replace(/\/$/, '')}/cache/today.json`;

--- a/web/src/components/BackfillDetailedStatus.svelte
+++ b/web/src/components/BackfillDetailedStatus.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  export let data: any = null;
+  let { data = null }: { data: any } = $props();
 
-  $: tribunals = data?.tribunals || [];
-  $: updatedAt = data?.updated_at ? new Date(data.updated_at).toLocaleString('pt-BR') : 'N/A';
+  let tribunals = $derived(data?.tribunals || []);
+  let updatedAt = $derived(data?.updated_at ? new Date(data.updated_at).toLocaleString('pt-BR') : 'N/A');
 </script>
 
 <div class="card bg-base-100 shadow-sm border border-base-300">

--- a/web/src/components/JulesSessionStatus.svelte
+++ b/web/src/components/JulesSessionStatus.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { fetchWithRetry } from '../lib/fetchData';
 
-  export let apiKey: string = '';
+  let { apiKey = '' }: { apiKey?: string } = $props();
 
   interface Session {
     name: string; // The full name, typically includes ID
@@ -11,9 +11,9 @@
     createTime: string;
   }
 
-  let sessions: Session[] = [];
-  let loading = false;
-  let error = '';
+  let sessions = $state<Session[]>([]);
+  let loading = $state(false);
+  let error = $state('');
 
   onMount(async () => {
     // If no API key is provided, we try to load it from localStorage for convenience during development

--- a/web/src/components/TribunalDetail.svelte
+++ b/web/src/components/TribunalDetail.svelte
@@ -101,7 +101,7 @@
     end: backfillTargetRange?.end || today,
   });
 
-  const BASE = typeof import.meta !== 'undefined' ? (import.meta.env?.BASE_URL || '/causaganha/') : '/causaganha/';
+  const BASE = import.meta.env.BASE_URL;
   const baseUrl = BASE.endsWith('/') ? BASE : BASE + '/';
 
   function handleTribunalChange(e: Event) {

--- a/web/src/components/TribunalView.svelte
+++ b/web/src/components/TribunalView.svelte
@@ -36,7 +36,7 @@
   const snapshotItems = $derived(iaSnapshot?.items || {});
   const snapshotByYear = $derived(iaSnapshot?.by_year || {});
 
-  const BASE = typeof import.meta !== 'undefined' ? (import.meta.env?.BASE_URL || '/causaganha/') : '/causaganha/';
+  const BASE = import.meta.env.BASE_URL;
   const baseUrl = BASE.endsWith('/') ? BASE : BASE + '/';
 
   const normalizedQuery = $derived(query.trim().toLowerCase());

--- a/web/src/lib/fetchData.ts
+++ b/web/src/lib/fetchData.ts
@@ -7,7 +7,7 @@
  * Server-side (Astro build): uses local static files only.
  */
 
-const BASE = import.meta.env.BASE_URL ?? '/causaganha/';
+const BASE = import.meta.env.BASE_URL;
 const IA_BASE: string = 'https://archive.org/download/causaganha-dashboard/';
 
 function resolve(path: string): string {

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -20,7 +20,7 @@ const { weeklyAverages, lowestDay } = processWeeklyPattern(data);
 const displayOrder = [1, 2, 3, 4, 5, 6, 0];
 const displayWeekly = displayOrder.map(idx => weeklyAverages.find(w => w.dayIdx === idx));
 
-const base = import.meta.env.BASE_URL ?? '/causaganha/';
+const base = import.meta.env.BASE_URL;
 ---
 
 <Layout


### PR DESCRIPTION
## Summary
- remove hardcoded `/causaganha/` base-path fallbacks and use `import.meta.env.BASE_URL`
- migrate lingering legacy Svelte component patterns to Svelte 5 `$props`, `$state`, and `$derived`
- keep the PR narrowly scoped to the concrete `FRONTEND.md` violations found in the touched files

## Why
`FRONTEND.md` requires base-path-safe frontend code and Svelte 5 idioms. A few runtime paths still hardcoded the production GitHub Pages base, and a couple of Svelte components still used legacy prop/reactivity patterns.

## Impact
This keeps local dev and deployed path resolution aligned, and reduces drift from the project�s Svelte 5 conventions without changing product behavior.

## Validation
- `bun run typecheck` could not complete here because `openapi-typescript` is unavailable in this runner
- `bun run lint` could not complete here because `eslint` is unavailable in this runner
