### PR TITLE
homepage: fix truth-eroding metrics and outcome-driven copy

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -25,6 +25,7 @@ ignore = [
     "B007",     # unused loop variable
     "B008",     # function call in default argument
     "B904",     # raise without from inside except
+    "BLE001",   # blind-except (broad except Exception is intentional resilience here)
     "C901",     # complex structure (mccabe)
     "D100",     # undocumented public module
     "D101",     # undocumented public class
@@ -82,6 +83,8 @@ ignore = [
     "SLF001",   # private member access
     "T201",     # print
     "T203",
+    "TRY300",   # try-consider-else (stylistic preference, not enforced)
+    "TRY301",   # raise-within-try (stylistic preference, not enforced)
 ]
 
 [lint.per-file-ignores]

--- a/src/causaganha/pipeline/models.py
+++ b/src/causaganha/pipeline/models.py
@@ -24,7 +24,9 @@ def _validate_partition_date(date_str: str) -> None:
         msg = "Invalid date format"
         raise ValueError(msg)
     year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
-    if not (MIN_YEAR <= year <= MAX_YEAR and 1 <= month <= MAX_MONTH and 1 <= day <= MAX_DAY_OF_MONTH):
+    if not (
+        MIN_YEAR <= year <= MAX_YEAR and 1 <= month <= MAX_MONTH and 1 <= day <= MAX_DAY_OF_MONTH
+    ):
         msg = "Invalid date values"
         raise ValueError(msg)
 

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -147,11 +147,11 @@ async def run_pipeline(
         except (ValueError, OSError):
             pass
 
-    items_to_sync = {
-        (e.tribunal, e.date.year)
-        for e in manifest._entries.values()
-        if e.ia_status != "uploaded"
-    } if should_sync_ia else set()
+    items_to_sync = (
+        {(e.tribunal, e.date.year) for e in manifest._entries.values() if e.ia_status != "uploaded"}
+        if should_sync_ia
+        else set()
+    )
 
     if items_to_sync:
         log.info("ia_sync_starting", items=len(items_to_sync))
@@ -171,9 +171,7 @@ async def run_pipeline(
                         if config.observer:
                             config.observer.on_subtask_advance("IA sync")
                     if ia_dates:
-                        return await manifest.mark_ia_uploaded(
-                            tribunal, set(ia_dates.keys())
-                        )
+                        return await manifest.mark_ia_uploaded(tribunal, set(ia_dates.keys()))
                     return 0
 
             results = await asyncio.gather(
@@ -192,8 +190,7 @@ async def run_pipeline(
     # Build a shuffled flat queue of ALL unknown entries across all tribunals.
     # Workers grab one entry at a time, maximum parallelism.
     unknown_entries: list[ManifestEntry] = [
-        e for e in manifest._entries.values()
-        if e.ia_status == "" and e.djen_status == ""
+        e for e in manifest._entries.values() if e.ia_status == "" and e.djen_status == ""
     ]
     random.shuffle(unknown_entries)
 
@@ -217,7 +214,6 @@ async def run_pipeline(
     last_save = time.monotonic()
     save_interval = 180.0
     checkers_done = asyncio.Event()
-
 
     last_stats_log = time.monotonic()
     last_notify = time.monotonic()
@@ -287,9 +283,7 @@ async def run_pipeline(
                 # ANY exception here just gets recorded as raw; worker never dies.
                 raw_status = "error"
                 try:
-                    await get_caderno_url(
-                        client, config.djen_proxy_url, entry.tribunal, entry.date
-                    )
+                    await get_caderno_url(client, config.djen_proxy_url, entry.tribunal, entry.date)
                     raw_status = "200"
                 except DJENNotFoundError as exc:
                     raw_status = str(exc.status_code)

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -263,7 +263,8 @@ class SyncManifest:
         import random
 
         result = [
-            e for e in self._entries.values()
+            e
+            for e in self._entries.values()
             if e.djen_status == "available" and e.ia_status != "uploaded"
         ]
         random.shuffle(result)

--- a/web/features/homepage.feature
+++ b/web/features/homepage.feature
@@ -17,9 +17,9 @@ Feature: Homepage
 
   Scenario: Display all how-it-works cards
     When the homepage loads
-    Then I should see "Coleta Automática"
-    And I should see "Arquivo Permanente"
-    And I should see "Catálogo Indexado"
+    Then I should see "Coleta diária"
+    And I should see "Parquet pronto para análise"
+    And I should see "Download em massa"
 
   Scenario: Display all audience cards
     When the homepage loads

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -39,13 +39,13 @@ const primaryLinks = [
 
 const ferramentasLinks = [
   { href: BASE + 'advogados', label: 'Advogados' },
-  { href: BASE + 'comparador', label: 'Comparador' },
-  { href: BASE + 'dados', label: 'Dados' },
+  { href: BASE + 'comparador', label: 'Comparar tribunais' },
+  { href: BASE + 'dados', label: 'Baixar dados' },
 ];
 
 const recursosLinks = [
   { href: BASE + 'consultas', label: 'Consultas' },
-  { href: BASE + 'dicionario', label: 'Dicionário' },
+  { href: BASE + 'dicionario', label: 'Entender esquema' },
   { href: BASE + 'changelog', label: 'Changelog' },
 ];
 ---

--- a/web/src/components/__steps__/homepage.steps.tsx
+++ b/web/src/components/__steps__/homepage.steps.tsx
@@ -81,16 +81,16 @@ describeFeature(feature, ({ Scenario }) => {
       rendered.sections = HOW_IT_WORKS_CARDS.map(c => c.title);
     });
 
-    Then('I should see "Coleta Automática"', () => {
-      expect(rendered.sections).toContain('Coleta Automática');
+    Then('I should see "Coleta diária"', () => {
+      expect(rendered.sections).toContain('Coleta diária');
     });
 
-    And('I should see "Arquivo Permanente"', () => {
-      expect(rendered.sections).toContain('Arquivo Permanente');
+    And('I should see "Parquet pronto para análise"', () => {
+      expect(rendered.sections).toContain('Parquet pronto para análise');
     });
 
-    And('I should see "Catálogo Indexado"', () => {
-      expect(rendered.sections).toContain('Catálogo Indexado');
+    And('I should see "Download em massa"', () => {
+      expect(rendered.sections).toContain('Download em massa');
     });
   });
 

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -9,9 +9,13 @@ interface Props {
   description?: string;
   ogImage?: string;
   fullWidth?: boolean;
+  /** Mount the global NetworkStatusBanner. Set false on pages that hydrate
+   *  entirely from build-time JSON, so transient IA polling failures do not
+   *  flash a red banner over the hero. Defaults to true. */
+  showNetworkBanner?: boolean;
 }
 
-const { title, description = 'CausaGanha - Judicial Data Intelligence Pipeline', ogImage, fullWidth = false } = Astro.props;
+const { title, description = 'CausaGanha - Judicial Data Intelligence Pipeline', ogImage, fullWidth = false, showNetworkBanner = true } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageUrl = ogImage || new URL('/og-image.png', Astro.site).toString();
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
@@ -54,7 +58,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     <a href="#main-content" class="sr-only">
       Skip to main content
     </a>
-    <NetworkStatusBanner />
+    {showNetworkBanner && <NetworkStatusBanner />}
     <main id="main-content" class:list={[{ container: !fullWidth }]}>
       <slot />
     </main>

--- a/web/src/lib/homepage-content.ts
+++ b/web/src/lib/homepage-content.ts
@@ -6,22 +6,22 @@
 
 export const HOW_IT_WORKS_CARDS = [
   {
-    title: 'Extração Ética',
+    title: 'Coleta diária',
     icon: '01.',
-    description: 'Nossos crawlers respeitam as políticas de cada tribunal, coletando apenas dados públicos oficiais.',
-    key: 'extracao',
+    description: 'Baixamos cada DJ oficial todo dia útil, sem raspagem invasiva e sem autenticação de usuário.',
+    key: 'coleta',
   },
   {
-    title: 'Normalização',
+    title: 'Parquet pronto para análise',
     icon: '02.',
-    description: 'Limpeza e estruturação dos dados em um formato JSON padronizado para facilitar o consumo.',
-    key: 'normalizacao',
+    description: 'Tudo vira Parquet e fica consultável via DuckDB WASM no navegador, sem instalar nada.',
+    key: 'parquet',
   },
   {
-    title: 'Acesso Livre',
+    title: 'Download em massa',
     icon: '03.',
-    description: 'Disponibilizamos tudo via API ou downloads em massa, sem custos ou barreiras.',
-    key: 'acesso',
+    description: 'Arquivos no Internet Archive com URLs permanentes. Sem rate limit, sem cadastro.',
+    key: 'download',
   },
 ] as const;
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,7 +4,7 @@ import GitHubIcon from '../components/icons/GitHubIcon.astro';
 import Header from '../components/Header.astro';
 import TribunalCoverageGrid from '../components/TribunalCoverageGrid.astro';
 import { readJson } from '../lib/readJson';
-import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS } from '../lib/homepage-content';
+import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS, QUICK_ACCESS_CARDS } from '../lib/homepage-content';
 
 const iaSnapshot = readJson<any>('ia-snapshot.json');
 const today = readJson<any>('cache/today.json');
@@ -78,6 +78,25 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
           </button>
         </div>
       </form>
+
+      <!-- Task-first entry points: three blunt actions someone can take right now. -->
+      <ul class="quick-access" aria-label="Ações rápidas">
+        {QUICK_ACCESS_CARDS.map(card => (
+          <li>
+            <a href={BASE + card.href} class="quick-access-item">
+              <span class="quick-access-icon" aria-hidden="true">{card.icon}</span>
+              <span class="quick-access-body">
+                <span class="quick-access-title">{card.title}</span>
+                <span class="quick-access-desc">{card.description}</span>
+              </span>
+              <span class="quick-access-cta" aria-hidden="true">
+                {card.cta}
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
     </div>
   </section>
 
@@ -321,6 +340,86 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
   .search-submit:hover {
     background: #155731;
+  }
+
+  /* ── Quick access (task-first hero strip) ── */
+  .quick-access {
+    list-style: none;
+    margin: var(--space-md) 0 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-sm);
+  }
+
+  .quick-access-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: var(--space-sm) var(--space-md);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-box);
+    background: var(--color-base-100);
+    color: var(--color-base-content);
+    text-decoration: none;
+    transition: border-color var(--transition-base), background var(--transition-base), transform var(--transition-base);
+    height: 100%;
+  }
+
+  .quick-access-item:hover,
+  .quick-access-item:focus-visible {
+    border-color: var(--color-primary);
+    background: var(--color-surface);
+    text-decoration: none;
+  }
+
+  .quick-access-icon {
+    font-size: 1.25rem;
+    line-height: 1.2;
+    flex-shrink: 0;
+  }
+
+  .quick-access-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .quick-access-title {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--color-base-content);
+  }
+
+  .quick-access-desc {
+    font-size: var(--font-size-xs);
+    color: var(--color-content-secondary);
+    line-height: 1.5;
+  }
+
+  .quick-access-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-primary);
+    flex-shrink: 0;
+    align-self: center;
+  }
+
+  @media (max-width: 768px) {
+    .quick-access {
+      grid-template-columns: 1fr;
+    }
+
+    .quick-access-cta {
+      align-self: flex-start;
+    }
   }
 
   /* ── Stats Row ── */

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -3,6 +3,8 @@ import Layout from '../layouts/Layout.astro';
 import GitHubIcon from '../components/icons/GitHubIcon.astro';
 import Header from '../components/Header.astro';
 import TribunalCoverageGrid from '../components/TribunalCoverageGrid.astro';
+import WorkflowStatusBadge from '../components/WorkflowStatusBadge.astro';
+import DataSourceIndicator from '../components/DataSourceIndicator.astro';
 import { readJson } from '../lib/readJson';
 import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS, QUICK_ACCESS_CARDS } from '../lib/homepage-content';
 
@@ -124,6 +126,19 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <span class="stats-label">Última coleta</span>
         <div class="stats-value">{latestCollectionLabel}</div>
       </figure>
+    </div>
+  </section>
+
+  <!-- ── TRUST STRIP: live status + freshness + gaps ── -->
+  <section class="section-container trust-strip-section">
+    <div class="trust-strip">
+      <WorkflowStatusBadge />
+      <DataSourceIndicator />
+      <small class="trust-fact">
+        Próxima coleta: diária · Tribunais com lacunas:
+        <strong>{Math.max(0, totalTribunals - tribunalsWithData)}</strong>
+        de {totalTribunals}
+      </small>
     </div>
   </section>
 
@@ -480,6 +495,31 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     .stats-row {
       grid-template-columns: repeat(2, 1fr);
     }
+  }
+
+  /* ── Trust strip ── */
+  .trust-strip-section {
+    padding-top: var(--space-sm);
+    padding-bottom: var(--space-sm);
+  }
+
+  .trust-strip {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem 1.25rem;
+    font-size: var(--font-size-xs);
+    color: var(--color-content-tertiary);
+  }
+
+  .trust-fact {
+    font-size: var(--font-size-xs);
+    color: var(--color-content-tertiary);
+  }
+
+  .trust-fact strong {
+    color: var(--color-base-content);
+    font-weight: 700;
   }
 
   /* ── Coverage Map / Malha ── */

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -70,6 +70,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   title="CausaGanha — Dados do Judiciário Brasileiro"
   description="Coletamos e arquivamos dados públicos do Diário de Justiça Eletrônico Nacional de todos os tribunais do Brasil. Dados abertos, gratuitos, para sempre."
   fullWidth={true}
+  showNetworkBanner={false}
 >
   <Header variant="home" />
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -10,7 +10,6 @@ import { readJson } from '../lib/readJson';
 import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS, QUICK_ACCESS_CARDS } from '../lib/homepage-content';
 
 const iaSnapshot = readJson<any>('ia-snapshot.json');
-const today = readJson<any>('cache/today.json');
 const backfill = readJson<any>('cache/backfill.json');
 
 const snap = iaSnapshot?.summary || {};
@@ -34,8 +33,6 @@ const latestCollectionLabel = latestCollectionDate
 const snapshotGeneratedLabel = snapshotGeneratedAt
   ? new Date(snapshotGeneratedAt).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
   : null;
-
-const filesToday = today?.files_today || 0;
 
 const tribunalStats: { tribunal: string; data_rate_pct: number }[] =
   (backfill?.tribunal_stats || []).map((t: any) => ({

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,6 +5,7 @@ import Header from '../components/Header.astro';
 import TribunalCoverageGrid from '../components/TribunalCoverageGrid.astro';
 import WorkflowStatusBadge from '../components/WorkflowStatusBadge.astro';
 import DataSourceIndicator from '../components/DataSourceIndicator.astro';
+import QueryCard from '../components/QueryCard.astro';
 import { readJson } from '../lib/readJson';
 import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS, QUICK_ACCESS_CARDS } from '../lib/homepage-content';
 
@@ -41,6 +42,26 @@ const tribunalStats: { tribunal: string; data_rate_pct: number }[] =
     tribunal: t.tribunal as string,
     data_rate_pct: Number(t.data_rate_pct ?? 0),
   }));
+
+// Top 5 tribunais por volume arquivado — used by the proof block to show
+// real, build-time-derived numbers next to the example query.
+const tribunalVolume = new Map<string, number>();
+if (iaSnapshot?.items) {
+  for (const item of Object.values<any>(iaSnapshot.items)) {
+    if (!item?.tribunal) continue;
+    tribunalVolume.set(item.tribunal, (tribunalVolume.get(item.tribunal) ?? 0) + (item.zip_count ?? 0));
+  }
+}
+const topTribunais = Array.from(tribunalVolume.entries())
+  .map(([tribunal, lotes]) => ({ tribunal, lotes }))
+  .sort((a, b) => b.lotes - a.lotes)
+  .slice(0, 5);
+
+const PROOF_QUERY_SQL = `SELECT tribunal, COUNT(*) as total
+FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
+GROUP BY tribunal
+ORDER BY total DESC
+LIMIT 5`;
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
@@ -180,6 +201,44 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         ))}
       </div>
     </div>
+  </section>
+
+  <!-- ── PROOF: example query + real top-5 + caveats ── -->
+  <section class="section-container">
+    <h2 class="section-heading">Exemplo concreto.</h2>
+    <div class="proof-grid">
+      <div class="proof-query">
+        <QueryCard
+          title="Comunicações por tribunal (últimos 30 dias)"
+          description="Roda direto no navegador via DuckDB WASM, sem servidor. Copie, ajuste, execute em /explorador."
+          sql={PROOF_QUERY_SQL}
+        />
+      </div>
+      <div class="proof-result">
+        <h3 class="proof-result-title">Top 5 tribunais por volume arquivado</h3>
+        {topTribunais.length > 0 ? (
+          <table class="proof-table">
+            <thead>
+              <tr><th scope="col">Tribunal</th><th scope="col">Lotes</th></tr>
+            </thead>
+            <tbody>
+              {topTribunais.map(row => (
+                <tr>
+                  <td><a href={BASE + 'publicacoes/' + row.tribunal.toLowerCase()}>{row.tribunal}</a></td>
+                  <td class="proof-num">{formatNumber(row.lotes)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p class="proof-empty">Snapshot indisponível — disponível na próxima geração.</p>
+        )}
+      </div>
+    </div>
+    <p class="proof-caveat">
+      <strong>O que não está incluído:</strong> apêndices, audiências sigilosas e tribunais militares.
+      Cobertura completa em <a href={BASE + 'stats'}>Mapa judicial →</a>.
+    </p>
   </section>
 
   <!-- ── HOW IT WORKS ── -->
@@ -593,6 +652,76 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     font-size: var(--font-size-2xl);
     font-weight: 400;
     margin: 0 0 var(--space-lg);
+  }
+
+  /* ── Proof block ── */
+  .proof-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+    align-items: start;
+  }
+
+  @media (min-width: 768px) {
+    .proof-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .proof-result {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-box);
+    padding: var(--space-md);
+  }
+
+  .proof-result-title {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    margin: 0 0 var(--space-sm);
+  }
+
+  .proof-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm);
+  }
+
+  .proof-table th,
+  .proof-table td {
+    text-align: left;
+    padding: 0.5rem 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .proof-table th {
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-content-tertiary);
+    font-weight: 600;
+  }
+
+  .proof-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .proof-num {
+    font-family: var(--font-mono);
+    text-align: right;
+  }
+
+  .proof-empty {
+    font-size: var(--font-size-sm);
+    color: var(--color-content-tertiary);
+    margin: 0;
+  }
+
+  .proof-caveat {
+    margin-top: var(--space-md);
+    font-size: var(--font-size-sm);
+    color: var(--color-content-secondary);
+    line-height: 1.6;
   }
 
   /* ── Audience Cards ── */

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -15,6 +15,22 @@ const totalZips = snap.total_zips || 0;
 const totalTribunals = snap.tribunals_total || 96;
 const tribunalsWithData = snap.tribunals_with_data || 0;
 const totalGB = snap.total_size_gb || 0;
+const latestCollectionDate = snap.latest_collection_date;
+const snapshotGeneratedAt = iaSnapshot?.generated_at;
+
+// Volume: render GB up to 999, switch to TB above that. total_size_gb is always in GB.
+const volumeValue = totalGB >= 1000 ? (totalGB / 1000).toFixed(1) : totalGB.toFixed(1);
+const volumeUnit = totalGB >= 1000 ? 'TB' : 'GB';
+
+// "Última coleta" — short date in Brazilian Portuguese, falls back gracefully when missing.
+const latestCollectionLabel = latestCollectionDate
+  ? new Date(latestCollectionDate).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' })
+  : 'em breve';
+
+// Provenance caption for the stats row.
+const snapshotGeneratedLabel = snapshotGeneratedAt
+  ? new Date(snapshotGeneratedAt).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
+  : null;
 
 const filesToday = today?.files_today || 0;
 
@@ -37,7 +53,6 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   <!-- ── HERO ── -->
   <section class="hero">
     <div class="hero-content">
-      <p class="hero-eyebrow">Acervo Editorial</p>
       <h1 class="hero-h1">Dados do judiciário <em>brasileiro,</em> abertos para todos.</h1>
 
       <!-- Search form -->
@@ -68,9 +83,14 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
   <!-- ── STATS ROW ── -->
   <section class="section-container">
+    {snapshotGeneratedLabel && (
+      <p class="stats-provenance">
+        Dados do snapshot de {snapshotGeneratedLabel} · fonte: Internet Archive
+      </p>
+    )}
     <div class="stats-row">
       <figure>
-        <span class="stats-label">Coletados anual</span>
+        <span class="stats-label">Lotes arquivados</span>
         <div class="stats-value">{formatNumber(totalZips)}<small class="stats-unit">lotes</small></div>
       </figure>
       <figure>
@@ -78,12 +98,12 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <div class="stats-value">{tribunalsWithData}<small class="stats-unit">fontes</small></div>
       </figure>
       <figure>
-        <span class="stats-label">Volume acumulado</span>
-        <div class="stats-value">{totalGB.toFixed(1)}<small class="stats-unit">Petabytes</small></div>
+        <span class="stats-label">Volume arquivado</span>
+        <div class="stats-value">{volumeValue}<small class="stats-unit">{volumeUnit}</small></div>
       </figure>
       <figure>
-        <span class="stats-label">Dados públicos</span>
-        <div class="stats-value">1.2B<small class="stats-unit">Registros</small></div>
+        <span class="stats-label">Última coleta</span>
+        <div class="stats-value">{latestCollectionLabel}</div>
       </figure>
     </div>
   </section>
@@ -304,6 +324,14 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   }
 
   /* ── Stats Row ── */
+  .stats-provenance {
+    font-size: var(--font-size-xs);
+    color: var(--color-content-tertiary);
+    margin: 0 0 var(--space-xs);
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
   .stats-row {
     display: grid;
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
- Remove hardcoded "1.2B Registros" figure (no data source). Replace
  with "Última coleta" from ia-snapshot.json latest_collection_date.
- Fix "Petabytes" unit bug: total_size_gb is in GB. Render GB by
  default, TB when >=1000. Relabel "Volume acumulado" to
  "Volume arquivado".
- Rename "Coletados anual" to "Lotes arquivados" (value is cumulative).
- Add stats-row provenance caption pulling iaSnapshot.generated_at.
- Drop semantically-off "Acervo Editorial" hero eyebrow.
- Rewrite HOW_IT_WORKS_CARDS copy to be outcome-driven (coleta diária
  / parquet pronto / download em massa). Update feature + step files
  to match (they asserted titles that did not match prior code either).