### PR TITLE
Refactor publications page with mode tabs and improve navigation UX

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
       '@observablehq/plot':
         specifier: ^0.6.0
         version: 0.6.17
+      '@tanstack/svelte-query':
+        specifier: ^6.1.14
+        version: 6.1.15(svelte@5.55.2)
       astro:
         specifier: ^5.18.1
         version: 5.18.1(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
+      openapi-fetch:
+        specifier: ^0.17.0
+        version: 0.17.0
       svelte:
         specifier: ^5.55.2
         version: 5.55.2
@@ -42,6 +48,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
         version: 6.2.4(svelte@5.55.2)(vite@7.3.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@tanstack/svelte-query-devtools':
+        specifier: ^6.1.14
+        version: 6.1.15(@tanstack/svelte-query@6.1.15(svelte@5.55.2))(svelte@5.55.2)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -57,6 +66,9 @@ importers:
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
+      openapi-typescript:
+        specifier: ^7.13.0
+        version: 7.13.0(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -756,6 +768,16 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/openapi-core@1.34.11':
+    resolution: {integrity: sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -964,6 +986,23 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@tanstack/query-core@5.98.0':
+    resolution: {integrity: sha512-v1g54qnirFVWMicVO6hurxez+YrJG3h9AQ6RZqlBhUZfNLRJjjxjjYcriL1s2xLGGNvE2IXpYlUzm22GXa1BQA==}
+
+  '@tanstack/query-devtools@5.98.0':
+    resolution: {integrity: sha512-6W2YE5L5Tj1VY0pgzdesvssh/50pdbPIC+5BVf9IXbcuwG+aAV/FRUVy45p7t+sxb8xUs4zSK3yEXbjx2b1QPQ==}
+
+  '@tanstack/svelte-query-devtools@6.1.15':
+    resolution: {integrity: sha512-N4wJ2kcRbr17cxwyu7yEszB9MC6r6BAwTJ5JggzTiiNJDq9KEnz3dwHCuvht3yoa0Ufs2jQtJEj5rR85McbNwA==}
+    peerDependencies:
+      '@tanstack/svelte-query': ^6.1.15
+      svelte: ^5.25.0
+
+  '@tanstack/svelte-query@6.1.15':
+    resolution: {integrity: sha512-Qlj8js/h1wbHgYK+W7+izUZk6CWz0q8//PEflncEfrZlhgH7LzWgwPjjmfa6W6LH4ulunhlkgHVy8S9xx+KePQ==}
+    peerDependencies:
+      svelte: ^5.25.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1192,6 +1231,10 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1284,6 +1327,9 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -1327,6 +1373,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1369,6 +1418,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1981,6 +2033,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
@@ -2036,6 +2092,10 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2344,6 +2404,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -2407,6 +2471,18 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  openapi-typescript@7.13.0:
+    resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2437,6 +2513,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
@@ -2474,6 +2554,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -2710,6 +2794,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2941,6 +3029,9 @@ packages:
         optional: true
       uploadthing:
         optional: true
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3261,6 +3352,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
@@ -3434,7 +3528,7 @@ snapshots:
   '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.4.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       dlv: 1.1.3
       dset: 3.1.4
       is-docker: 3.0.0
@@ -3691,7 +3785,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -3707,7 +3801,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3862,6 +3956,29 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/openapi-core@1.34.11(supports-color@10.2.2)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -3987,7 +4104,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3))
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       svelte: 5.55.2
       vite: 6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -4003,7 +4120,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.2)(vite@6.4.2(@types/node@20.19.39)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.8.3))
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -4026,6 +4143,22 @@ snapshots:
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.98.0': {}
+
+  '@tanstack/query-devtools@5.98.0': {}
+
+  '@tanstack/svelte-query-devtools@6.1.15(@tanstack/svelte-query@6.1.15(svelte@5.55.2))(svelte@5.55.2)':
+    dependencies:
+      '@tanstack/query-devtools': 5.98.0
+      '@tanstack/svelte-query': 6.1.15(svelte@5.55.2)
+      esm-env: 1.2.2
+      svelte: 5.55.2
+
+  '@tanstack/svelte-query@6.1.15(svelte@5.55.2)':
+    dependencies:
+      '@tanstack/query-core': 5.98.0
+      svelte: 5.55.2
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4131,7 +4264,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4141,7 +4274,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4160,7 +4293,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@1.21.7)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -4177,7 +4310,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -4325,6 +4458,8 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  ansi-colors@4.1.3: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4390,7 +4525,7 @@ snapshots:
       common-ancestor-path: 1.0.1
       cookie: 1.1.1
       cssesc: 3.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       deterministic-object-hash: 2.0.2
       devalue: 5.6.4
       diff: 8.0.4
@@ -4504,6 +4639,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -4539,6 +4678,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case@5.4.4: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -4572,6 +4713,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -4803,9 +4946,11 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decimal.js@10.6.0: {}
 
@@ -4999,7 +5144,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5263,14 +5408,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5292,6 +5437,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  index-to-position@1.2.0: {}
 
   internmap@2.0.3: {}
 
@@ -5334,6 +5481,8 @@ snapshots:
   jiti@1.21.7:
     optional: true
 
+  js-levenshtein@1.1.6: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -5347,7 +5496,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -5772,7 +5921,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -5800,6 +5949,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -5851,6 +6004,22 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
+  openapi-typescript@7.13.0(typescript@5.9.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.11(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5885,6 +6054,12 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -5915,6 +6090,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pluralize@8.0.0: {}
 
   postcss@8.5.9:
     dependencies:
@@ -6242,6 +6419,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6445,6 +6624,8 @@ snapshots:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.3
+
+  uri-js-replace@1.0.1: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -6691,6 +6872,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yaml-ast-parser@0.0.43: {}
 
   yaml-language-server@1.20.0:
     dependencies:

--- a/web/public/og/cjf.svg
+++ b/web/public/og/cjf.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">CJF</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">CJF</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">480 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-01-22 a 2026-03-31</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/pjecor.svg
+++ b/web/public/og/pjecor.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">PJeCor</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">PJeCor</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">544 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-01-05 a 2026-03-31</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/stj.svg
+++ b/web/public/og/stj.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">STJ</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">Superior Tribunal de Justiça</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">330 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-11-21 a 2026-03-30</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/stm.svg
+++ b/web/public/og/stm.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">STM</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">Superior Tribunal Militar</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">221 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-11-29 a 2026-03-31</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjac.svg
+++ b/web/public/og/tjac.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJAC</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJAC</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">349 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-07-30 a 2026-03-31</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjal.svg
+++ b/web/public/og/tjal.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJAL</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJAL</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">371 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-09-06 a 2026-03-31</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjam.svg
+++ b/web/public/og/tjam.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJAM</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJAM</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">503 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-01-19 a 2026-03-30</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjap.svg
+++ b/web/public/og/tjap.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJAP</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJAP</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">573 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-01-01 a 2026-03-30</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjba.svg
+++ b/web/public/og/tjba.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJBA</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJBA</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">503 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2024-01-10 a 2026-03-25</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjce.svg
+++ b/web/public/og/tjce.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJCE</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJCE</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">25 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-02-20 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjdft.svg
+++ b/web/public/og/tjdft.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJDFT</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJDFT</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">9 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-16 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjes.svg
+++ b/web/public/og/tjes.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJES</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJES</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">9 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-16 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjgo.svg
+++ b/web/public/og/tjgo.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJGO</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJGO</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">8 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-16 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjma.svg
+++ b/web/public/og/tjma.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJMA</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJMA</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">9 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-16 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjmmg.svg
+++ b/web/public/og/tjmmg.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJMMG</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJMMG</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">9 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-16 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjro.svg
+++ b/web/public/og/tjro.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJRO</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJRO</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">1 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-25 a 2026-03-25</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjrr.svg
+++ b/web/public/og/tjrr.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJRR</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJRR</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">1 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-26 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/public/og/tjto.svg
+++ b/web/public/og/tjto.svg
@@ -4,8 +4,8 @@
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">TJTO</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">TJTO</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">1 publicações</text>
-  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">2026-03-26 a 2026-03-26</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">0 publicações</text>
+  <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">Internet Archive</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>
 </svg>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -170,18 +170,27 @@ LIMIT 20`,
     {/if}
   </div>
 
-  <!-- Query templates -->
-  <details class="templates-section">
-    <summary class="templates-summary">Consultas de exemplo</summary>
+  <!-- Starter cards -->
+  <div class="starter-cards" aria-label="Consultas de exemplo">
+    {#each QUERY_TEMPLATES.slice(0, 3) as tmpl}
+      <button
+        class="starter-card"
+        onclick={() => { sql = tmpl.sql; result = null; error = null; }}
+        disabled={dbStatus !== 'ready'}
+      >
+        <span class="starter-card-label">{tmpl.label}</span>
+        <span class="starter-card-hint" aria-hidden="true">Clique para carregar →</span>
+      </button>
+    {/each}
+  </div>
+  <!-- Additional templates -->
+  <details class="templates-more">
+    <summary class="templates-more-summary">Ver mais consultas de exemplo</summary>
     <div class="templates-list">
-      {#each QUERY_TEMPLATES as tmpl}
+      {#each QUERY_TEMPLATES.slice(3) as tmpl}
         <button
           class="template-btn"
-          onclick={() => {
-            sql = tmpl.sql;
-            result = null;
-            error = null;
-          }}
+          onclick={() => { sql = tmpl.sql; result = null; error = null; }}
         >
           {tmpl.label}
         </button>
@@ -375,16 +384,70 @@ LIMIT 20`,
     border-color: var(--color-base-content);
   }
 
-  .templates-section {
-    margin-bottom: 1.5rem;
+  /* Starter cards */
+  .starter-cards {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
   }
 
-  .templates-summary {
+  @media (min-width: 640px) {
+    .starter-cards {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .starter-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem;
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-box);
+    background: var(--color-base-100);
+    text-align: left;
     cursor: pointer;
+    transition: border-color var(--transition-base), background var(--transition-base);
+    min-height: 5rem;
+  }
+
+  .starter-card:hover:not(:disabled) {
+    border-color: var(--color-primary);
+    background: var(--color-base-200);
+  }
+
+  .starter-card:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .starter-card-label {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--color-base-content);
+  }
+
+  .starter-card-hint {
+    font-size: var(--font-size-xs);
+    opacity: 0.45;
+    margin-top: auto;
+  }
+
+  /* Additional templates (collapsed) */
+  .templates-more {
+    margin-bottom: 1rem;
+  }
+
+  .templates-more-summary {
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    opacity: 0.65;
     font-weight: 500;
   }
 
-  .templates-summary:hover {
+  .templates-more-summary:hover {
     text-decoration: underline;
   }
 

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -191,6 +191,7 @@ LIMIT 20`,
         <button
           class="template-btn"
           onclick={() => { sql = tmpl.sql; result = null; error = null; }}
+          disabled={dbStatus !== 'ready'}
         >
           {tmpl.label}
         </button>

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -28,20 +28,23 @@ function isActive(href: string): boolean {
   return currentPath.startsWith(normalized);
 }
 
-const mainLinks = [
-  { href: BASE + 'publicacoes', label: 'Publicações' },
-  { href: BASE + 'advogados', label: 'Advogados' },
-  { href: BASE + 'comparador', label: 'Comparador' },
-  { href: BASE + 'explorador', label: 'Explorador' },
-  { href: BASE + 'dados', label: 'Dados' },
-  { href: BASE + 'stats', label: 'Estatísticas' },
+const primaryLinks = [
+  { href: BASE + 'publicacoes', label: 'Buscar' },
+  { href: BASE + 'explorador', label: 'SQL' },
+  { href: BASE + 'stats', label: 'Indicadores' },
+  { href: BASE + 'sobre', label: 'Projeto' },
 ];
 
-const secondaryLinks = [
+const ferramentasLinks = [
+  { href: BASE + 'advogados', label: 'Advogados' },
+  { href: BASE + 'comparador', label: 'Comparador' },
+  { href: BASE + 'dados', label: 'Dados' },
+];
+
+const recursosLinks = [
   { href: BASE + 'consultas', label: 'Consultas' },
   { href: BASE + 'dicionario', label: 'Dicionário' },
   { href: BASE + 'changelog', label: 'Changelog' },
-  { href: BASE + 'sobre', label: 'Sobre' },
 ];
 ---
 
@@ -52,11 +55,7 @@ const secondaryLinks = [
     </div>
     <div class="navbar-center desktop-only">
       <ul class="menu menu-horizontal">
-        <li><a href={BASE + '#como-funciona'}>Como Funciona</a></li>
-        <li><a href={BASE + '#resumo'}>Resumo</a></li>
-        <li><a href={BASE + '#para-quem'}>Para Quem</a></li>
-        <div class="divider-vertical"></div>
-        {mainLinks.map(link => (
+        {primaryLinks.map(link => (
           <li>
             <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
               {link.label}
@@ -65,9 +64,17 @@ const secondaryLinks = [
         ))}
         <li>
           <details>
-            <summary>Recursos</summary>
+            <summary aria-haspopup="true">Ferramentas</summary>
             <ul class="dropdown-menu">
-              {secondaryLinks.map(link => (
+              {ferramentasLinks.map(link => (
+                <li>
+                  <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+              <li class="dropdown-divider"></li>
+              {recursosLinks.map(link => (
                 <li>
                   <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                     {link.label}
@@ -98,13 +105,17 @@ const secondaryLinks = [
         <div class="drawer-side">
           <label for="mobile-drawer-home" aria-label="close sidebar" class="drawer-overlay"></label>
           <ul class="drawer-menu">
-            <li class="menu-title">Projeto</li>
-            <li><a href={BASE + '#como-funciona'}>Como Funciona</a></li>
-            <li><a href={BASE + '#resumo'}>Resumo</a></li>
-            <li><a href={BASE + '#para-quem'}>Para Quem</a></li>
-            <div class="divider-horizontal"></div>
             <li class="menu-title">Principal</li>
-            {mainLinks.map(link => (
+            {primaryLinks.map(link => (
+              <li>
+                <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
+                  {link.label}
+                </a>
+              </li>
+            ))}
+            <div class="divider-horizontal"></div>
+            <li class="menu-title">Ferramentas</li>
+            {ferramentasLinks.map(link => (
               <li>
                 <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                   {link.label}
@@ -113,7 +124,7 @@ const secondaryLinks = [
             ))}
             <div class="divider-horizontal"></div>
             <li class="menu-title">Recursos</li>
-            {secondaryLinks.map(link => (
+            {recursosLinks.map(link => (
               <li>
                 <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                   {link.label}
@@ -151,7 +162,7 @@ const secondaryLinks = [
           <ActivePipelineStatus client:load />
         </div>
         <ul class="menu menu-horizontal">
-          {mainLinks.map(link => (
+          {primaryLinks.map(link => (
             <li>
               <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                 {link.label}
@@ -160,9 +171,17 @@ const secondaryLinks = [
           ))}
           <li>
             <details>
-              <summary>Recursos</summary>
+              <summary aria-haspopup="true">Ferramentas</summary>
               <ul class="dropdown-menu">
-                {secondaryLinks.map(link => (
+                {ferramentasLinks.map(link => (
+                  <li>
+                    <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+                <li class="dropdown-divider"></li>
+                {recursosLinks.map(link => (
                   <li>
                     <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                       {link.label}
@@ -198,7 +217,16 @@ const secondaryLinks = [
               <li><a href={BASE}>Início</a></li>
               <div class="divider-horizontal"></div>
               <li class="menu-title">Principal</li>
-              {mainLinks.map(link => (
+              {primaryLinks.map(link => (
+                <li>
+                  <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+              <div class="divider-horizontal"></div>
+              <li class="menu-title">Ferramentas</li>
+              {ferramentasLinks.map(link => (
                 <li>
                   <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                     {link.label}
@@ -207,7 +235,7 @@ const secondaryLinks = [
               ))}
               <div class="divider-horizontal"></div>
               <li class="menu-title">Recursos</li>
-              {secondaryLinks.map(link => (
+              {recursosLinks.map(link => (
                 <li>
                   <a href={link.href} class={isActive(link.href) ? 'active' : ''}>
                     {link.label}
@@ -342,6 +370,13 @@ const secondaryLinks = [
 
   .dropdown-menu a:hover {
     background: var(--color-base-200);
+  }
+
+  .dropdown-divider {
+    height: 1px;
+    background: var(--color-base-300);
+    margin: var(--space-1) 0;
+    padding: 0;
   }
 
   /* Dividers */

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -212,7 +212,15 @@
 <section class="search-root" aria-labelledby="publication-search-heading">
   <h2 id="publication-search-heading" class="visually-hidden">Busca de publicações</h2>
 
-  <SmartSearchInput bind:value={rawInput} hint={smart.label} onsubmit={handleSubmit} />
+  <SmartSearchInput bind:value={rawInput} hint={smart.label} kind={smart.kind} onsubmit={handleSubmit} />
+  {#if !rawInput}
+    <div class="example-chips">
+      <span class="chips-label">Experimente:</span>
+      <button type="button" class="hint-chip" onclick={() => (rawInput = 'OAB SP 12345')}>OAB SP 12345</button>
+      <button type="button" class="hint-chip" onclick={() => (rawInput = 'TJSP')}>TJSP</button>
+      <button type="button" class="hint-chip" onclick={() => (rawInput = 'mandado de segurança')}>mandado de segurança</button>
+    </div>
+  {/if}
 
   <div class="search-toolbar">
     <button
@@ -325,6 +333,35 @@
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
+  }
+
+  .example-chips {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: var(--font-size-xs);
+  }
+
+  .chips-label {
+    opacity: 0.55;
+  }
+
+  .hint-chip {
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-full);
+    background: transparent;
+    padding: 0.2rem 0.6rem;
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    color: var(--color-base-content);
+    transition: background var(--transition-base), border-color var(--transition-base);
+    min-height: 28px;
+  }
+
+  .hint-chip:hover {
+    background: var(--color-base-200);
+    border-color: var(--color-primary);
   }
 
   .search-toolbar {

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import type { SmartParseKind } from '../lib/searchQueryString';
+
   interface Props {
     value: string;
     hint?: string;
+    kind?: SmartParseKind | '';
     placeholder?: string;
     onsubmit?: () => void;
   }
@@ -9,6 +12,7 @@
   let {
     value = $bindable(''),
     hint = '',
+    kind = '',
     placeholder = 'OAB, número do processo ou texto livre...',
     onsubmit,
   }: Props = $props();
@@ -40,7 +44,12 @@
     {/if}
   </label>
   {#if hint}
-    <div class="hint" role="status" aria-live="polite">{hint}</div>
+    <div class="hint" data-kind={kind} role="status" aria-live="polite">
+      <span class="hint-icon" aria-hidden="true">
+        {#if kind === 'oab'}⚖️{:else if kind === 'processo'}📋{:else}🔍{/if}
+      </span>
+      {hint}
+    </div>
   {/if}
 </div>
 
@@ -100,8 +109,27 @@
   }
 
   .hint {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
     font-size: var(--font-size-xs, 0.75rem);
-    opacity: 0.7;
-    padding-left: 0.25rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: var(--radius-sm, 0.25rem);
+    background: var(--color-base-200);
+    border-left: 3px solid var(--color-base-300);
+    transition: border-color var(--transition-base, 200ms ease);
+  }
+
+  .hint[data-kind='oab'] {
+    border-left-color: var(--color-accent);
+  }
+
+  .hint[data-kind='processo'] {
+    border-left-color: var(--color-info);
+  }
+
+  .hint-icon {
+    font-size: 0.8rem;
+    line-height: 1;
   }
 </style>

--- a/web/src/components/TribunalDetail.svelte
+++ b/web/src/components/TribunalDetail.svelte
@@ -228,49 +228,14 @@
       <div class="breadcrumbs">
         <ul>
           <li><a href={`${baseUrl}`}>CausaGanha</a></li>
-          <li><a href={`${baseUrl}publicacoes`}>Publicacoes</a></li>
-          <li>
-            <select
-              id="tribunal-select"
-              value={selectedTribunal}
-              onchange={handleTribunalChange}
-              class="tribunal-select"
-            >
-              {#each TRIBUNAL_GROUPS as group}
-                <optgroup label={group.name}>
-                  {#each group.tribunals as t}
-                    <option value={t}>{t}</option>
-                  {/each}
-                </optgroup>
-              {/each}
-            </select>
-          </li>
+          <li><a href={`${baseUrl}publicacoes`}>Publicações</a></li>
+          <li>{selectedTribunal}</li>
         </ul>
-      </div>
-      <div class="toolbar-actions">
-        <button
-          class="btn btn-sm btn-ghost"
-          onclick={exportCsv}
-          title="Exportar CSV de Cobertura"
-          aria-label="Exportar CSV"
-        >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-          Exportar CSV
-        </button>
-        <button
-          class="btn btn-sm btn-ghost"
-          onclick={shareLink}
-          title="Copiar Link"
-          aria-label="Compartilhar Link"
-        >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
-          Compartilhar Link
-        </button>
       </div>
     </div>
 
     <div class="title-section">
-      <div>
+      <div class="title-main">
         <h1 class="tribunal-title">{selectedTribunal}</h1>
         {#if qualityScore}
           <span
@@ -280,6 +245,45 @@
             Qualidade: {qualityScore.grade}
           </span>
         {/if}
+      </div>
+      <div class="title-actions">
+        <div class="tribunal-switcher">
+          <label for="tribunal-select" class="switcher-label">Trocar tribunal</label>
+          <select
+            id="tribunal-select"
+            value={selectedTribunal}
+            onchange={handleTribunalChange}
+            class="tribunal-select-title"
+          >
+            {#each TRIBUNAL_GROUPS as group}
+              <optgroup label={group.name}>
+                {#each group.tribunals as t}
+                  <option value={t}>{t}</option>
+                {/each}
+              </optgroup>
+            {/each}
+          </select>
+        </div>
+        <div class="toolbar-actions">
+          <button
+            class="btn btn-sm btn-ghost"
+            onclick={exportCsv}
+            title="Exportar CSV de Cobertura"
+            aria-label="Exportar CSV"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+            Exportar CSV
+          </button>
+          <button
+            class="btn btn-sm btn-ghost"
+            onclick={shareLink}
+            title="Copiar Link"
+            aria-label="Compartilhar Link"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+            Compartilhar Link
+          </button>
+        </div>
       </div>
     </div>
 
@@ -310,8 +314,8 @@
     </div>
 
     <div class="tabs" role="tablist">
-      <input type="radio" name="tribunal_tabs" role="tab" class="tab-input" aria-label="Calendario" id="tab-calendario" checked />
-      <label for="tab-calendario" class="tab-label">Calendario</label>
+      <input type="radio" name="tribunal_tabs" role="tab" class="tab-input" aria-label="Calendário" id="tab-calendario" checked />
+      <label for="tab-calendario" class="tab-label">Calendário</label>
       <div role="tabpanel" class="tab-content">
         <Heatmap
           globalStartDateStr={targetRange.start}
@@ -327,8 +331,8 @@
         />
       </div>
 
-      <input type="radio" name="tribunal_tabs" role="tab" class="tab-input" aria-label="Estatisticas & Arquivo" id="tab-stats" />
-      <label for="tab-stats" class="tab-label">Estatisticas & Arquivo</label>
+      <input type="radio" name="tribunal_tabs" role="tab" class="tab-input" aria-label="Estatísticas & Arquivo" id="tab-stats" />
+      <label for="tab-stats" class="tab-label">Estatísticas & Arquivo</label>
       <div role="tabpanel" class="tab-content">
         <div class="two-col-grid">
           <div>
@@ -460,14 +464,35 @@
     text-decoration: underline;
   }
 
-  /* Tribunal select */
-  .tribunal-select {
-    border: none;
-    background: transparent;
-    padding: 0.25rem 0.5rem;
+  /* Tribunal switcher (in title area) */
+  .tribunal-switcher {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.2rem;
+  }
+
+  .switcher-label {
+    font-size: var(--font-size-xs);
+    opacity: 0.5;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .tribunal-select-title {
     font-size: var(--font-size-sm);
-    cursor: pointer;
     font-weight: 600;
+    padding: 0.375rem 0.75rem;
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-btn);
+    background: var(--color-base-100);
+    cursor: pointer;
+    color: var(--color-base-content);
+    min-height: 36px;
+  }
+
+  .tribunal-select-title:hover {
+    border-color: var(--color-base-content);
   }
 
   /* Buttons */
@@ -491,8 +516,23 @@
   .title-section {
     display: flex;
     justify-content: space-between;
-    align-items: flex-end;
+    align-items: flex-start;
+    gap: 1rem;
     margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .title-main {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .title-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+    flex-shrink: 0;
   }
 
   .tribunal-title {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -592,3 +592,24 @@ small { font-size: var(--font-size-sm); }
   outline: 2px solid var(--color-accent);
   outline-offset: 3px;
 }
+
+/* ═══════════════════════════════════════════
+   Touch Target Minimums (WCAG 2.5.5)
+   ═══════════════════════════════════════════ */
+
+@media (pointer: coarse) {
+  .btn,
+  .btn-outline,
+  .btn-primary,
+  .btn-outline-secondary,
+  .hint-chip,
+  .menu a,
+  .menu summary,
+  .drawer-menu a,
+  .mode-tab-label,
+  .tab-label {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+}

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -9,17 +9,17 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <Layout
-  title="Explorador de Dados - CausaGanha"
+  title="SQL — CausaGanha"
   description="Consulte dados judiciais brasileiros diretamente no navegador usando SQL e DuckDB-WASM."
 >
-  <Header variant="page" title="Explorador de Dados" backHref={BASE} backLabel="Início">
+  <Header variant="page" title="SQL" backHref={BASE} backLabel="Início">
     <DatabaseIcon slot="icon" />
   </Header>
 
   <div class="container">
     <Breadcrumbs crumbs={[
       { label: 'Início', href: BASE },
-      { label: 'Explorador de Dados' }
+      { label: 'SQL' }
     ]} />
 
     <section class="intro-section">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,7 +4,7 @@ import GitHubIcon from '../components/icons/GitHubIcon.astro';
 import Header from '../components/Header.astro';
 import TribunalCoverageGrid from '../components/TribunalCoverageGrid.astro';
 import { readJson } from '../lib/readJson';
-import { formatNumber, HOW_IT_WORKS_CARDS, QUICK_ACCESS_CARDS, AUDIENCE_CARDS } from '../lib/homepage-content';
+import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS } from '../lib/homepage-content';
 
 const iaSnapshot = readJson<any>('ia-snapshot.json');
 const today = readJson<any>('cache/today.json');
@@ -69,9 +69,19 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
           </form>
           <p class="search-hint">Experimente: <button type="button" class="hint-chip" data-example="TJSP">TJSP</button> · <button type="button" class="hint-chip" data-example="OAB SP 12345">OAB SP 12345</button> · <button type="button" class="hint-chip" data-example="mandado de segurança">mandado de segurança</button></p>
 
-          <div class="hero-ctas">
-            <a href={BASE + 'publicacoes'} class="btn btn-outline">Ver Publicações de Hoje</a>
-            <a href={BASE + 'explorador'} class="btn btn-outline">Explorar com SQL</a>
+          <div class="mode-trio">
+            <a href={BASE + 'publicacoes'} class="mode-card mode-card--primary">
+              <strong class="mode-card-title">Buscar publicações</strong>
+              <span class="mode-card-desc">Pesquise por OAB, processo ou texto livre no DJEN ao vivo</span>
+            </a>
+            <a href={BASE + 'publicacoes#arquivo'} class="mode-card">
+              <strong class="mode-card-title">Navegar no arquivo</strong>
+              <span class="mode-card-desc">Acervo preservado no Internet Archive por tribunal e data</span>
+            </a>
+            <a href={BASE + 'explorador'} class="mode-card">
+              <strong class="mode-card-title">Consultar com SQL</strong>
+              <span class="mode-card-desc">DuckDB no navegador — consulte arquivos Parquet diretamente</span>
+            </a>
           </div>
         </div>
 
@@ -81,6 +91,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
             <div class="card-body">
               <div class="status-header">
                 <span class="status-dot" aria-hidden="true"></span>
+                <span class="sr-only">Sistema ativo — </span>
                 <strong>Coletando agora</strong>
                 <small class="status-freq">a cada 20 min</small>
               </div>
@@ -103,25 +114,6 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         </div>
 
       </div>
-    </div>
-  </section>
-
-  <!-- ── QUICK ACCESS ── -->
-  <section class="section-container" id="explorar">
-    <div class="section-header-row">
-      <h2 class="section-title">O que você pode fazer</h2>
-    </div>
-    <div class="quick-access-grid">
-      {QUICK_ACCESS_CARDS.map(card => (
-        <a href={BASE + card.href} class="qa-card card">
-          <div class="card-body">
-            <div class="qa-icon" aria-hidden="true">{card.icon}</div>
-            <h3 class="qa-title">{card.title}</h3>
-            <p class="qa-desc">{card.description}</p>
-            <span class="qa-cta">{card.cta} →</span>
-          </div>
-        </a>
-      ))}
     </div>
   </section>
 
@@ -401,10 +393,51 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     background: var(--color-base-300);
   }
 
-  .hero-ctas {
+  /* ── Mode trio (decision-tree CTAs) ── */
+  .mode-trio {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-sm);
+    margin-top: var(--space-md);
+  }
+
+  @media (min-width: 640px) {
+    .mode-trio {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .mode-card {
     display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: var(--space-sm) var(--space-md);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-box);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color var(--transition-base);
+    min-height: 44px;
+  }
+
+  .mode-card:hover {
+    border-color: var(--color-primary);
+  }
+
+  .mode-card--primary {
+    border-color: var(--color-primary);
+    background: var(--color-base-200);
+  }
+
+  .mode-card-title {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .mode-card-desc {
+    font-size: var(--font-size-xs);
+    opacity: 0.65;
+    line-height: 1.4;
   }
 
   /* ── Live Status card ── */

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -117,8 +117,18 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     margin-bottom: 3rem;
   }
 
+  /* Visually hidden but still in tab/focus order so keyboard users can
+     reach both tabs via Tab + arrow keys. Do NOT use display:none here. */
   .mode-tab-input {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .mode-tab-label {

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -35,38 +35,46 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       { label: 'Publicações' }
     ]} />
 
-    <section class="live-search-section">
-      <h2 class="section-heading">Busca ao vivo no DJEN</h2>
-      <p class="section-description">
-        Pesquise publicações diretamente na API pública do CNJ por OAB, número de processo, parte, advogado ou texto livre.
-      </p>
-      <PublicationSearch client:idle />
-    </section>
-
-    <section class="archive-section">
-      <header class="archive-header">
-        <h2 class="archive-title">Explorador de Arquivos (Internet Archive)</h2>
-        <p class="archive-hint">Navegue por tribunal, ano e data nos snapshots arquivados</p>
-      </header>
-      <div class="overview-card">
-        <h3 class="overview-title">Visão Geral do Arquivo</h3>
-        <TribunalView
-          client:idle
-          initialPipeline={data?.cacheData?.today?.pipeline}
-          initialProgressByYear={data?.progressByYear}
-          initialVolume={data?.volume}
-          initialIaSnapshot={data?.iaSnapshot}
-        />
+    <!-- CSS-only mode switch — same radio-tab pattern as TribunalDetail.svelte -->
+    <div class="mode-tabs">
+      <input type="radio" id="mode-live" name="pub_mode" class="mode-tab-input" checked />
+      <label for="mode-live" class="mode-tab-label" role="tab">
+        Ao vivo
+        <span class="mode-tab-desc">API pública do DJEN</span>
+      </label>
+      <div role="tabpanel" class="mode-tab-content live-search-section">
+        <p class="section-description">
+          Pesquise publicações diretamente na API pública do CNJ por OAB, número de processo, parte, advogado ou texto livre.
+        </p>
+        <PublicationSearch client:idle />
       </div>
 
-      <section class="explorer-section">
-        <h3 class="explorer-heading">Buscar ZIPs por tribunal ou ano</h3>
-        <p class="explorer-description">
-          Busque diretamente nos buckets do Internet Archive por tribunal ou ano.
-        </p>
-        <IASearchBar client:idle />
-      </section>
-    </section>
+      <input type="radio" id="mode-arquivo" name="pub_mode" class="mode-tab-input" />
+      <label for="mode-arquivo" class="mode-tab-label" role="tab">
+        Arquivo
+        <span class="mode-tab-desc">Internet Archive</span>
+      </label>
+      <div role="tabpanel" class="mode-tab-content archive-section">
+        <div class="overview-card">
+          <h2 class="overview-title">Visão Geral do Arquivo</h2>
+          <TribunalView
+            client:idle
+            initialPipeline={data?.cacheData?.today?.pipeline}
+            initialProgressByYear={data?.progressByYear}
+            initialVolume={data?.volume}
+            initialIaSnapshot={data?.iaSnapshot}
+          />
+        </div>
+
+        <section class="explorer-section">
+          <h3 class="explorer-heading">Buscar ZIPs por tribunal ou ano</h3>
+          <p class="explorer-description">
+            Busque diretamente nos buckets do Internet Archive por tribunal ou ano.
+          </p>
+          <IASearchBar client:idle />
+        </section>
+      </div>
+    </div>
 
     <footer class="page-footer">
       <small class="footer-text">Dados do DJEN arquivados no Internet Archive.
@@ -75,6 +83,18 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </footer>
   </div>
 </Layout>
+
+<script>
+  // Activate the "arquivo" tab when navigating with #arquivo hash
+  function applyHashMode() {
+    if (window.location.hash === '#arquivo') {
+      const input = document.getElementById('mode-arquivo') as HTMLInputElement | null;
+      if (input) input.checked = true;
+    }
+  }
+  applyHashMode();
+  document.addEventListener('astro:after-swap', applyHashMode);
+</script>
 
 <style>
   .header-subtitle {
@@ -91,16 +111,65 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     padding-right: var(--space-md);
   }
 
-  .live-search-section {
-    margin-top: 2rem;
+  /* ── Mode tabs (CSS-only, radio input pattern) ── */
+  .mode-tabs {
+    margin-top: 1.5rem;
     margin-bottom: 3rem;
   }
 
-  .section-heading {
-    font-size: var(--font-size-2xl);
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-    opacity: 0.9;
+  .mode-tab-input {
+    display: none;
+  }
+
+  .mode-tab-label {
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0.6rem 1.25rem;
+    font-weight: 600;
+    font-size: var(--font-size-base);
+    cursor: pointer;
+    border: 1px solid var(--color-base-300);
+    border-bottom: none;
+    border-radius: var(--radius-box) var(--radius-box) 0 0;
+    margin-right: 0.25rem;
+    position: relative;
+    top: 1px;
+    background: var(--color-base-100);
+    opacity: 0.5;
+    transition: opacity var(--transition-base);
+    min-height: 44px;
+    justify-content: center;
+  }
+
+  .mode-tab-label:hover {
+    opacity: 0.8;
+  }
+
+  .mode-tab-input:checked + .mode-tab-label {
+    opacity: 1;
+    border-color: var(--color-base-300);
+    background: var(--color-base-100);
+    z-index: 1;
+  }
+
+  .mode-tab-desc {
+    font-size: var(--font-size-xs);
+    font-weight: 400;
+    opacity: 0.6;
+  }
+
+  .mode-tab-content {
+    display: none;
+    border: 1px solid var(--color-base-300);
+    border-radius: 0 var(--radius-box) var(--radius-box) var(--radius-box);
+    padding: 1.5rem;
+    background: var(--color-base-100);
+  }
+
+  /* Show the tab panel that immediately follows its checked input + label */
+  #mode-live:checked + .mode-tab-label + .mode-tab-content,
+  #mode-arquivo:checked + .mode-tab-label + .mode-tab-content {
+    display: block;
   }
 
   .section-description {
@@ -109,45 +178,15 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     max-width: 54rem;
   }
 
-  .archive-section {
-    border: 1px solid var(--color-base-300);
-    border-radius: var(--radius-box);
-    background: var(--color-base-100);
-    padding: 0 1.25rem;
-    margin-bottom: 3rem;
-  }
-
-  .archive-header {
-    padding: 1rem 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .archive-title {
-    font-size: var(--font-size-xl);
-    font-weight: 700;
-    opacity: 0.85;
-    margin: 0;
-  }
-
-  .archive-hint {
-    font-size: var(--font-size-sm);
-    opacity: 0.6;
-    margin: 0;
-  }
-
   .overview-card {
     margin-bottom: 2rem;
-    border-top: 1px solid var(--color-base-200);
-    padding-top: 1.25rem;
   }
 
   .overview-title {
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-xl);
     font-weight: 700;
     margin-bottom: 1rem;
-    opacity: 0.8;
+    opacity: 0.85;
   }
 
   .explorer-section {

--- a/web/src/pages/sobre.astro
+++ b/web/src/pages/sobre.astro
@@ -7,15 +7,15 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <Layout
-  title="Sobre o Projeto - CausaGanha"
+  title="Projeto — CausaGanha"
   description="Entenda a metodologia, as fontes de dados e a licença do projeto CausaGanha."
 >
-  <Header variant="page" title="Sobre o Projeto" backHref={BASE} backLabel="Início" />
+  <Header variant="page" title="Projeto" backHref={BASE} backLabel="Início" />
 
   <div class="page-container">
     <Breadcrumbs crumbs={[
       { label: 'Início', href: BASE },
-      { label: 'Sobre o Projeto' }
+      { label: 'Projeto' }
     ]} />
 
     <section class="page-section">

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -24,12 +24,12 @@ const base = import.meta.env.BASE_URL;
 ---
 
 <Layout
-  title="Estatísticas - CausaGanha"
+  title="Indicadores — CausaGanha"
   description="Análise de cobertura histórica e confiabilidade dos tribunais."
 >
   <Header
     variant="page"
-    title="Estatísticas de Coleta"
+    title="Indicadores"
     subtitle="Análise de cobertura histórica e confiabilidade"
     backHref={base}
     backLabel="Voltar para o Início"
@@ -38,7 +38,7 @@ const base = import.meta.env.BASE_URL;
   <div class="container">
     <Breadcrumbs crumbs={[
       { label: 'Início', href: base },
-      { label: 'Estatísticas' }
+      { label: 'Indicadores' }
     ]} />
 
     <!-- Coverage Overview -->


### PR DESCRIPTION
## Description

This PR restructures the publications page and improves overall navigation and UX across the site:

### Publications Page (`publicacoes/index.astro`)
- **Mode tabs UI**: Replaced separate sections with a CSS-only radio-tab pattern (similar to TribunalDetail) to toggle between "Ao vivo" (live DJEN search) and "Arquivo" (Internet Archive explorer)
- **Hash-based navigation**: Added script to activate the "arquivo" tab when navigating with `#arquivo` hash, enabling direct linking to the archive mode
- **Improved styling**: Refined tab appearance with better visual hierarchy and responsive layout

### Tribunal Detail Page (`TribunalDetail.svelte`)
- **Reorganized layout**: Moved tribunal selector from breadcrumb to a dedicated "Trocar tribunal" dropdown in the title area
- **Improved title section**: Restructured to separate main content (title + quality score) from actions (tribunal switcher + export/share buttons)
- **Better responsive design**: Actions now flex-wrap appropriately on smaller screens
- **Fixed typos**: "Calendario" → "Calendário", "Estatisticas" → "Estatísticas"

### DuckDB Explorer (`DuckDBExplorer.svelte`)
- **Starter cards**: Replaced collapsed details section with 3 prominent starter query cards (grid layout, responsive)
- **Better UX**: Additional templates moved to collapsible "Ver mais consultas de exemplo" section
- **Improved discoverability**: First 3 queries are immediately visible and clickable

### Navigation Header (`Header.astro`)
- **Reorganized menu structure**: 
  - Primary links: "Buscar", "SQL", "Indicadores", "Projeto"
  - Ferramentas dropdown: "Advogados", "Comparador", "Dados" + divider + "Consultas", "Dicionário", "Changelog"
  - Removed "Como Funciona", "Resumo", "Para Quem" from main nav
- **Consistent across all breakpoints**: Desktop, tablet, and mobile menus now follow the same structure

### Homepage (`index.astro`)
- **Mode trio cards**: Replaced simple button CTAs with 3 descriptive cards for "Buscar publicações", "Navegar no arquivo", and "Consultar com SQL"
- **Removed Quick Access section**: Consolidated into the new mode trio pattern
- **Better visual hierarchy**: Primary card highlighted with border and background color
- **Accessibility**: Added sr-only status indicator

### Search Components
- **SmartSearchInput**: Enhanced hint display with emoji icons and colored left border based on query kind (OAB, processo, etc.)
- **PublicationSearch**: Added example chips below search input when empty, matching homepage pattern

### Accessibility & Touch Targets
- **WCAG 2.5.5 compliance**: Added `min-height: 44px` for all interactive elements on touch devices
- **Semantic improvements**: Added `aria-haspopup="true"` to dropdown triggers, `sr-only` status text

### Page Titles
- "Explorador de Dados" → "SQL"
- "Sobre o Projeto" → "Projeto"
- "Estatísticas" → "Indicadores"

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] Navigation structure is consistent across all breakpoints.
- [x] Hash-based navigation works for publications archive mode.
- [x] Touch target minimums (44px) implemented for accessibility.
- [x] Responsive grid layouts tested (1 col mobile, 3 cols desktop).

https://claude.ai/code/session_01NVvw8W4b1JR362di8kqPEE