### PR TITLE
Add homepage widgets, rating segmentation, and score filtering

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -7,6 +7,7 @@ on:
       - 'web/**'
       - 'scripts/generate_dashboard_cache.py'
       - 'scripts/generate_ia_snapshot.py'
+      - 'scripts/generate_homepage_widgets.py'
   # No schedule needed — update-catalog.yml triggers this after every successful collect
   workflow_dispatch:
 
@@ -71,6 +72,12 @@ jobs:
           mkdir -p web/public/cache
           uv run python scripts/generate_dashboard_cache.py
           uv run python scripts/generate_ia_snapshot.py --output web/public/ia-snapshot.json
+          # Homepage widgets (activity strip, top tribunais 30d, top advogados).
+          # Non-fatal: if generation fails, a prior cached JSON (if any) is
+          # used, and index.astro degrades gracefully when the JSON is absent.
+          uv run python scripts/generate_homepage_widgets.py \
+            --output web/public/cache/homepage-widgets.json \
+            || echo "homepage-widgets generation failed (non-fatal)"
           echo "Cache files generated:"
           ls -la web/public/cache/
         env:

--- a/scripts/generate_homepage_widgets.py
+++ b/scripts/generate_homepage_widgets.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Generate homepage widget data from consolidated Parquet lake on Internet Archive.
+
+Reads `manifest.parquet` from the causaganha-catalog to discover the remote URLs
+of all `*-comunicacoes.parquet` and `*-advogados.parquet` files, then aggregates
+three widgets:
+
+  1. activity_summary: counts for the last closed month (intimations, unique OABs,
+     processes, tribunals active).
+  2. top_tribunais_30d: top 5 tribunals by volume of communications in the last
+     30 days.
+  3. top_advogados_atividade: top 20 lawyers by case count in the current year
+     (nominal, descriptive — NOT a quality ranking).
+
+The output JSON is read at Astro build time by `web/src/pages/index.astro` via
+`readJson('cache/homepage-widgets.json')`. If any widget fails to build, we emit
+an empty list/dict for that key and let the Astro page render gracefully.
+
+Usage:
+    python scripts/generate_homepage_widgets.py
+        [--output web/public/cache/homepage-widgets.json]
+        [--year 2026]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+logger = logging.getLogger("generate_homepage_widgets")
+
+SCHEMA_VERSION = 1
+MANIFEST_URL = "https://archive.org/download/causaganha-catalog/manifest.parquet"
+TOP_TRIBUNAIS_LIMIT = 5
+TOP_ADVOGADOS_LIMIT = 20
+MIN_CASES_PER_LAWYER = 10
+
+
+def _connect() -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute("INSTALL httpfs; LOAD httpfs;")
+    return con
+
+
+def _load_manifest(con: duckdb.DuckDBPyConnection) -> bool:
+    """Load the global manifest. Returns False if it can't be loaded."""
+    try:
+        con.execute(
+            f"CREATE OR REPLACE TABLE manifest AS SELECT * FROM read_parquet('{MANIFEST_URL}')"
+        )
+        row = con.execute("SELECT COUNT(*) FROM manifest").fetchone()
+        if row is None or row[0] == 0:
+            logger.warning("manifest is empty")
+            return False
+        logger.info("manifest loaded: %s rows", row[0])
+    except duckdb.Error as exc:
+        logger.warning("failed to load manifest: %s", exc)
+        return False
+    return True
+
+
+def _discover_parquet_urls(
+    con: duckdb.DuckDBPyConnection,
+    table_name: str,
+    year: int | None = None,
+) -> list[str]:
+    """Find all Parquet URLs for a given table (e.g. 'comunicacoes' or 'advogados').
+
+    The manifest schema varies slightly between codepaths; we try the most common
+    columns and fall back gracefully. Filters by year on the `date` column when
+    provided.
+    """
+    year_filter = f"AND date LIKE '{year}-%'" if year is not None else ""
+    candidate_sqls = [
+        f"""
+        SELECT DISTINCT ia_url
+        FROM manifest
+        WHERE file_type = 'parquet'
+          AND table_name = '{table_name}'
+          {year_filter}
+        """,
+        f"""
+        SELECT DISTINCT ia_url
+        FROM manifest
+        WHERE file_name LIKE '%-{table_name}.parquet'
+          {year_filter}
+        """,
+    ]
+    for sql in candidate_sqls:
+        try:
+            rows = con.execute(sql).fetchall()
+        except duckdb.Error as exc:
+            logger.debug("manifest probe failed for %s: %s", table_name, exc)
+            continue
+        urls = [r[0] for r in rows if r and r[0]]
+        if urls:
+            logger.info("discovered %d %s parquets", len(urls), table_name)
+            return urls
+    logger.warning("no %s parquets discovered", table_name)
+    return []
+
+
+def _array_literal(urls: list[str]) -> str:
+    """Render a DuckDB array literal of strings from a Python list.
+
+    We validate that every URL looks like an IA archive URL to reduce the risk of
+    SQL injection through poisoned manifest rows.
+    """
+    clean = []
+    for url in urls:
+        if not isinstance(url, str):
+            continue
+        if not url.startswith("https://archive.org/"):
+            continue
+        if "'" in url or ";" in url or "--" in url:
+            continue
+        clean.append(f"'{url}'")
+    return "[" + ", ".join(clean) + "]"
+
+
+def _activity_summary(
+    con: duckdb.DuckDBPyConnection,
+    com_urls: list[str],
+    adv_urls: list[str],
+    year: int,
+) -> dict[str, Any]:
+    """Widget 1: last closed month summary (intimations, OABs, processes, tribunals)."""
+    if not com_urls or not adv_urls:
+        return {}
+    # Last closed month = previous calendar month relative to today (UTC).
+    now = datetime.now(UTC)
+    if now.month == 1:
+        period_year, period_month = now.year - 1, 12
+    else:
+        period_year, period_month = now.year, now.month - 1
+    try:
+        row = con.execute(
+            f"""
+            WITH com AS (
+                SELECT intimation_id, sigla_tribunal, numero_processo
+                FROM read_parquet({_array_literal(com_urls)}, union_by_name=true)
+                WHERE year = {period_year} AND month = {period_month}
+            ),
+            adv AS (
+                SELECT intimation_id, oab_number, oab_state
+                FROM read_parquet({_array_literal(adv_urls)}, union_by_name=true)
+                WHERE oab_number IS NOT NULL AND oab_state IS NOT NULL
+            )
+            SELECT
+                COUNT(DISTINCT com.intimation_id) AS intimacoes,
+                COUNT(DISTINCT adv.oab_number || '/' || adv.oab_state) AS oabs,
+                COUNT(DISTINCT com.numero_processo) AS processos,
+                COUNT(DISTINCT com.sigla_tribunal) AS tribunais
+            FROM com LEFT JOIN adv USING(intimation_id)
+            """
+        ).fetchone()
+    except duckdb.Error as exc:
+        logger.warning("activity_summary failed: %s", exc)
+        return {}
+    if row is None:
+        return {}
+    intimacoes, oabs, processos, tribunais = row
+    if not intimacoes:
+        return {}
+    return {
+        "periodo": f"{period_year:04d}-{period_month:02d}",
+        "intimacoes": int(intimacoes),
+        "oabs_unicas": int(oabs or 0),
+        "processos": int(processos or 0),
+        "tribunais": int(tribunais or 0),
+    }
+
+
+def _top_tribunais_30d(
+    con: duckdb.DuckDBPyConnection,
+    com_urls: list[str],
+) -> list[dict[str, Any]]:
+    """Widget 2: top tribunals by communications volume in the last 30 days."""
+    if not com_urls:
+        return []
+    try:
+        rows = con.execute(
+            f"""
+            SELECT sigla_tribunal AS tribunal, COUNT(*) AS comunicacoes
+            FROM read_parquet({_array_literal(com_urls)}, union_by_name=true)
+            WHERE data_disponibilizacao >= current_date - INTERVAL 30 DAY
+            GROUP BY 1
+            ORDER BY 2 DESC
+            LIMIT {TOP_TRIBUNAIS_LIMIT}
+            """
+        ).fetchall()
+    except duckdb.Error as exc:
+        logger.warning("top_tribunais_30d failed: %s", exc)
+        return []
+    return [{"tribunal": r[0], "comunicacoes": int(r[1])} for r in rows if r and r[0]]
+
+
+def _top_advogados_atividade(
+    con: duckdb.DuckDBPyConnection,
+    com_urls: list[str],
+    adv_urls: list[str],
+    year: int,
+) -> list[dict[str, Any]]:
+    """Widget 3: top lawyers by volume of communications in the given year.
+
+    Filters out singletons (< MIN_CASES_PER_LAWYER) to keep signal/noise high.
+    Includes per-lawyer primary tribunal and autor/réu split.
+    """
+    if not com_urls or not adv_urls:
+        return []
+    try:
+        rows = con.execute(
+            f"""
+            WITH com AS (
+                SELECT intimation_id, sigla_tribunal
+                FROM read_parquet({_array_literal(com_urls)}, union_by_name=true)
+                WHERE year = {year}
+            ),
+            adv AS (
+                SELECT intimation_id, oab_number, oab_state, lawyer_name, polo
+                FROM read_parquet({_array_literal(adv_urls)}, union_by_name=true)
+                WHERE oab_number IS NOT NULL AND oab_state IS NOT NULL
+            ),
+            joined AS (
+                SELECT com.intimation_id, com.sigla_tribunal,
+                       adv.oab_number, adv.oab_state, adv.lawyer_name, adv.polo
+                FROM com JOIN adv USING(intimation_id)
+            ),
+            per_lawyer_tribunal AS (
+                SELECT oab_number, oab_state, sigla_tribunal, COUNT(*) AS n
+                FROM joined GROUP BY 1, 2, 3
+            ),
+            primary_tribunal AS (
+                SELECT oab_number, oab_state, sigla_tribunal AS tribunal_principal
+                FROM (
+                    SELECT oab_number, oab_state, sigla_tribunal,
+                           ROW_NUMBER() OVER (PARTITION BY oab_number, oab_state
+                                              ORDER BY n DESC, sigla_tribunal) AS rk
+                    FROM per_lawyer_tribunal
+                )
+                WHERE rk = 1
+            ),
+            totals AS (
+                SELECT oab_number, oab_state,
+                       any_value(lawyer_name) AS nome,
+                       COUNT(*) AS comunicacoes,
+                       AVG(CASE WHEN polo = 'A' THEN 1.0
+                                WHEN polo = 'P' THEN 0.0 END) AS pct_autor
+                FROM joined
+                GROUP BY 1, 2
+                HAVING COUNT(*) >= {MIN_CASES_PER_LAWYER}
+            )
+            SELECT t.oab_number, t.oab_state, t.nome,
+                   t.comunicacoes, p.tribunal_principal, t.pct_autor
+            FROM totals t JOIN primary_tribunal p USING(oab_number, oab_state)
+            ORDER BY t.comunicacoes DESC, t.oab_number
+            LIMIT {TOP_ADVOGADOS_LIMIT}
+            """
+        ).fetchall()
+    except duckdb.Error as exc:
+        logger.warning("top_advogados_atividade failed: %s", exc)
+        return []
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        oab, uf, nome, n, trib, pct_autor = row
+        # pct_autor may be NULL if polo is always other values; clamp to [0,1].
+        if pct_autor is None:
+            autor_pct = 0.0
+        else:
+            autor_pct = max(0.0, min(1.0, float(pct_autor)))
+        results.append(
+            {
+                "oab": oab,
+                "uf": uf,
+                "nome": nome,
+                "comunicacoes": int(n),
+                "tribunal_principal": trib,
+                "polos": {
+                    "A": round(autor_pct, 3),
+                    "P": round(1.0 - autor_pct, 3),
+                },
+            }
+        )
+    return results
+
+
+def build_widgets(year: int) -> dict[str, Any]:
+    """Build the full homepage-widgets payload.
+
+    Always returns a valid envelope. Individual widgets may be empty if their
+    underlying data isn't available yet.
+    """
+    con = _connect()
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "year": year,
+        "activity_summary": {},
+        "top_tribunais_30d": [],
+        "top_advogados_atividade": [],
+    }
+
+    if not _load_manifest(con):
+        return payload
+
+    com_urls = _discover_parquet_urls(con, "comunicacoes", year=year)
+    adv_urls = _discover_parquet_urls(con, "advogados", year=year)
+
+    payload["activity_summary"] = _activity_summary(con, com_urls, adv_urls, year)
+    payload["top_tribunais_30d"] = _top_tribunais_30d(con, com_urls)
+    payload["top_advogados_atividade"] = _top_advogados_atividade(con, com_urls, adv_urls, year)
+
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default="web/public/cache/homepage-widgets.json",
+        help="Output path for the widget JSON",
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=datetime.now(UTC).year,
+        help="Year to aggregate over for the 'top advogados' widget",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    payload = build_widgets(args.year)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    summary = payload.get("activity_summary") or {}
+    logger.info(
+        "wrote %s (year=%s, periodo=%s, intimacoes=%s, top_tribunais=%d, top_advogados=%d)",
+        output_path,
+        args.year,
+        summary.get("periodo", "n/a"),
+        summary.get("intimacoes", "n/a"),
+        len(payload["top_tribunais_30d"]),
+        len(payload["top_advogados_atividade"]),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_ground_truth.py
+++ b/scripts/prepare_ground_truth.py
@@ -4,6 +4,7 @@ from collections import Counter
 #!/usr/bin/env python3
 """Preparar ground truth de decisões validadas para RAG."""
 
+import argparse
 import sys
 
 import duckdb
@@ -15,8 +16,145 @@ from rich.table import Table
 console = Console()
 
 
+# Stratified sampling targets each (tribunal x outcome x confidence-bucket) cell
+# and tries to draw at least MIN_PER_CELL rows per cell, up to TARGET_TOTAL rows.
+# The goal is a ground-truth set that reflects the full shape of the data, not
+# just the cases that happen to have the highest confidence.
+STRATIFIED_CONFIDENCE_BUCKETS: tuple[tuple[float, float, str], ...] = (
+    (0.6, 0.7, "low"),
+    (0.7, 0.8, "mid"),
+    (0.8, 0.9, "high"),
+    (0.9, 1.001, "top"),
+)
+STRATIFIED_OUTCOMES = ("procedente", "parcialmente procedente", "improcedente")
+STRATIFIED_MIN_PER_CELL = 10
+STRATIFIED_TARGET_TOTAL = 500
+
+
+def _bucket_for(conf: float) -> str | None:
+    """Return the name of the confidence bucket a score falls into."""
+    for low, high, name in STRATIFIED_CONFIDENCE_BUCKETS:
+        if low <= conf < high:
+            return name
+    return None
+
+
+def run_stratified_sampling(
+    conn: duckdb.DuckDBPyConnection,
+    target: int = STRATIFIED_TARGET_TOTAL,
+    min_per_cell: int = STRATIFIED_MIN_PER_CELL,
+) -> list[tuple]:
+    """Draw a stratified sample of classifications for ground-truth review.
+
+    Samples by (sigla_tribunal x outcome x confidence_bucket). Each cell gets at
+    least ``min_per_cell`` rows when available; remaining capacity up to
+    ``target`` is distributed proportionally to cell sizes.
+    """
+    buckets_sql = ", ".join(
+        f"({low}, {high}, '{name}')" for low, high, name in STRATIFIED_CONFIDENCE_BUCKETS
+    )
+    outcomes_sql = ", ".join(f"'{o}'" for o in STRATIFIED_OUTCOMES)
+
+    conn.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE _gt_candidates AS
+        SELECT
+            da.intimation_id,
+            da.outcome,
+            da.winner_party_name,
+            da.loser_party_name,
+            da.winner_lawyer_oab,
+            da.loser_lawyer_oab,
+            da.confidence_score,
+            i.texto,
+            i.sigla_tribunal,
+            b.bucket
+        FROM decision_analysis da
+        JOIN intimations i ON da.intimation_id = i.id
+        JOIN (
+            SELECT * FROM (VALUES {buckets_sql}) AS t(lo, hi, bucket)
+        ) b ON da.confidence_score >= b.lo AND da.confidence_score < b.hi
+        WHERE da.outcome IN ({outcomes_sql})
+          AND i.texto IS NOT NULL
+          AND LENGTH(i.texto) BETWEEN 500 AND 8000
+        """
+    )
+
+    # Show cell sizes up front so operators can spot holes.
+    cells = conn.execute(
+        """
+        SELECT sigla_tribunal, outcome, bucket, COUNT(*) AS n
+        FROM _gt_candidates
+        GROUP BY 1, 2, 3
+        ORDER BY n DESC
+        """
+    ).fetchall()
+    console.print(f"[cyan]Células (tribunal x outcome x bucket): {len(cells)}[/cyan]")
+
+    # Seed: take up to min_per_cell per cell, randomly ordered per cell.
+    seeded = conn.execute(
+        f"""
+        WITH ranked AS (
+            SELECT *,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY sigla_tribunal, outcome, bucket
+                       ORDER BY RANDOM()
+                   ) AS rk
+            FROM _gt_candidates
+        )
+        SELECT intimation_id, outcome, texto, winner_party_name, loser_party_name,
+               winner_lawyer_oab, loser_lawyer_oab, confidence_score,
+               LENGTH(texto) AS text_length
+        FROM ranked
+        WHERE rk <= {min_per_cell}
+        """
+    ).fetchall()
+
+    remaining = max(0, target - len(seeded))
+    if remaining > 0:
+        seeded_ids = {row[0] for row in seeded}
+        placeholders = ",".join(["?"] * len(seeded_ids)) if seeded_ids else "NULL"
+        extra = conn.execute(
+            f"""
+            SELECT intimation_id, outcome, texto, winner_party_name, loser_party_name,
+                   winner_lawyer_oab, loser_lawyer_oab, confidence_score,
+                   LENGTH(texto) AS text_length
+            FROM _gt_candidates
+            WHERE intimation_id NOT IN ({placeholders})
+            ORDER BY RANDOM()
+            LIMIT {remaining}
+            """,
+            list(seeded_ids),
+        ).fetchall()
+        seeded.extend(extra)
+
+    return seeded[:target]
+
+
 def main() -> None:
     """Preparar ground truth validado."""
+    parser = argparse.ArgumentParser(
+        description="Prepara ground truth para validação do classificador."
+    )
+    parser.add_argument(
+        "--stratified",
+        action="store_true",
+        help="Amostragem estratificada por (tribunal x outcome x bucket de confidence).",
+    )
+    parser.add_argument(
+        "--target",
+        type=int,
+        default=STRATIFIED_TARGET_TOTAL,
+        help="Tamanho-alvo do conjunto estratificado (padrão: 500).",
+    )
+    parser.add_argument(
+        "--min-per-cell",
+        type=int,
+        default=STRATIFIED_MIN_PER_CELL,
+        help="Mínimo de amostras por célula antes da amostragem proporcional.",
+    )
+    args = parser.parse_args()
+
     console.print("\n[bold cyan]📋 Preparação de Ground Truth[/bold cyan]\n")
 
     # Conectar ao banco
@@ -39,31 +177,40 @@ def main() -> None:
         )
     """)
 
-    # Buscar decisões da LLM com alta confiança para usar como ground truth
-    console.print("\n[yellow]Buscando decisões com alta confiança da LLM...[/yellow]\n")
-
-    candidates = conn.execute("""
-        SELECT
-            ar.intimation_id,
-            ar.outcome,
-            i.texto,
-            ar.winner_party_name,
-            ar.loser_party_name,
-            ar.winner_lawyer_oab,
-            ar.loser_lawyer_oab,
-            ar.confidence_score,
-            LENGTH(i.texto) as text_length
-        FROM analysis_results ar
-        JOIN intimations i ON ar.intimation_id = i.id
-        WHERE ar.confidence_score >= 0.90
-          AND ar.outcome IN ('WIN', 'LOSS', 'PARTIAL', 'UNKNOWN')
-          AND i.texto IS NOT NULL
-          AND LENGTH(i.texto) BETWEEN 500 AND 8000
-        ORDER BY ar.confidence_score DESC
-        LIMIT 100
-    """).fetchall()
-
-    console.print(f"✓ Encontrados {len(candidates)} candidatos com confiança ≥ 90%\n")
+    if args.stratified:
+        console.print(
+            "\n[yellow]Amostragem estratificada por (tribunal x outcome x "
+            "confidence bucket)...[/yellow]\n"
+        )
+        candidates = run_stratified_sampling(
+            conn,
+            target=args.target,
+            min_per_cell=args.min_per_cell,
+        )
+        console.print(f"✓ {len(candidates)} candidatos estratificados\n")
+    else:
+        console.print("\n[yellow]Buscando decisões com alta confiança da LLM...[/yellow]\n")
+        candidates = conn.execute("""
+            SELECT
+                ar.intimation_id,
+                ar.outcome,
+                i.texto,
+                ar.winner_party_name,
+                ar.loser_party_name,
+                ar.winner_lawyer_oab,
+                ar.loser_lawyer_oab,
+                ar.confidence_score,
+                LENGTH(i.texto) as text_length
+            FROM analysis_results ar
+            JOIN intimations i ON ar.intimation_id = i.id
+            WHERE ar.confidence_score >= 0.90
+              AND ar.outcome IN ('WIN', 'LOSS', 'PARTIAL', 'UNKNOWN')
+              AND i.texto IS NOT NULL
+              AND LENGTH(i.texto) BETWEEN 500 AND 8000
+            ORDER BY ar.confidence_score DESC
+            LIMIT 100
+        """).fetchall()
+        console.print(f"✓ Encontrados {len(candidates)} candidatos com confiança ≥ 90%\n")
 
     # Estatísticas por outcome
     table = Table(title="Distribuição de Candidatos")
@@ -83,17 +230,22 @@ def main() -> None:
 
     console.print(table)
 
-    # Selecionar subset balanceado
-    console.print("\n[bold]Selecionando subset balanceado para ground truth:[/bold]\n")
-
-    # Queremos ~25 de cada tipo para começar
-    target_per_outcome = 25
-    ground_truth_items = []
-
-    for outcome in ["WIN", "LOSS", "PARTIAL", "UNKNOWN"]:
-        items = [c for c in candidates if c[1] == outcome][:target_per_outcome]
-        ground_truth_items.extend(items)
-        console.print(f"  {outcome:8s}: {len(items)} decisões")
+    if args.stratified:
+        # Stratified sampling already balanced the candidates; use them all.
+        ground_truth_items = list(candidates)
+        by_outcome = Counter(item[1] for item in ground_truth_items)
+        console.print("\n[bold]Distribuição estratificada final:[/bold]")
+        for outcome, count in by_outcome.most_common():
+            console.print(f"  {outcome}: {count}")
+    else:
+        # Selecionar subset balanceado (modo clássico)
+        console.print("\n[bold]Selecionando subset balanceado para ground truth:[/bold]\n")
+        target_per_outcome = 25
+        ground_truth_items = []
+        for outcome in ["WIN", "LOSS", "PARTIAL", "UNKNOWN"]:
+            items = [c for c in candidates if c[1] == outcome][:target_per_outcome]
+            ground_truth_items.extend(items)
+            console.print(f"  {outcome:8s}: {len(items)} decisões")
 
     console.print(f"\n[green]Total selecionado: {len(ground_truth_items)} decisões[/green]\n")
 

--- a/src/causaganha/pipeline/score.py
+++ b/src/causaganha/pipeline/score.py
@@ -25,6 +25,34 @@ from causaganha.storage.repositories.rating import (
 logger = structlog.get_logger()
 
 
+# Confidence thresholds that gate how the OpenSkill rating is updated.
+# - below CONFIDENCE_FLOOR: skip entirely (don't trust the classifier).
+# - CONFIDENCE_FLOOR <= c < CONFIDENCE_FULL: interpolate towards the new rating
+#   with weight ``c``, so low-confidence matches nudge ratings less.
+# - at or above CONFIDENCE_FULL: apply the full OpenSkill delta.
+CONFIDENCE_FLOOR = 0.6
+CONFIDENCE_FULL = 0.8
+
+
+def _interpolate_rating(
+    old_rating: Any,
+    new_rating: Any,
+    weight: float,
+    model: Any,
+) -> Any:
+    """Blend an updated rating with the prior based on classifier confidence.
+
+    Weight of 1.0 returns ``new_rating`` unchanged; weight of 0.0 returns the
+    prior. Values in between produce a rating whose mu/sigma are the linear
+    blend of the two endpoints, which is the simplest honest way to propagate
+    classifier uncertainty without forking the OpenSkill library.
+    """
+    w = max(0.0, min(1.0, float(weight)))
+    mu = old_rating.mu + w * (new_rating.mu - old_rating.mu)
+    sigma = old_rating.sigma + w * (new_rating.sigma - old_rating.sigma)
+    return create_rating(model, mu=mu, sigma=sigma)
+
+
 async def calculate_ratings(
     batch_size: int = 100,
 ) -> dict[str, Any]:
@@ -43,6 +71,8 @@ async def calculate_ratings(
 
     processed = 0
     failed = 0
+    skipped_low_confidence = 0
+    skipped_missing_oab = 0
 
     try:
         # Get unrated analyses
@@ -53,6 +83,8 @@ async def calculate_ratings(
             return {
                 "processed": 0,
                 "failed": 0,
+                "skipped_low_confidence": 0,
+                "skipped_missing_oab": 0,
                 "status": "success",
             }
 
@@ -65,9 +97,36 @@ async def calculate_ratings(
                 loser_oab = analysis["loser_lawyer_oab"]
                 loser_state = analysis["loser_lawyer_state"]
 
-                # Get current ratings
-                winner_data = get_lawyer_rating(con, winner_oab, winner_state)
-                loser_data = get_lawyer_rating(con, loser_oab, loser_state)
+                # Identity is strictly (oab, state); rows missing either are
+                # unusable for rating. Mark them as rated so they don't block
+                # the queue forever, but count them separately.
+                if not winner_oab or not winner_state or not loser_oab or not loser_state:
+                    skipped_missing_oab += 1
+                    mark_analysis_as_rated(con, analysis["id"])
+                    continue
+
+                # Tribunal-segmented rating: each sigla_tribunal is its own
+                # "league" so top lawyers at TJSP aren't inflated by wins at
+                # a smaller jurisdiction with weaker opposition.
+                tribunal = analysis.get("sigla_tribunal") or "GLOBAL"
+
+                # Low-confidence gate: skip matches the classifier isn't
+                # sure about; keep the queue moving by marking as rated.
+                confidence = analysis.get("confidence_score")
+                if confidence is not None and float(confidence) < CONFIDENCE_FLOOR:
+                    skipped_low_confidence += 1
+                    mark_analysis_as_rated(con, analysis["id"])
+                    continue
+
+                # Weight for partial/full updates based on confidence.
+                if confidence is None or float(confidence) >= CONFIDENCE_FULL:
+                    update_weight = 1.0
+                else:
+                    update_weight = float(confidence)
+
+                # Get current ratings (per tribunal)
+                winner_data = get_lawyer_rating(con, winner_oab, winner_state, tribunal=tribunal)
+                loser_data = get_lawyer_rating(con, loser_oab, loser_state, tribunal=tribunal)
 
                 # Resolve names
                 winner_name = winner_data.get("lawyer_name") if winner_data else None
@@ -114,30 +173,42 @@ async def calculate_ratings(
                     result="win_a",
                 )
 
-                # Update ratings in DB
+                # Apply confidence-weighted interpolation for mid-confidence
+                # matches. At full confidence this is a no-op; at lower
+                # confidence the rating moves only partway to the OpenSkill
+                # update, reflecting our uncertainty about the outcome label.
+                effective_winner = _interpolate_rating(
+                    winner_rating, new_winner[0], update_weight, model
+                )
+                effective_loser = _interpolate_rating(
+                    loser_rating, new_loser[0], update_weight, model
+                )
+
+                # Update ratings in DB (per tribunal)
                 # Winner
                 update_lawyer_rating(
                     con,
                     oab_number=winner_oab,
                     oab_state=winner_state,
                     lawyer_name=winner_name,
-                    mu=new_winner[0].mu,
-                    sigma=new_winner[0].sigma,
+                    mu=effective_winner.mu,
+                    sigma=effective_winner.sigma,
                     wins=winner_wins + 1,
                     losses=winner_losses,
+                    tribunal=tribunal,
                 )
 
                 # Record winner snapshot
                 insert_rating_snapshot(
                     con,
-                    advogado_id=f"{winner_oab}:{winner_state}",
+                    advogado_id=f"{winner_oab}:{winner_state}:{tribunal}",
                     comunicacao_id=str(analysis["id"]),
                     oab_number=winner_oab,
                     oab_state=winner_state,
                     mu_before=winner_rating.mu,
                     sigma_before=winner_rating.sigma,
-                    mu_after=new_winner[0].mu,
-                    sigma_after=new_winner[0].sigma,
+                    mu_after=effective_winner.mu,
+                    sigma_after=effective_winner.sigma,
                     wins=winner_wins + 1,
                     losses=winner_losses,
                 )
@@ -148,23 +219,24 @@ async def calculate_ratings(
                     oab_number=loser_oab,
                     oab_state=loser_state,
                     lawyer_name=loser_name,
-                    mu=new_loser[0].mu,
-                    sigma=new_loser[0].sigma,
+                    mu=effective_loser.mu,
+                    sigma=effective_loser.sigma,
                     wins=loser_wins,
                     losses=loser_losses + 1,
+                    tribunal=tribunal,
                 )
 
                 # Record loser snapshot
                 insert_rating_snapshot(
                     con,
-                    advogado_id=f"{loser_oab}:{loser_state}",
+                    advogado_id=f"{loser_oab}:{loser_state}:{tribunal}",
                     comunicacao_id=str(analysis["id"]),
                     oab_number=loser_oab,
                     oab_state=loser_state,
                     mu_before=loser_rating.mu,
                     sigma_before=loser_rating.sigma,
-                    mu_after=new_loser[0].mu,
-                    sigma_after=new_loser[0].sigma,
+                    mu_after=effective_loser.mu,
+                    sigma_after=effective_loser.sigma,
                     wins=loser_wins,
                     losses=loser_losses + 1,
                 )
@@ -181,12 +253,16 @@ async def calculate_ratings(
             "rating_calculation_complete",
             processed=processed,
             failed=failed,
+            skipped_low_confidence=skipped_low_confidence,
+            skipped_missing_oab=skipped_missing_oab,
         )
     except Exception as e:
         logger.exception("rating_pipeline_failed", error=str(e))
         return {
             "processed": processed,
             "failed": failed,
+            "skipped_low_confidence": skipped_low_confidence,
+            "skipped_missing_oab": skipped_missing_oab,
             "status": "failed",
             "error": str(e),
         }
@@ -194,5 +270,7 @@ async def calculate_ratings(
         return {
             "processed": processed,
             "failed": failed,
+            "skipped_low_confidence": skipped_low_confidence,
+            "skipped_missing_oab": skipped_missing_oab,
             "status": "success",
         }

--- a/src/causaganha/storage/repositories/analysis.py
+++ b/src/causaganha/storage/repositories/analysis.py
@@ -4,7 +4,6 @@ import json
 from typing import Any
 from uuid import UUID
 
-from ibis import _
 from ibis.backends.duckdb import Backend
 
 from causaganha.analysis.models import DecisionAnalysis
@@ -75,24 +74,61 @@ def store_analysis(
     )
 
 
+# Outcomes that actually produce a winner/loser and therefore can update
+# OpenSkill ratings. "unknown" and non-ratable outcomes are excluded so the
+# rating isn't polluted by cases the classifier couldn't resolve.
+RATABLE_OUTCOMES = ("procedente", "parcialmente procedente", "improcedente")
+
+# Decision types that we do NOT feed into the rating system. Interim orders
+# (decisões interlocutórias) are procedural and rarely mark a definitive
+# winner; dropping them reduces noise in the OpenSkill updates.
+EXCLUDED_DECISION_TYPES = ("decisão interlocutória",)
+
+
 def get_unrated_analyses(
     con: Backend,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     """Get analyses that haven't been processed for ratings yet.
 
+    Joins with ``intimations`` so callers can segment ratings per tribunal
+    (``sigla_tribunal`` is included in the returned dicts). Also filters out
+    non-ratable outcomes and interim orders upfront so the rating pipeline
+    never has to re-check those conditions.
+
     Args:
         con: Database connection.
         limit: Max number of records to return.
 
     Returns:
-        List of analysis records.
+        List of analysis records, each augmented with ``sigla_tribunal``.
     """
     analysis = con.table("decision_analysis")
+    intimations = con.table("intimations")
+
+    joined = analysis.join(
+        intimations,
+        analysis.intimation_id == intimations.id,
+    )
 
     result = (
-        analysis.filter(_.rated == False)  # noqa: E712
-        .order_by(_.created_at.asc())
+        joined.filter(analysis.rated == False)  # noqa: E712
+        .filter(analysis.outcome.isin(RATABLE_OUTCOMES))
+        .filter(analysis.decision_type.notin(EXCLUDED_DECISION_TYPES))
+        .select(
+            id=analysis.id,
+            intimation_id=analysis.intimation_id,
+            winner_lawyer_oab=analysis.winner_lawyer_oab,
+            winner_lawyer_state=analysis.winner_lawyer_state,
+            loser_lawyer_oab=analysis.loser_lawyer_oab,
+            loser_lawyer_state=analysis.loser_lawyer_state,
+            decision_type=analysis.decision_type,
+            outcome=analysis.outcome,
+            confidence_score=analysis.confidence_score,
+            created_at=analysis.created_at,
+            sigla_tribunal=intimations.sigla_tribunal,
+        )
+        .order_by(analysis.created_at.asc())
         .limit(limit)
     )
 

--- a/src/causaganha/storage/repositories/rating.py
+++ b/src/causaganha/storage/repositories/rating.py
@@ -11,6 +11,12 @@ from ibis.backends.duckdb import Backend
 logger = structlog.get_logger()
 
 
+# Minimum wins + losses before a lawyer is considered "ranked enough" to show
+# on any public leaderboard. Below this threshold the OpenSkill sigma is still
+# too wide to produce a meaningful ordering.
+MIN_MATCHES_FOR_LEADERBOARD = 20
+
+
 def get_lawyer_rating(
     con: Backend,
     oab_number: str,
@@ -113,6 +119,57 @@ def update_lawyer_rating(  # noqa: PLR0913
             tribunal,
         ],
     )
+
+
+def list_leaderboard(
+    con: Backend,
+    tribunal: str,
+    *,
+    limit: int = 100,
+    min_matches: int = MIN_MATCHES_FOR_LEADERBOARD,
+) -> list[dict[str, Any]]:
+    """Return the public leaderboard for a tribunal.
+
+    This is the read path for anything user-facing. It only exposes lawyers
+    with enough match history (``wins + losses >= min_matches``) and returns
+    the *conservative* rating (``mu - 3*sigma``) — raw mu/sigma are considered
+    internals and intentionally omitted here to prevent a future consumer from
+    accidentally ordering by a confidence-inflated score.
+
+    Args:
+        con: Database connection.
+        tribunal: Tribunal code ("GLOBAL" for the cross-league rating).
+        limit: Max rows to return.
+        min_matches: Minimum (wins + losses) required to appear.
+
+    Returns:
+        List of dicts with oab_number, oab_state, lawyer_name, rating,
+        total_cases, wins, losses, win_rate, tribunal.
+    """
+    ratings = con.table("lawyer_ratings")
+
+    query = (
+        ratings.filter(_.tribunal == tribunal)
+        .filter((_.wins + _.losses) >= min_matches)
+        .select(
+            _.oab_number,
+            _.oab_state,
+            _.lawyer_name,
+            _.rating,
+            _.total_cases,
+            _.wins,
+            _.losses,
+            _.win_rate,
+            _.tribunal,
+        )
+        .order_by(_.rating.desc())
+        .limit(limit)
+    )
+
+    result = query.to_pandas()
+    if result.empty:
+        return []
+    return result.to_dict("records")
 
 
 def insert_rating_snapshot(  # noqa: PLR0913

--- a/tests/test_rating_segmentation.py
+++ b/tests/test_rating_segmentation.py
@@ -1,0 +1,249 @@
+"""Tests for per-tribunal ratings and leaderboard hygiene.
+
+Covers:
+- ``update_lawyer_rating`` keys on ``(oab_number, oab_state, tribunal)``, so the
+  same lawyer can hold distinct ratings in distinct leagues.
+- ``list_leaderboard`` hides lawyers below the minimum match count and only
+  exposes the conservative rating (never raw mu/sigma).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ibis
+import pytest
+
+from causaganha.storage.repositories.rating import (
+    MIN_MATCHES_FOR_LEADERBOARD,
+    get_lawyer_rating,
+    list_leaderboard,
+    update_lawyer_rating,
+)
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent / "src" / "causaganha" / "storage" / "schema.sql"
+)
+
+
+def _init_schema(con):
+    sql = SCHEMA_PATH.read_text()
+    for statement in sql.split(";"):
+        stmt = statement.strip()
+        if stmt:
+            con.raw_sql(stmt)
+
+
+@pytest.fixture
+def con():
+    backend = ibis.duckdb.connect()
+    _init_schema(backend)
+    return backend
+
+
+def test_same_lawyer_has_independent_ratings_per_tribunal(con) -> None:
+    """A lawyer active in two tribunais should get two independent rating rows."""
+    update_lawyer_rating(
+        con,
+        oab_number="1234",
+        oab_state="SP",
+        lawyer_name="ADV A",
+        mu=26.0,
+        sigma=7.5,
+        wins=5,
+        losses=3,
+        tribunal="TJSP",
+    )
+    update_lawyer_rating(
+        con,
+        oab_number="1234",
+        oab_state="SP",
+        lawyer_name="ADV A",
+        mu=24.0,
+        sigma=8.0,
+        wins=2,
+        losses=4,
+        tribunal="TJMG",
+    )
+
+    tjsp = get_lawyer_rating(con, "1234", "SP", tribunal="TJSP")
+    tjmg = get_lawyer_rating(con, "1234", "SP", tribunal="TJMG")
+
+    assert tjsp is not None
+    assert tjmg is not None
+    assert tjsp["mu"] == pytest.approx(26.0)
+    assert tjmg["mu"] == pytest.approx(24.0)
+    assert tjsp["wins"] == 5
+    assert tjmg["wins"] == 2
+
+
+def test_update_lawyer_rating_upserts_on_same_tribunal(con) -> None:
+    """Re-updating the same (oab, state, tribunal) must overwrite, not duplicate."""
+    update_lawyer_rating(
+        con,
+        oab_number="9999",
+        oab_state="RJ",
+        lawyer_name="ADV B",
+        mu=25.0,
+        sigma=8.0,
+        wins=10,
+        losses=10,
+        tribunal="TJRJ",
+    )
+    update_lawyer_rating(
+        con,
+        oab_number="9999",
+        oab_state="RJ",
+        lawyer_name="ADV B",
+        mu=27.0,
+        sigma=6.5,
+        wins=15,
+        losses=10,
+        tribunal="TJRJ",
+    )
+
+    df = con.table("lawyer_ratings").to_pandas()
+    mine = df[(df["oab_number"] == "9999") & (df["tribunal"] == "TJRJ")]
+    assert len(mine) == 1
+    assert mine.iloc[0]["mu"] == pytest.approx(27.0)
+    assert mine.iloc[0]["wins"] == 15
+
+
+def test_list_leaderboard_hides_lawyers_below_min_matches(con) -> None:
+    """Lawyers below MIN_MATCHES_FOR_LEADERBOARD must not appear publicly."""
+    # Below threshold
+    update_lawyer_rating(
+        con,
+        oab_number="100",
+        oab_state="SP",
+        lawyer_name="Novato",
+        mu=30.0,
+        sigma=5.0,
+        wins=5,
+        losses=5,
+        tribunal="TJSP",
+    )
+    # Exactly at threshold
+    update_lawyer_rating(
+        con,
+        oab_number="200",
+        oab_state="SP",
+        lawyer_name="Veterano",
+        mu=27.0,
+        sigma=5.0,
+        wins=MIN_MATCHES_FOR_LEADERBOARD - 1,
+        losses=1,
+        tribunal="TJSP",
+    )
+    # Well above threshold
+    update_lawyer_rating(
+        con,
+        oab_number="300",
+        oab_state="SP",
+        lawyer_name="Craque",
+        mu=28.0,
+        sigma=4.0,
+        wins=50,
+        losses=10,
+        tribunal="TJSP",
+    )
+
+    rows = list_leaderboard(con, tribunal="TJSP")
+    oabs = {r["oab_number"] for r in rows}
+
+    assert "100" not in oabs, "Lawyer below min matches must not appear"
+    assert "200" in oabs
+    assert "300" in oabs
+
+
+def test_list_leaderboard_does_not_leak_mu_sigma(con) -> None:
+    """Raw mu/sigma are internals; only the conservative rating is public."""
+    update_lawyer_rating(
+        con,
+        oab_number="400",
+        oab_state="SP",
+        lawyer_name="Expostor",
+        mu=35.0,
+        sigma=3.0,
+        wins=100,
+        losses=20,
+        tribunal="TJSP",
+    )
+
+    rows = list_leaderboard(con, tribunal="TJSP")
+    assert rows, "Expected at least one leaderboard row"
+
+    fields = set(rows[0].keys())
+    assert "rating" in fields
+    assert "mu" not in fields, "Raw mu must not appear in the public leaderboard"
+    assert "sigma" not in fields, "Raw sigma must not appear in the public leaderboard"
+
+
+def test_list_leaderboard_is_ordered_by_conservative_rating(con) -> None:
+    """Leaderboard ordering must follow mu - 3*sigma, not raw mu."""
+    # Higher mu but very uncertain
+    update_lawyer_rating(
+        con,
+        oab_number="500",
+        oab_state="SP",
+        lawyer_name="Inflado",
+        mu=35.0,
+        sigma=8.0,  # mu - 3*sigma = 11
+        wins=30,
+        losses=5,
+        tribunal="TJSP",
+    )
+    # Lower mu but well-established
+    update_lawyer_rating(
+        con,
+        oab_number="600",
+        oab_state="SP",
+        lawyer_name="Sólido",
+        mu=28.0,
+        sigma=2.0,  # mu - 3*sigma = 22
+        wins=60,
+        losses=20,
+        tribunal="TJSP",
+    )
+
+    rows = list_leaderboard(con, tribunal="TJSP")
+    assert len(rows) == 2
+    # The sólid player must rank ahead of the inflated one
+    assert rows[0]["oab_number"] == "600"
+    assert rows[1]["oab_number"] == "500"
+
+
+def test_list_leaderboard_scopes_by_tribunal(con) -> None:
+    """Leaderboard for TJSP must not include lawyers who only rate at TJMG."""
+    update_lawyer_rating(
+        con,
+        oab_number="700",
+        oab_state="SP",
+        lawyer_name="Paulista",
+        mu=28.0,
+        sigma=4.0,
+        wins=40,
+        losses=10,
+        tribunal="TJSP",
+    )
+    update_lawyer_rating(
+        con,
+        oab_number="800",
+        oab_state="MG",
+        lawyer_name="Mineiro",
+        mu=29.0,
+        sigma=4.0,
+        wins=40,
+        losses=10,
+        tribunal="TJMG",
+    )
+
+    sp_rows = list_leaderboard(con, tribunal="TJSP")
+    mg_rows = list_leaderboard(con, tribunal="TJMG")
+
+    sp_oabs = {r["oab_number"] for r in sp_rows}
+    mg_oabs = {r["oab_number"] for r in mg_rows}
+
+    assert sp_oabs == {"700"}
+    assert mg_oabs == {"800"}

--- a/tests/test_score_filters.py
+++ b/tests/test_score_filters.py
@@ -1,0 +1,231 @@
+"""Tests for rating-pipeline filters: interlocutórias, non-ratable outcomes,
+low-confidence skip, and tribunal segmentation in ``get_unrated_analyses``.
+
+These tests drive an in-memory DuckDB via Ibis so they run without the real
+``data/causaganha.duckdb`` file and never touch the network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ibis
+import pytest
+
+from causaganha.storage.repositories.analysis import (
+    EXCLUDED_DECISION_TYPES,
+    RATABLE_OUTCOMES,
+    get_unrated_analyses,
+)
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent / "src" / "causaganha" / "storage" / "schema.sql"
+)
+
+
+def _init_schema(con):
+    """Apply the project schema to an in-memory DuckDB connection."""
+    sql = SCHEMA_PATH.read_text()
+    for statement in sql.split(";"):
+        stmt = statement.strip()
+        if stmt:
+            con.raw_sql(stmt)
+
+
+def _insert_intimation(con, *, iid: int, tribunal: str) -> None:
+    con.con.execute(
+        """
+        INSERT INTO intimations (
+            id, numero_processo, data_disponibilizacao, sigla_tribunal,
+            texto, hash
+        ) VALUES (?, ?, DATE '2026-04-01', ?, 'corpo da intimação', ?)
+        """,
+        [iid, f"proc-{iid}", tribunal, f"hash-{iid}"],
+    )
+
+
+def _insert_analysis(  # noqa: PLR0913
+    con,
+    *,
+    intimation_id: int,
+    outcome: str,
+    decision_type: str,
+    confidence: float,
+    winner_oab: str = "1111",
+    winner_state: str = "SP",
+    loser_oab: str = "2222",
+    loser_state: str = "SP",
+) -> None:
+    con.con.execute(
+        """
+        INSERT INTO decision_analysis (
+            intimation_id,
+            winner_lawyer_oab, winner_lawyer_state, winner_party_name,
+            loser_lawyer_oab,  loser_lawyer_state,  loser_party_name,
+            decision_type, outcome,
+            confidence_score, analysis_method, model_used, model_provider
+        ) VALUES (
+            ?, ?, ?, 'A', ?, ?, 'B', ?, ?, ?, 'llm', 'gemini-2.5-flash', 'google'
+        )
+        """,
+        [
+            intimation_id,
+            winner_oab,
+            winner_state,
+            loser_oab,
+            loser_state,
+            decision_type,
+            outcome,
+            confidence,
+        ],
+    )
+
+
+@pytest.fixture
+def con():
+    backend = ibis.duckdb.connect()
+    _init_schema(backend)
+    return backend
+
+
+def test_ratable_outcomes_are_sentence_level() -> None:
+    """Only outcomes that actually resolve the dispute should be ratable."""
+    assert "procedente" in RATABLE_OUTCOMES
+    assert "improcedente" in RATABLE_OUTCOMES
+    assert "parcialmente procedente" in RATABLE_OUTCOMES
+    # Procedural labels must not leak into the rating pipeline
+    assert "unknown" not in RATABLE_OUTCOMES
+
+
+def test_interlocutorias_are_excluded() -> None:
+    """Interim orders should be listed as non-ratable decision types."""
+    assert "decisão interlocutória" in EXCLUDED_DECISION_TYPES
+
+
+def test_get_unrated_analyses_filters_non_ratable_outcomes(con) -> None:
+    """Only procedente/improcedente/parcialmente procedente should be returned."""
+    _insert_intimation(con, iid=1, tribunal="TJSP")
+    _insert_intimation(con, iid=2, tribunal="TJSP")
+    _insert_intimation(con, iid=3, tribunal="TJSP")
+
+    _insert_analysis(
+        con,
+        intimation_id=1,
+        outcome="procedente",
+        decision_type="sentença",
+        confidence=0.9,
+    )
+    _insert_analysis(
+        con,
+        intimation_id=2,
+        outcome="unknown",
+        decision_type="sentença",
+        confidence=0.9,
+    )
+    _insert_analysis(
+        con,
+        intimation_id=3,
+        outcome="parcialmente procedente",
+        decision_type="sentença",
+        confidence=0.75,
+    )
+
+    rows = get_unrated_analyses(con, limit=100)
+    intimation_ids = {r["intimation_id"] for r in rows}
+
+    assert intimation_ids == {1, 3}
+
+
+def test_get_unrated_analyses_excludes_interlocutorias(con) -> None:
+    """Interlocutórias are procedural and must not enter the rating queue."""
+    _insert_intimation(con, iid=10, tribunal="TJSP")
+    _insert_intimation(con, iid=11, tribunal="TJSP")
+
+    _insert_analysis(
+        con,
+        intimation_id=10,
+        outcome="procedente",
+        decision_type="decisão interlocutória",
+        confidence=0.95,
+    )
+    _insert_analysis(
+        con,
+        intimation_id=11,
+        outcome="procedente",
+        decision_type="sentença",
+        confidence=0.95,
+    )
+
+    rows = get_unrated_analyses(con, limit=100)
+    intimation_ids = {r["intimation_id"] for r in rows}
+
+    assert intimation_ids == {11}
+
+
+def test_get_unrated_analyses_includes_sigla_tribunal(con) -> None:
+    """The rating pipeline segments by tribunal, so the join must surface it."""
+    _insert_intimation(con, iid=20, tribunal="TJSP")
+    _insert_intimation(con, iid=21, tribunal="TJMG")
+
+    _insert_analysis(
+        con,
+        intimation_id=20,
+        outcome="procedente",
+        decision_type="sentença",
+        confidence=0.9,
+    )
+    _insert_analysis(
+        con,
+        intimation_id=21,
+        outcome="improcedente",
+        decision_type="acórdão",
+        confidence=0.9,
+    )
+
+    rows = get_unrated_analyses(con, limit=100)
+    by_id = {r["intimation_id"]: r for r in rows}
+
+    assert by_id[20]["sigla_tribunal"] == "TJSP"
+    assert by_id[21]["sigla_tribunal"] == "TJMG"
+
+
+def test_interpolate_rating_blends_towards_new() -> None:
+    """Mid-confidence updates should move only partway towards the OpenSkill delta."""
+    from causaganha.pipeline.score import _interpolate_rating
+    from causaganha.scoring.openskill import create_rating, get_openskill_model
+
+    model = get_openskill_model()
+    old = create_rating(model, mu=25.0, sigma=8.333)
+    new = create_rating(model, mu=27.0, sigma=7.333)
+
+    # Weight 0.0 keeps the prior
+    kept = _interpolate_rating(old, new, 0.0, model)
+    assert kept.mu == pytest.approx(25.0)
+    assert kept.sigma == pytest.approx(8.333)
+
+    # Weight 1.0 applies the full update
+    full = _interpolate_rating(old, new, 1.0, model)
+    assert full.mu == pytest.approx(27.0)
+    assert full.sigma == pytest.approx(7.333)
+
+    # Mid weight is a linear blend
+    mid = _interpolate_rating(old, new, 0.5, model)
+    assert mid.mu == pytest.approx(26.0)
+    assert mid.sigma == pytest.approx(7.833)
+
+
+def test_interpolate_rating_clamps_weight() -> None:
+    """Out-of-range weights must be clamped to [0, 1] so we never extrapolate."""
+    from causaganha.pipeline.score import _interpolate_rating
+    from causaganha.scoring.openskill import create_rating, get_openskill_model
+
+    model = get_openskill_model()
+    old = create_rating(model, mu=25.0, sigma=8.0)
+    new = create_rating(model, mu=30.0, sigma=7.0)
+
+    below = _interpolate_rating(old, new, -1.0, model)
+    assert below.mu == pytest.approx(25.0)
+
+    above = _interpolate_rating(old, new, 2.5, model)
+    assert above.mu == pytest.approx(30.0)

--- a/web/src/lib/readJson.ts
+++ b/web/src/lib/readJson.ts
@@ -55,6 +55,33 @@ export interface CacheBackfillFile {
   [key: string]: unknown;
 }
 
+/**
+ * Widgets rendered on the homepage. Generated once per day by
+ * `scripts/generate_homepage_widgets.py` and committed to
+ * `web/public/cache/homepage-widgets.json` via CI.
+ */
+export interface HomepageWidgets {
+  schema_version?: number;
+  generated_at?: string;
+  year?: number;
+  activity_summary?: {
+    periodo?: string;
+    intimacoes?: number;
+    oabs_unicas?: number;
+    processos?: number;
+    tribunais?: number;
+  };
+  top_tribunais_30d?: Array<{ tribunal: string; comunicacoes: number }>;
+  top_advogados_atividade?: Array<{
+    oab: string;
+    uf: string;
+    nome?: string | null;
+    comunicacoes: number;
+    tribunal_principal?: string | null;
+    polos?: { A?: number; P?: number };
+  }>;
+}
+
 export function readJson<T = unknown>(relativePath: string): T | null {
   try {
     const fullPath = path.resolve('./public', relativePath);

--- a/web/src/pages/advogados.astro
+++ b/web/src/pages/advogados.astro
@@ -32,8 +32,8 @@ const avgCoverage = tribunalStats.length
     <div class="alert-wrapper">
       <AlertBanner
         level="info"
-        title="Sem ranking nominal público"
-        message="Esta página prioriza dados já disponíveis no repositório: cobertura por tribunal e atalhos de consulta por OAB no explorador."
+        title="Ranking de atividade disponível; ranking de qualidade em validação"
+        message="Um ranking descritivo por volume de atuação (quem aparece em mais comunicações) está publicado na home. O ranking de qualidade (vitórias/derrotas via OpenSkill) permanece em validação até o classificador atingir a meta de precisão."
       />
     </div>
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -6,11 +6,25 @@ import TribunalCoverageGrid from '../components/TribunalCoverageGrid.astro';
 import WorkflowStatusBadge from '../components/WorkflowStatusBadge.astro';
 import DataSourceIndicator from '../components/DataSourceIndicator.astro';
 import QueryCard from '../components/QueryCard.astro';
-import { readJson } from '../lib/readJson';
+import { readJson, type HomepageWidgets } from '../lib/readJson';
 import { formatNumber, HOW_IT_WORKS_CARDS, AUDIENCE_CARDS, QUICK_ACCESS_CARDS } from '../lib/homepage-content';
 
 const iaSnapshot = readJson<any>('ia-snapshot.json');
 const backfill = readJson<any>('cache/backfill.json');
+const widgets = readJson<HomepageWidgets>('cache/homepage-widgets.json');
+
+const activitySummary = widgets?.activity_summary ?? null;
+const topAdvogados = widgets?.top_advogados_atividade ?? [];
+const topTribunaisLive = widgets?.top_tribunais_30d ?? [];
+
+const activityPeriodoLabel = activitySummary?.periodo
+  ? (() => {
+      const [y, m] = activitySummary.periodo.split('-').map(Number);
+      if (!y || !m) return activitySummary.periodo;
+      const d = new Date(Date.UTC(y, m - 1, 1));
+      return d.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+    })()
+  : null;
 
 const snap = iaSnapshot?.summary || {};
 const totalZips = snap.total_zips || 0;
@@ -40,25 +54,41 @@ const tribunalStats: { tribunal: string; data_rate_pct: number }[] =
     data_rate_pct: Number(t.data_rate_pct ?? 0),
   }));
 
-// Top 5 tribunais por volume arquivado — used by the proof block to show
-// real, build-time-derived numbers next to the example query.
-const tribunalVolume = new Map<string, number>();
-if (iaSnapshot?.items) {
-  for (const item of Object.values<any>(iaSnapshot.items)) {
-    if (!item?.tribunal) continue;
-    tribunalVolume.set(item.tribunal, (tribunalVolume.get(item.tribunal) ?? 0) + (item.zip_count ?? 0));
+// Top 5 tribunais por movimento — prefer the daily-generated widget (real
+// communications in the last 30 days). Falls back to ZIP-lot counts when the
+// widget JSON isn't available yet, so the page still renders during setup.
+let topTribunais: { tribunal: string; lotes: number; label: string }[] = [];
+if (topTribunaisLive.length > 0) {
+  topTribunais = topTribunaisLive.map(row => ({
+    tribunal: row.tribunal,
+    lotes: row.comunicacoes,
+    label: 'Comunicações (30d)',
+  }));
+} else {
+  const tribunalVolume = new Map<string, number>();
+  if (iaSnapshot?.items) {
+    for (const item of Object.values<any>(iaSnapshot.items)) {
+      if (!item?.tribunal) continue;
+      tribunalVolume.set(item.tribunal, (tribunalVolume.get(item.tribunal) ?? 0) + (item.zip_count ?? 0));
+    }
   }
+  topTribunais = Array.from(tribunalVolume.entries())
+    .map(([tribunal, lotes]) => ({ tribunal, lotes, label: 'Lotes' }))
+    .sort((a, b) => b.lotes - a.lotes)
+    .slice(0, 5);
 }
-const topTribunais = Array.from(tribunalVolume.entries())
-  .map(([tribunal, lotes]) => ({ tribunal, lotes }))
-  .sort((a, b) => b.lotes - a.lotes)
-  .slice(0, 5);
+const topTribunaisHeader = topTribunais[0]?.label ?? 'Lotes';
 
 const PROOF_QUERY_SQL = `SELECT tribunal, COUNT(*) as total
 FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
 GROUP BY tribunal
 ORDER BY total DESC
 LIMIT 5`;
+
+function formatPctLabel(pct: number | undefined): string {
+  if (typeof pct !== 'number' || Number.isNaN(pct)) return '–';
+  return `${Math.round(pct * 100)}%`;
+}
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
@@ -148,6 +178,19 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </div>
   </section>
 
+  {activitySummary && activitySummary.intimacoes && (
+    <!-- ── ACTIVITY STRIP: movimento do último mês fechado ── -->
+    <section class="section-container activity-strip-section">
+      <p class="activity-strip">
+        <span class="activity-label">Movimento em {activityPeriodoLabel ?? activitySummary.periodo}:</span>
+        <strong>{formatNumber(activitySummary.intimacoes)}</strong> intimações ·
+        <strong>{formatNumber(activitySummary.oabs_unicas ?? 0)}</strong> OABs únicas ·
+        <strong>{formatNumber(activitySummary.processos ?? 0)}</strong> processos ·
+        <strong>{formatNumber(activitySummary.tribunais ?? 0)}</strong> tribunais ativos
+      </p>
+    </section>
+  )}
+
   <!-- ── TRUST STRIP: live status + freshness + gaps ── -->
   <section class="section-container trust-strip-section">
     <div class="trust-strip">
@@ -185,6 +228,52 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </div>
   </section>
 
+  {topAdvogados.length > 0 && (
+    <!-- ── TOP ADVOGADOS POR ATIVIDADE (nominal, descritivo) ── -->
+    <section class="section-container">
+      <h2 class="section-heading">Advogados mais ativos em {widgets?.year ?? new Date().getFullYear()}.</h2>
+      <p class="activity-disclaimer">
+        Ranking <strong>descritivo</strong> por volume de atuação. <em>Não</em> é medida de qualidade ou resultado —
+        um advogado aparece no topo simplesmente por atuar em mais processos.
+        Metodologia em <a href={BASE + 'sobre'}>/sobre</a>.
+      </p>
+      <div class="table-wrap">
+        <table class="lawyers-table">
+          <thead>
+            <tr>
+              <th scope="col" class="rank-col">#</th>
+              <th scope="col">OAB</th>
+              <th scope="col">Nome</th>
+              <th scope="col" class="num-col">Comunicações</th>
+              <th scope="col">Tribunal principal</th>
+              <th scope="col" class="num-col">% Autor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topAdvogados.map((adv, i) => (
+              <tr>
+                <td class="rank-col">{i + 1}</td>
+                <td class="mono">
+                  <a href={`${BASE}publicacoes?ufOab=${encodeURIComponent(adv.uf)}&numeroOab=${encodeURIComponent(adv.oab)}`}>
+                    {adv.oab}/{adv.uf}
+                  </a>
+                </td>
+                <td>{adv.nome ?? '—'}</td>
+                <td class="num-col mono">{formatNumber(adv.comunicacoes)}</td>
+                <td class="mono">{adv.tribunal_principal ?? '—'}</td>
+                <td class="num-col mono">{formatPctLabel(adv.polos?.A)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p class="activity-footnote">
+        Atualizado diariamente · filtro mínimo de 10 comunicações ·
+        <a href={BASE + 'advogados'}>mais em /advogados</a>
+      </p>
+    </section>
+  )}
+
   <!-- ── PARA QUEM ── -->
   <section class="section-alt">
     <div class="section-container">
@@ -213,11 +302,11 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         />
       </div>
       <div class="proof-result">
-        <h3 class="proof-result-title">Top 5 tribunais por volume arquivado</h3>
+        <h3 class="proof-result-title">Top 5 tribunais por movimento</h3>
         {topTribunais.length > 0 ? (
           <table class="proof-table">
             <thead>
-              <tr><th scope="col">Tribunal</th><th scope="col">Lotes</th></tr>
+              <tr><th scope="col">Tribunal</th><th scope="col">{topTribunaisHeader}</th></tr>
             </thead>
             <tbody>
               {topTribunais.map(row => (
@@ -552,6 +641,100 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     .stats-row {
       grid-template-columns: repeat(2, 1fr);
     }
+  }
+
+  /* ── Activity strip (widget 1) ── */
+  .activity-strip-section {
+    padding-top: var(--space-sm);
+    padding-bottom: 0;
+  }
+
+  .activity-strip {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    line-height: 1.6;
+    color: var(--color-content-secondary);
+  }
+
+  .activity-strip strong {
+    color: var(--color-base-content);
+    font-family: var(--font-mono);
+    font-weight: 700;
+  }
+
+  .activity-label {
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-content-tertiary);
+    margin-right: 0.5rem;
+  }
+
+  /* ── Top advogados table (widget 3) ── */
+  .activity-disclaimer {
+    font-size: var(--font-size-sm);
+    color: var(--color-content-secondary);
+    line-height: 1.6;
+    margin: 0 0 var(--space-md);
+    max-width: 56rem;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-box);
+  }
+
+  .lawyers-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm);
+  }
+
+  .lawyers-table th,
+  .lawyers-table td {
+    padding: 0.55rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    text-align: left;
+    vertical-align: baseline;
+  }
+
+  .lawyers-table thead th {
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-content-tertiary);
+    font-weight: 600;
+    background: var(--color-base-200);
+  }
+
+  .lawyers-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .lawyers-table tbody tr:hover {
+    background: var(--color-base-200);
+  }
+
+  .lawyers-table .rank-col {
+    width: 2.5rem;
+    color: var(--color-content-tertiary);
+    font-family: var(--font-mono);
+  }
+
+  .lawyers-table .num-col {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .lawyers-table .mono {
+    font-family: var(--font-mono);
+  }
+
+  .activity-footnote {
+    margin-top: var(--space-sm);
+    font-size: var(--font-size-xs);
+    color: var(--color-content-tertiary);
   }
 
   /* ── Trust strip ── */


### PR DESCRIPTION
## Description

This PR introduces three major features to improve the homepage and rating system:

### 1. Homepage Widgets Generation (`scripts/generate_homepage_widgets.py`)
- New script that aggregates data from the Internet Archive Parquet lake to generate three widgets:
  - **activity_summary**: Counts for the last closed month (intimations, unique OABs, processes, tribunals)
  - **top_tribunais_30d**: Top 5 tribunals by communications volume in the last 30 days
  - **top_advogados_atividade**: Top 20 lawyers by case count in the current year (nominal, descriptive ranking)
- Output JSON is read at Astro build time and displayed on the homepage
- Gracefully handles missing data by emitting empty structures

### 2. Per-Tribunal Rating Segmentation
- Modified `calculate_ratings()` in `src/causaganha/pipeline/score.py` to segment ratings by tribunal
- Each tribunal is treated as its own "league" so top lawyers at TJSP aren't inflated by wins at smaller jurisdictions
- Added confidence-based interpolation: low-confidence matches (0.6–0.8) nudge ratings less than high-confidence ones (≥0.8)
- Introduced `CONFIDENCE_FLOOR` (0.6) and `CONFIDENCE_FULL` (0.8) thresholds
- Added `_interpolate_rating()` helper to blend old and new ratings based on classifier confidence

### 3. Score Filtering and Leaderboard Safety
- Added `RATABLE_OUTCOMES` constant to filter only sentence-level outcomes (procedente, parcialmente procedente, improcedente)
- Added `EXCLUDED_DECISION_TYPES` to exclude interim orders (decisões interlocutórias) from rating pipeline
- Modified `get_unrated_analyses()` to join with `intimations` table and surface `sigla_tribunal` for tribunal segmentation
- New `list_leaderboard()` function in `rating.py` that:
  - Only exposes lawyers with ≥20 matches (configurable via `MIN_MATCHES_FOR_LEADERBOARD`)
  - Returns conservative rating (`mu - 3*sigma`) instead of raw mu/sigma to prevent confidence-inflated ordering
  - Scopes results by tribunal
- Updated `prepare_ground_truth.py` with stratified sampling by (tribunal × outcome × confidence bucket) to improve ground-truth diversity

### 4. Homepage UI Updates
- Added activity strip showing last closed month's metrics (intimations, OABs, processes, tribunals)
- Added top lawyers table with OAB, name, communication count, primary tribunal, and author/defendant split
- Falls back gracefully to ZIP-lot counts when widget JSON isn't available yet
- Added disclaimer that the ranking is descriptive (by volume), not a quality measure

### 5. Tests
- Added `tests/test_rating_segmentation.py`: Tests per-tribunal independence, upsert behavior, leaderboard filtering, and conservative rating exposure
- Added `tests/test_score_filters.py`: Tests ratable outcome filtering, interlocutória exclusion, tribunal surfacing, and confidence-based interpolation

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] Added unit tests for rating segmentation, leaderboard filtering, and score filtering logic
- [x] Existing tests pass; new tests cover the filtering and interpolation logic

https://claude.ai/code/session_01KTjtuBAjZELEhMFNP3YxQL