### PR TITLE
Migrate from ia-state.json to sync-manifest.csv for state tracking

### DIFF
--- a/.github/actions/download-state/action.yml
+++ b/.github/actions/download-state/action.yml
@@ -9,6 +9,6 @@ runs:
         # Download the manifest (primary state file)
         curl -sSfL -o data/sync-manifest.csv \
           "https://archive.org/download/causaganha-dashboard/sync-manifest.csv" \
-          || echo 'tribunal,date,ia_status,djen_status,updated_at' > data/sync-manifest.csv
+          || echo 'tribunal,date,ia_status,djen_status,djen_raw,updated_at' > data/sync-manifest.csv
         echo "State files:"
         ls -lh data/

--- a/.github/actions/download-state/action.yml
+++ b/.github/actions/download-state/action.yml
@@ -1,10 +1,5 @@
 name: Download State
 description: "Download pipeline state files from Internet Archive"
-inputs:
-  inventory:
-    description: "Also download zip-inventory.txt (legacy)"
-    required: false
-    default: "false"
 runs:
   using: composite
   steps:
@@ -15,14 +10,5 @@ runs:
         curl -sSfL -o data/sync-manifest.csv \
           "https://archive.org/download/causaganha-dashboard/sync-manifest.csv" \
           || echo 'tribunal,date,ia_status,djen_status,updated_at' > data/sync-manifest.csv
-        # Legacy state files (for other scripts that may still use them)
-        curl -sSfL -o data/ia-state.json \
-          "https://archive.org/download/causaganha-dashboard/ia-state.json" || echo '{}' > data/ia-state.json
-        curl -sSfL -o data/backfill-state.json \
-          "https://archive.org/download/causaganha-dashboard/backfill-state.json" || echo '{}' > data/backfill-state.json
-        if [ "${{ inputs.inventory }}" = "true" ]; then
-          curl -sSfL -o data/zip-inventory.txt \
-            "https://archive.org/download/causaganha-dashboard/zip-inventory.txt" || echo 'timestamp,tribunal,date,status,url' > data/zip-inventory.txt
-        fi
         echo "State files:"
         ls -lh data/

--- a/.github/workflows/consolidate-parquet.yml
+++ b/.github/workflows/consolidate-parquet.yml
@@ -77,6 +77,12 @@ jobs:
             || echo '{"current_date":null,"processed_zips":[],"completed_dates":[]}' > data/consolidate-checkpoint.json
           echo "Checkpoint state:"
           cat data/consolidate-checkpoint.json | python3 -m json.tool 2>/dev/null || cat data/consolidate-checkpoint.json
+          # Download sync-manifest.csv so consolidate.py can discover ZIPs without
+          # requiring a fresh manifest.parquet (avoids slow per-tribunal IA API fallback)
+          curl -sSfL -o data/sync-manifest.csv \
+            "https://archive.org/download/causaganha-dashboard/sync-manifest.csv" \
+            || echo 'tribunal,date,ia_status,djen_status,djen_raw,updated_at' > data/sync-manifest.csv
+          echo "Sync manifest entries: $(tail -n +2 data/sync-manifest.csv | wc -l)"
 
       - name: Run consolidation
         id: consolidate

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -94,13 +94,20 @@ def main() -> int:
     new_rows = get_new_uploads()
     logger.info("new_rows_from_state", count=len(new_rows))
 
+    # Only entries NOT yet in the existing manifest are truly new.
+    # sync-manifest.csv accumulates all historical uploads, so comparing
+    # against the existing manifest.jsonl avoids spurious has_new_uploads=true.
+    existing_keys = {(r.get("date"), r.get("tribunal")) for r in existing_rows}
+    truly_new = [r for r in new_rows if (r.get("date"), r.get("tribunal")) not in existing_keys]
+    logger.info("truly_new_uploads", count=len(truly_new))
+
     if os_env := os.environ.get("GITHUB_OUTPUT"):
         with Path(os_env).open("a", encoding="utf-8") as out:
-            out.write(f"has_new_uploads={'true' if new_rows else 'false'}\n")
+            out.write(f"has_new_uploads={'true' if truly_new else 'false'}\n")
 
-    if not new_rows:
+    if not truly_new:
         logger.info("no_new_rows_to_append")
-        # Even if no new rows, we should ensure local manifest exists for downstream
+        # Even if no new rows, ensure local manifest exists for downstream steps
         if not LOCAL_MANIFEST_PATH.exists() and existing_rows:
             LOCAL_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
             with LOCAL_MANIFEST_PATH.open("w", encoding="utf-8") as f:

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -17,7 +17,7 @@ logger = structlog.get_logger()
 IA_CATALOG_ITEM = "causaganha-catalog"
 FALLBACK_MANIFEST_URL = "https://archive.org/download/causaganha-catalog/manifest.jsonl"
 LOCAL_MANIFEST_PATH = Path("data/manifest.jsonl")
-IA_STATE_PATH = Path("data/ia-state.json")
+SYNC_MANIFEST_PATH = Path("data/sync-manifest.csv")
 
 
 def download_existing_manifest() -> list[dict]:
@@ -41,45 +41,48 @@ def download_existing_manifest() -> list[dict]:
 
 
 def get_new_uploads() -> list[dict]:
-    """Extract newly uploaded ZIPs from ia-state.json."""
-    if not IA_STATE_PATH.exists():
-        logger.warning("ia_state_not_found", path=str(IA_STATE_PATH))
+    """Extract uploaded ZIPs from sync-manifest.csv.
+
+    Reads the canonical state file written by djen-backup/engine.py.
+    Returns all entries with ia_status=uploaded, deduplication is handled
+    by the caller via (date, tribunal) keying.
+    """
+    if not SYNC_MANIFEST_PATH.exists():
+        logger.warning("sync_manifest_not_found", path=str(SYNC_MANIFEST_PATH))
         return []
 
-    try:
-        data = json.loads(IA_STATE_PATH.read_text(encoding="utf-8"))
-    except Exception as e:
-        logger.exception("error_reading_ia_state", error=str(e))
-        return []
-
-    entries = data.get("entries", {})
-    new_rows = []
+    rows = []
     now_str = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
 
-    for date_str, item_data in entries.items():
-        if isinstance(item_data, dict):
-            for tribunal, status_data in item_data.items():
-                status = status_data
-                duration_s = None
-                if isinstance(status_data, dict):
-                    status = status_data.get("status")
-                    duration_s = status_data.get("duration_s")
+    try:
+        for line in SYNC_MANIFEST_PATH.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("tribunal"):
+                continue
+            parts = line.split(",")
+            if len(parts) < 3:
+                continue
+            tribunal = parts[0].upper()
+            date_str = parts[1]
+            ia_status = parts[2]
+            if ia_status != "uploaded":
+                continue
+            updated_at = parts[5] if len(parts) > 5 else now_str
+            year = date_str[:4]
+            filename = f"djen-{date_str}-{tribunal}.zip"
+            item_id = f"djen-{tribunal.lower()}-{year}"
+            rows.append({
+                "date": date_str,
+                "tribunal": tribunal,
+                "zip_url": f"https://archive.org/download/{item_id}/{filename}",
+                "downloaded_at": updated_at,
+            })
+    except Exception as e:
+        logger.exception("error_reading_sync_manifest", error=str(e))
+        return []
 
-                if status == "uploaded":
-                    year = date_str[:4]
-                    filename = f"djen-{date_str}-{tribunal.upper()}.zip"
-                    item_id = f"djen-{tribunal.lower()}-{year}"
-                    row = {
-                        "date": date_str,
-                        "tribunal": tribunal.upper(),
-                        "zip_url": f"https://archive.org/download/{item_id}/{filename}",
-                        "downloaded_at": now_str,
-                    }
-                    if duration_s is not None:
-                        row["duration_s"] = duration_s
-                    new_rows.append(row)
-
-    return new_rows
+    logger.info("new_uploads_from_sync_manifest", count=len(rows))
+    return rows
 
 
 def main() -> int:

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -71,12 +71,14 @@ def get_new_uploads() -> list[dict]:
             year = date_str[:4]
             filename = f"djen-{date_str}-{tribunal}.zip"
             item_id = f"djen-{tribunal.lower()}-{year}"
-            rows.append({
-                "date": date_str,
-                "tribunal": tribunal,
-                "zip_url": f"https://archive.org/download/{item_id}/{filename}",
-                "downloaded_at": updated_at,
-            })
+            rows.append(
+                {
+                    "date": date_str,
+                    "tribunal": tribunal,
+                    "zip_url": f"https://archive.org/download/{item_id}/{filename}",
+                    "downloaded_at": updated_at,
+                }
+            )
     except Exception as e:
         logger.exception("error_reading_sync_manifest", error=str(e))
         return []

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -51,6 +51,8 @@ DJEN_START_DATE = date(2024, 1, 1)
 
 IA_CATALOG_ITEM = "causaganha-catalog"
 
+SYNC_MANIFEST_PATH = Path("data/sync-manifest.csv")
+
 # Known table names from consolidation output
 KNOWN_TABLE_NAMES = {
     "comunicacoes",
@@ -62,6 +64,7 @@ KNOWN_TABLE_NAMES = {
     "advogado_nomes",
     "processos",
     "representacoes",
+    "classificacoes",
 }
 
 # Cache for tribunal stopped checks (tribunal -> date -> bool)
@@ -111,31 +114,53 @@ def run_ia_command(args: list[str], timeout: int = 300) -> str:
         return output
 
 
-def get_items_from_ia_state(state_file: Path | str = "data/ia-state.json") -> list[str]:
-    """Get list of item IDs modified in the current run from ia-state.json."""
-    path = Path(state_file)
-    if not path.exists():
-        logger.info("ia_state_not_found", path=str(path))
+def get_items_from_sync_manifest(
+    manifest_path: Path = SYNC_MANIFEST_PATH,
+) -> list[str]:
+    """Get IA item IDs from sync-manifest.csv (uploaded entries only).
+
+    Replaces the old get_items_from_ia_state() which read the deprecated
+    ia-state.json. The new djen-backup engine writes to sync-manifest.csv
+    using the canonical item format djen-{tribunal.lower()}-{year}.
+    """
+    if not manifest_path.exists():
+        logger.info("sync_manifest_not_found", path=str(manifest_path))
         return []
 
+    item_ids: set[str] = set()
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        entries = data.get("entries", {})
-        items = [f"djen-{date_str}" for date_str in entries]
-        logger.info("loaded_items_from_ia_state", count=len(items))
-        return items
+        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("tribunal"):
+                continue
+            parts = line.split(",")
+            if len(parts) < 3:
+                continue
+            tribunal = parts[0].lower()
+            date_str = parts[1]
+            ia_status = parts[2]
+            if ia_status == "uploaded" and len(date_str) >= 4:
+                item_ids.add(f"djen-{tribunal}-{date_str[:4]}")
     except Exception as e:
-        logger.warning("failed_to_parse_ia_state", error=str(e))
+        logger.warning("failed_to_parse_sync_manifest", error=str(e))
         return []
+
+    items = sorted(item_ids)
+    logger.info("loaded_items_from_sync_manifest", count=len(items))
+    return items
 
 
 def list_ia_items() -> list[str]:
     """List all djen-* items from Internet Archive.
 
+    Covers both item formats:
+      - New: djen-{tribunal}-{year}  (e.g. djen-tjro-2025)
+      - Old: djen-{YYYY-MM-DD}       (e.g. djen-2026-01-15)
+
     Returns empty list on error - caller should handle gracefully.
     """
     logger.info("listing_ia_items")
-    output = run_ia_command(["search", "identifier:djen-20*", "--itemlist"])
+    output = run_ia_command(["search", "identifier:djen-*", "--itemlist"])
 
     if not output:
         logger.warning("no_items_found_or_error")
@@ -247,51 +272,40 @@ def get_local_coverage(con: duckdb.DuckDBPyConnection) -> set[tuple[str, str]]:
         return set()
 
 
-def generate_collect_progress(con: duckdb.DuckDBPyConnection) -> dict:
+def generate_collect_progress(
+    sync_manifest_path: Path = SYNC_MANIFEST_PATH,
+) -> dict:
     """Generate download (collect) progress metrics for dashboard.
 
-    Based on djen_state.coverage table (what was downloaded/attempted).
+    Reads sync-manifest.csv (written by djen-backup/engine.py) instead of the
+    old djen_state.coverage DuckDB table which is no longer populated.
     """
-    # Check if table exists
-    try:
-        con.execute("SELECT 1 FROM djen_state.coverage LIMIT 1")
-    except duckdb.CatalogException:
-        # Table doesn't exist, return empty stats
-        return {
-            "oldest_date": None,
-            "newest_date": None,
-            "unique_days": 0,
-            "total_items": 0,
-            "target_range": {"start": "2024-01-01", "end": "2026-02-03", "total_days": 764},
-            "progress_pct": 0.0,
-            "last_updated": datetime.now(UTC).isoformat(),
-        }
-
-    result = con.execute("""
-        SELECT
-            MIN(date) as oldest_date,
-            MAX(date) as newest_date,
-            COUNT(DISTINCT date) as unique_days,
-            COUNT(*) as total_items
-        FROM djen_state.coverage
-    """).fetchone()
-
     target_start = date(2024, 1, 1)
-    target_end = date(2026, 2, 3)
+    target_end = date.today()
     target_days = (target_end - target_start).days + 1
 
-    oldest_date = result[0] or None
-    newest_date = result[1] or None
-    unique_days = result[2] or 0
-    total_items = result[3] or 0
+    uploaded_dates: set[str] = set()
+    if sync_manifest_path.exists():
+        try:
+            for line in sync_manifest_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith("tribunal"):
+                    continue
+                parts = line.split(",")
+                if len(parts) >= 3 and parts[2] == "uploaded":
+                    uploaded_dates.add(parts[1])
+        except Exception as e:
+            logger.warning("collect_progress_manifest_read_failed", error=str(e))
 
-    progress_pct = (unique_days / target_days * 100) if unique_days > 0 else 0
+    unique_days = len(uploaded_dates)
+    dates_sorted = sorted(uploaded_dates) if uploaded_dates else []
+    progress_pct = (unique_days / target_days * 100) if unique_days > 0 else 0.0
 
     return {
-        "oldest_date": str(oldest_date) if oldest_date else None,
-        "newest_date": str(newest_date) if newest_date else None,
+        "oldest_date": dates_sorted[0] if dates_sorted else None,
+        "newest_date": dates_sorted[-1] if dates_sorted else None,
         "unique_days": unique_days,
-        "total_items": total_items,
+        "total_items": unique_days,
         "target_range": {
             "start": str(target_start),
             "end": str(target_end),
@@ -657,13 +671,22 @@ def load_existing_manifest() -> list[dict]:
 
 
 def get_item_date(item_id: str) -> date | None:
-    """Extract date from item identifier (e.g. djen-2026-01-06)."""
+    """Extract date from item identifier.
+
+    Handles two formats:
+      - Old: djen-2026-01-06  → returns 2026-01-06
+      - New: djen-tjro-2025   → returns None (no specific date in ID)
+    """
     if not item_id.startswith("djen-"):
         return None
     try:
-        # djen-YYYY-MM-DD
-        date_str = item_id.replace("djen-", "")[:10]
-        return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC).date()
+        suffix = item_id[len("djen-"):]
+        # Old format: suffix starts with a digit (year)
+        if suffix[:1].isdigit():
+            date_str = suffix[:10]
+            return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC).date()
+        # New format: djen-{tribunal}-{year} — no specific date available
+        return None
     except Exception:
         return None
 
@@ -1272,7 +1295,7 @@ def main() -> int:
             # Infer existing items from the manifest
             existing_items = {m.get("ia_item") for m in existing_manifest if m.get("ia_item")}
             # Add new items modified in the current run
-            new_items = set(get_items_from_ia_state())
+            new_items = set(get_items_from_sync_manifest())
             # We must pass all known items to generate_manifest so it preserves
             # the unchanged ones while processing the new/modified ones
             items = list(existing_items | new_items)
@@ -1347,30 +1370,21 @@ def main() -> int:
     # Generate backfill progress metrics for dashboard
     logger.info("generating_backfill_progress")
 
-    # We need to connect to the main DB to get coverage stats
-    # It might not exist if running fresh, handle gracefully
-    main_db_path = Path("data/causaganha.duckdb")
-    # Generate collect progress (downloads)
+    # Generate collect progress (downloads) from sync-manifest.csv
     collect_progress_path = None
-    if main_db_path.exists():
-        try:
-            # Open read-only
-            con = duckdb.connect(str(main_db_path), read_only=True)
-            collect_data = generate_collect_progress(con)
-            con.close()
+    try:
+        collect_data = generate_collect_progress()
 
-            # Save current state (JSON)
-            collect_progress_path = output_dir / "collect-progress.json"
-            collect_progress_path.write_text(json.dumps(collect_data, ensure_ascii=False, indent=2))
-            logger.info("collect_progress_saved", path=str(collect_progress_path))
+        # Save current state (JSON)
+        collect_progress_path = output_dir / "collect-progress.json"
+        collect_progress_path.write_text(json.dumps(collect_data, ensure_ascii=False, indent=2))
+        logger.info("collect_progress_saved", path=str(collect_progress_path))
 
-            # Append to history (JSONL)
-            collect_history_path = output_dir / "collect-progress.jsonl"
-            append_progress_jsonl(collect_history_path, collect_data)
-        except Exception as e:
-            logger.exception("collect_progress_failed", error=str(e))
-    else:
-        logger.warning("main_db_not_found", path=str(main_db_path))
+        # Append to history (JSONL)
+        collect_history_path = output_dir / "collect-progress.jsonl"
+        append_progress_jsonl(collect_history_path, collect_data)
+    except Exception as e:
+        logger.exception("collect_progress_failed", error=str(e))
 
     # Generate consolidate progress (parquets)
     consolidate_data = generate_consolidate_progress(manifest)

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -680,7 +680,7 @@ def get_item_date(item_id: str) -> date | None:
     if not item_id.startswith("djen-"):
         return None
     try:
-        suffix = item_id[len("djen-"):]
+        suffix = item_id[len("djen-") :]
         # Old format: suffix starts with a digit (year)
         if suffix[:1].isdigit():
             date_str = suffix[:10]

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -281,7 +281,7 @@ def generate_collect_progress(
     old djen_state.coverage DuckDB table which is no longer populated.
     """
     target_start = date(2024, 1, 1)
-    target_end = date.today()
+    target_end = datetime.now(tz=UTC).date()
     target_days = (target_end - target_start).days + 1
 
     uploaded_dates: set[str] = set()

--- a/scripts/generate_dashboard_cache.py
+++ b/scripts/generate_dashboard_cache.py
@@ -31,7 +31,6 @@ Outputs:
 
 import argparse
 import contextlib
-import csv
 import json
 import os
 import sys
@@ -41,7 +40,6 @@ import urllib.error
 import urllib.request
 from datetime import UTC, datetime, timedelta
 from datetime import date as date_type
-from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -61,8 +59,7 @@ IA_SEARCH_URL = (
     "&fl[]=identifier&fl[]=item_size"
     "&rows=10000&output=json"
 )
-IA_STATE_URL = "https://archive.org/download/causaganha-dashboard/ia-state.json"
-IA_ZIP_INVENTORY_URL = "https://archive.org/download/causaganha-dashboard/zip-inventory.txt"
+SYNC_MANIFEST_PATH = Path("data/sync-manifest.csv")
 
 TRIBUNALS = [
     "STF",
@@ -132,38 +129,33 @@ TRIBUNALS = [
 
 
 def load_absent_coverage_from_ia_state(
-    state_path: Path = Path("data/ia-state.json"),
+    sync_manifest_path: Path = SYNC_MANIFEST_PATH,
 ) -> dict[str, list[str]]:
-    """Load absent coverage from ia-state.json (local file or IA download URL)."""
-    state_data: dict[str, Any] | None = None
-
-    if state_path.exists():
-        with contextlib.suppress(OSError, json.JSONDecodeError):
-            state_data = json.loads(state_path.read_text(encoding="utf-8"))
-
-    if state_data is None:
-        state_data = fetch_json(IA_STATE_URL)
-
-    if not state_data:
-        return {}
-
-    entries = state_data.get("entries")
-    if not isinstance(entries, dict):
+    """Load absent coverage from sync-manifest.csv (replaces ia-state.json)."""
+    if not sync_manifest_path.exists():
         return {}
 
     absent_coverage: dict[str, list[str]] = {}
-    for date_key, tribunals in entries.items():
-        if not isinstance(date_key, str) or not isinstance(tribunals, dict):
-            continue
-        # Validate date format to prevent ValueError in downstream strptime calls
-        try:
-            datetime.strptime(date_key, "%Y-%m-%d")
-        except ValueError:
-            continue
-        for tribunal_code, status in tribunals.items():
-            if status != "absent" or not isinstance(tribunal_code, str):
+    try:
+        for line in sync_manifest_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("tribunal"):
                 continue
-            absent_coverage.setdefault(tribunal_code, []).append(date_key)
+            parts = line.split(",")
+            if len(parts) < 4:
+                continue
+            tribunal = parts[0].strip().upper()
+            date_str = parts[1].strip()
+            djen_status = parts[3].strip()
+            if not tribunal or not date_str or djen_status != "absent":
+                continue
+            try:
+                datetime.strptime(date_str, "%Y-%m-%d")
+            except ValueError:
+                continue
+            absent_coverage.setdefault(tribunal, []).append(date_str)
+    except OSError:
+        return {}
 
     return absent_coverage
 
@@ -182,52 +174,40 @@ def fetch_json(url: str, timeout: int = 30) -> dict[str, Any] | None:
         return None
 
 
-def fetch_text(url: str, timeout: int = 30) -> str | None:
-    """Fetch text from URL with error handling."""
-    try:
-        req = urllib.request.Request(
-            url,
-            headers={"User-Agent": "CausaGanha-Dashboard/3.0"},
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as response:
-            return response.read().decode()
-    except (UnicodeDecodeError, urllib.error.URLError, urllib.error.HTTPError):
-        return None
-
-
 def load_zip_inventory(
-    inventory_path: Path = Path("data/zip-inventory.txt"),
+    sync_manifest_path: Path = SYNC_MANIFEST_PATH,
 ) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
-    """Load uploaded/absent coverage from zip inventory, preferring local disk."""
-    inventory_text = None
-    if inventory_path.exists():
-        with contextlib.suppress(OSError):
-            inventory_text = inventory_path.read_text(encoding="utf-8")
-
-    if inventory_text is None:
-        inventory_text = fetch_text(IA_ZIP_INVENTORY_URL)
-
-    if not inventory_text:
+    """Load uploaded/absent coverage from sync-manifest.csv (replaces zip-inventory.txt)."""
+    if not sync_manifest_path.exists():
         return {}, {}
 
     uploaded: dict[str, set[str]] = {}
     absent: dict[str, set[str]] = {}
 
-    for row in csv.DictReader(StringIO(inventory_text)):
-        tribunal = str(row.get("tribunal", "")).strip().upper()
-        date_str = str(row.get("date", "")).strip()
-        status = str(row.get("status", "")).strip().lower()
-        if not tribunal or not date_str or status not in {"uploaded", "absent"}:
-            continue
-
-        # Validate date format before storing to avoid ValueError in strptime downstream
-        try:
-            datetime.strptime(date_str, "%Y-%m-%d")
-        except ValueError:
-            continue
-
-        target = uploaded if status == "uploaded" else absent
-        target.setdefault(tribunal, set()).add(date_str)
+    try:
+        for line in sync_manifest_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("tribunal"):
+                continue
+            parts = line.split(",")
+            if len(parts) < 4:
+                continue
+            tribunal = parts[0].strip().upper()
+            date_str = parts[1].strip()
+            ia_status = parts[2].strip()
+            djen_status = parts[3].strip()
+            if not tribunal or not date_str:
+                continue
+            try:
+                datetime.strptime(date_str, "%Y-%m-%d")
+            except ValueError:
+                continue
+            if ia_status == "uploaded":
+                uploaded.setdefault(tribunal, set()).add(date_str)
+            elif djen_status == "absent":
+                absent.setdefault(tribunal, set()).add(date_str)
+    except OSError:
+        return {}, {}
 
     return uploaded, absent
 

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -116,9 +116,12 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
     in list_zips_for_date() when manifest.parquet has not yet been regenerated.
 
     Returns:
-        Dict mapping date_str → list of ZIP entries with keys:
-        ``tribunal``, ``item_id``, ``filename``.
-        Only ``ia_status=uploaded`` entries are included.
+        Dict mapping date_str → list of entries with keys:
+        ``tribunal``, ``item_id``, ``filename``, ``absent``.
+        Includes BOTH uploaded (ia_status=uploaded) and confirmed-absent
+        (djen_status=absent) entries so that present_count in list_zips_for_date()
+        correctly mirrors the manifest.parquet behaviour (which counts .absent files
+        as "present" for the completeness check).
         Empty dict if file does not exist.
     """
     if not path.exists():
@@ -137,20 +140,28 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
             tribunal = parts[0].upper()
             date_str = parts[1]
             ia_status = parts[2]
-            if ia_status != "uploaded":
-                continue
-            year = date_str[:4]
-            item_id = f"djen-{tribunal.lower()}-{year}"
-            filename = f"djen-{date_str}-{tribunal}.zip"
-            by_date.setdefault(date_str, []).append(
-                {"tribunal": tribunal, "item_id": item_id, "filename": filename}
-            )
+            djen_status = parts[3] if len(parts) > 3 else ""
+
+            if ia_status == "uploaded":
+                year = date_str[:4]
+                item_id = f"djen-{tribunal.lower()}-{year}"
+                filename = f"djen-{date_str}-{tribunal}.zip"
+                by_date.setdefault(date_str, []).append(
+                    {"tribunal": tribunal, "item_id": item_id, "filename": filename, "absent": False}
+                )
+            elif djen_status == "absent":
+                # Tribunal confirmed no publication on this date — counts as "present"
+                # for the completeness check but produces no ZIP to download.
+                by_date.setdefault(date_str, []).append(
+                    {"tribunal": tribunal, "item_id": "", "filename": "", "absent": True}
+                )
     except Exception as e:
         logger.warning("sync_manifest_load_failed", path=str(path), error=str(e))
         return {}
 
-    total = sum(len(v) for v in by_date.values())
-    logger.info("sync_manifest_loaded", dates=len(by_date), total_zips=total)
+    total_zips = sum(1 for v in by_date.values() for e in v if not e["absent"])
+    total_absent = sum(1 for v in by_date.values() for e in v if e["absent"])
+    logger.info("sync_manifest_loaded", dates=len(by_date), total_zips=total_zips, total_absent=total_absent)
     return by_date
 
 
@@ -484,17 +495,19 @@ def list_zips_for_date(
     # 2. sync-manifest.csv (fast, avoids per-tribunal IA API calls)
     if sync_manifest is not None:
         entries = sync_manifest.get(date, [])
+        present_count = len(entries)  # includes both uploaded ZIPs and confirmed-absent
         for e in entries:
-            zips.append(
-                {
-                    "filename": e["filename"],
-                    "tribunal": e["tribunal"],
-                    "item_id": e["item_id"],
-                    "size": 0,
-                }
-            )
-        logger.info("zips_from_sync_manifest", date=date, count=len(zips))
-        return zips, len(zips)
+            if not e["absent"]:
+                zips.append(
+                    {
+                        "filename": e["filename"],
+                        "tribunal": e["tribunal"],
+                        "item_id": e["item_id"],
+                        "size": 0,
+                    }
+                )
+        logger.info("zips_from_sync_manifest", date=date, zips=len(zips), present=present_count)
+        return zips, present_count
 
     # 3. IA metadata API per tribunal (slow fallback — only used if both sources absent)
     present = set()

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -147,7 +147,12 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
                 item_id = f"djen-{tribunal.lower()}-{year}"
                 filename = f"djen-{date_str}-{tribunal}.zip"
                 by_date.setdefault(date_str, []).append(
-                    {"tribunal": tribunal, "item_id": item_id, "filename": filename, "absent": False}
+                    {
+                        "tribunal": tribunal,
+                        "item_id": item_id,
+                        "filename": filename,
+                        "absent": False,
+                    }
                 )
             elif djen_status == "absent":
                 # Tribunal confirmed no publication on this date — counts as "present"
@@ -161,7 +166,9 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
 
     total_zips = sum(1 for v in by_date.values() for e in v if not e["absent"])
     total_absent = sum(1 for v in by_date.values() for e in v if e["absent"])
-    logger.info("sync_manifest_loaded", dates=len(by_date), total_zips=total_zips, total_absent=total_absent)
+    logger.info(
+        "sync_manifest_loaded", dates=len(by_date), total_zips=total_zips, total_absent=total_absent
+    )
     return by_date
 
 
@@ -1899,7 +1906,9 @@ def main() -> int:
                 if elapsed > deadline_sec - 120:
                     break
 
-            target_date_or_none = find_next_unconsolidated(manifest, ctx=ctx, sync_manifest=sync_manifest)
+            target_date_or_none = find_next_unconsolidated(
+                manifest, ctx=ctx, sync_manifest=sync_manifest
+            )
             if target_date_or_none is None:
                 break
 

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -104,6 +104,55 @@ class ConsolidationContext:
 # Checkpoint state file path
 _CHECKPOINT_STATE_FILE = Path("data/consolidate-checkpoint.json")
 
+# Sync manifest path (written by djen-backup/engine.py)
+_SYNC_MANIFEST_FILE = Path("data/sync-manifest.csv")
+
+
+def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[str, Any]]]:
+    """Load sync-manifest.csv into a by-date lookup.
+
+    The sync-manifest is the canonical state written by djen-backup/engine.py.
+    Using it as an intermediate source avoids the slow IA metadata API fallback
+    in list_zips_for_date() when manifest.parquet has not yet been regenerated.
+
+    Returns:
+        Dict mapping date_str → list of ZIP entries with keys:
+        ``tribunal``, ``item_id``, ``filename``.
+        Only ``ia_status=uploaded`` entries are included.
+        Empty dict if file does not exist.
+    """
+    if not path.exists():
+        logger.info("sync_manifest_not_found", path=str(path))
+        return {}
+
+    by_date: dict[str, list[dict[str, Any]]] = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("tribunal"):
+                continue
+            parts = line.split(",")
+            if len(parts) < 3:
+                continue
+            tribunal = parts[0].upper()
+            date_str = parts[1]
+            ia_status = parts[2]
+            if ia_status != "uploaded":
+                continue
+            year = date_str[:4]
+            item_id = f"djen-{tribunal.lower()}-{year}"
+            filename = f"djen-{date_str}-{tribunal}.zip"
+            by_date.setdefault(date_str, []).append(
+                {"tribunal": tribunal, "item_id": item_id, "filename": filename}
+            )
+    except Exception as e:
+        logger.warning("sync_manifest_load_failed", path=str(path), error=str(e))
+        return {}
+
+    total = sum(len(v) for v in by_date.values())
+    logger.info("sync_manifest_loaded", dates=len(by_date), total_zips=total)
+    return by_date
+
 
 def load_checkpoint_state() -> dict[str, Any]:
     """Load checkpoint state from disk.
@@ -234,23 +283,29 @@ def fetch_manifest_records() -> list[dict]:
         return records
 
 
-def fetch_consolidation_candidates(manifest: list[dict] | None = None) -> list[str]:
-    """Fetch dates needing consolidation from catalog manifest.
+def fetch_consolidation_candidates(
+    manifest: list[dict] | None = None,
+    sync_manifest: dict[str, list[dict[str, Any]]] | None = None,
+) -> list[str]:
+    """Fetch dates needing consolidation.
 
-    If manifest is provided (in-memory), queries it using DuckDB.
-    Otherwise, downloads it from IA first.
-    Returns dates sorted by date descending (newest first).
+    Priority order:
+      1. manifest.parquet (in-memory or downloaded from IA) — authoritative,
+         knows exactly which dates have ZIPs and which already have Parquets.
+      2. sync-manifest.csv (local file) — fast fallback: dates with uploaded
+         ZIPs that are not yet in the consolidation checkpoint.
+    Returns dates sorted descending (newest first).
     """
-    if manifest is None:
-        manifest_url = "https://archive.org/download/causaganha-catalog/manifest.parquet"
-        logger.info("fetching_consolidation_candidates_from_url", url=manifest_url)
-        # For simplicity in this case, we use the URL directly in DuckDB
+    # 1a. In-memory manifest (already fetched)
+    if manifest is not None:
+        logger.info("fetching_consolidation_candidates_from_memory", records=len(manifest))
         con = duckdb.connect()
-        con.execute("INSTALL httpfs; LOAD httpfs;")
         try:
+            df_data = [{"date": m["date"], "file_type": m["file_type"]} for m in manifest]
+            df = pd.DataFrame(df_data)  # noqa: F841
             query = """
                 SELECT date
-                FROM read_parquet('https://archive.org/download/causaganha-catalog/manifest.parquet')
+                FROM df
                 GROUP BY date
                 HAVING SUM(CASE WHEN file_type='zip' THEN 1 ELSE 0 END) > 0
                    AND SUM(CASE WHEN file_type='parquet' THEN 1 ELSE 0 END) = 0
@@ -259,36 +314,52 @@ def fetch_consolidation_candidates(manifest: list[dict] | None = None) -> list[s
             result = con.execute(query).fetchall()
             return [str(r[0]) for r in result]
         except Exception as e:
-            logger.warning("fetch_candidates_failed", error=str(e))
+            logger.warning("fetch_candidates_failed_memory", error=str(e))
             return []
         finally:
             con.close()
 
-    # Use in-memory manifest
-    logger.info("fetching_consolidation_candidates_from_memory", records=len(manifest))
+    # 1b. Download manifest.parquet from IA and query it
+    manifest_url = "https://archive.org/download/causaganha-catalog/manifest.parquet"
+    logger.info("fetching_consolidation_candidates_from_url", url=manifest_url)
     con = duckdb.connect()
     try:
-        # Load manifest list into a DuckDB table
-        # We only need date and file_type
-        df_data = [{"date": m["date"], "file_type": m["file_type"]} for m in manifest]
-
-        df = pd.DataFrame(df_data)  # noqa: F841
-
+        con.execute("INSTALL httpfs; LOAD httpfs;")
         query = """
             SELECT date
-            FROM df
+            FROM read_parquet('https://archive.org/download/causaganha-catalog/manifest.parquet')
             GROUP BY date
             HAVING SUM(CASE WHEN file_type='zip' THEN 1 ELSE 0 END) > 0
                AND SUM(CASE WHEN file_type='parquet' THEN 1 ELSE 0 END) = 0
             ORDER BY date DESC
         """
         result = con.execute(query).fetchall()
-        return [str(r[0]) for r in result]
+        candidates = [str(r[0]) for r in result]
+        if candidates:
+            logger.info("candidates_from_manifest_parquet", count=len(candidates))
+            return candidates
     except Exception as e:
-        logger.warning("fetch_candidates_failed_memory", error=str(e))
-        return []
+        logger.warning("fetch_candidates_from_manifest_parquet_failed", error=str(e))
     finally:
         con.close()
+
+    # 2. Fallback: sync-manifest.csv — dates uploaded but not yet consolidated
+    if sync_manifest:
+        checkpoint = load_checkpoint_state()
+        completed = set(checkpoint.get("completed_dates", []))
+        candidates = sorted(
+            (d for d in sync_manifest if d not in completed),
+            reverse=True,
+        )
+        logger.info(
+            "candidates_from_sync_manifest",
+            total_dates=len(sync_manifest),
+            completed=len(completed),
+            candidates=len(candidates),
+        )
+        return candidates
+
+    return []
 
 
 class CheckpointManager:
@@ -378,16 +449,21 @@ def list_local_zips(directory: str) -> tuple[list[dict[str, Any]], int]:
 
 
 def list_zips_for_date(
-    date: str, manifest: list[dict] | None = None
+    date: str,
+    manifest: list[dict] | None = None,
+    sync_manifest: dict[str, list[dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     """Find all ZIP files for a specific date on IA.
 
-    If manifest is provided, use it (fast). Otherwise use IA metadata API (slow).
+    Priority order (fastest → slowest):
+      1. manifest.parquet records (in-memory, already fetched)
+      2. sync-manifest.csv records (local file, O(1) lookup)
+      3. IA metadata API per tribunal (slow — 40+ HTTP calls, avoid)
     """
     logger.info("listing_zips", date=date)
     zips: list[dict[str, Any]] = []
 
-    # 1. Use manifest if available (fast)
+    # 1. manifest.parquet (fast, already in memory)
     if manifest:
         files = [m for m in manifest if m["date"] == date]
         present = set()
@@ -400,12 +476,27 @@ def list_zips_for_date(
                             "filename": f["file_name"],
                             "tribunal": f["tribunal"],
                             "item_id": f["ia_item"],
-                            "size": 0,  # manifest doesn't have size currently
+                            "size": 0,
                         }
                     )
         return zips, len(present)
 
-    # 2. Use IA metadata API (slow fallback)
+    # 2. sync-manifest.csv (fast, avoids per-tribunal IA API calls)
+    if sync_manifest is not None:
+        entries = sync_manifest.get(date, [])
+        for e in entries:
+            zips.append(
+                {
+                    "filename": e["filename"],
+                    "tribunal": e["tribunal"],
+                    "item_id": e["item_id"],
+                    "size": 0,
+                }
+            )
+        logger.info("zips_from_sync_manifest", date=date, count=len(zips))
+        return zips, len(zips)
+
+    # 3. IA metadata API per tribunal (slow fallback — only used if both sources absent)
     present = set()
     for tribunal in TRIBUNAIS:
         item_id = get_ia_item_id(tribunal, date)
@@ -437,7 +528,7 @@ def list_zips_for_date(
         except Exception as e:
             logger.warning("metadata_fetch_failed", item_id=item_id, error=str(e))
 
-    logger.info("zips_found", count=len(zips), date=date)
+    logger.info("zips_found_via_api", count=len(zips), date=date)
     return zips, len(present)
 
 
@@ -1301,11 +1392,12 @@ def find_next_unconsolidated(
     manifest: list[dict] | None = None,
     checkpoint_file: Path | None = None,
     ctx: ConsolidationContext | None = None,
+    sync_manifest: dict[str, list[dict[str, Any]]] | None = None,
 ) -> str | None:
     """Find the most recent date needing consolidation.
 
     First tries to fetch candidates from the catalog manifest (fast).
-    Falls back to walking backward from today (slow) if manifest is unavailable.
+    Falls back to sync-manifest.csv, then to walking backward from today (slow).
 
     Returns the date string or None if everything is consolidated.
     """
@@ -1314,7 +1406,7 @@ def find_next_unconsolidated(
 
     # 1. Try manifest-based discovery (fast, minimal API calls)
     if ctx.consolidation_candidates is None:
-        ctx.consolidation_candidates = fetch_consolidation_candidates(manifest)
+        ctx.consolidation_candidates = fetch_consolidation_candidates(manifest, sync_manifest)
 
     if ctx.consolidation_candidates:
         while ctx.consolidation_candidates:
@@ -1518,6 +1610,7 @@ def consolidate_date(
     date: str,
     manifest: list[dict] | None = None,
     *,
+    sync_manifest: dict[str, list[dict[str, Any]]] | None = None,
     dry_run: bool = False,
     force: bool = False,
     local_zips: str | None = None,
@@ -1528,7 +1621,8 @@ def consolidate_date(
 
     Args:
         date: Date string in YYYY-MM-DD format.
-        manifest: In-memory manifest of IA files.
+        manifest: In-memory manifest.parquet records (fastest source).
+        sync_manifest: In-memory sync-manifest.csv records (fast fallback).
         dry_run: If True, skip uploading to Internet Archive.
         force: If True, consolidate even if the day is incomplete.
         local_zips: Local directory containing ZIPs (for testing).
@@ -1558,7 +1652,7 @@ def consolidate_date(
         zips, present_count = list_local_zips(local_zips)
         logger.info("using_local_zips", directory=local_zips, count=len(zips))
     else:
-        zips, present_count = list_zips_for_date(date, manifest)
+        zips, present_count = list_zips_for_date(date, manifest, sync_manifest)
 
     # Filter out already processed ZIPs
     original_count = len(zips)
@@ -1750,14 +1844,14 @@ def main() -> int:
         "uploaded_mb": 0.0,
     }
 
-    # Fetch manifest once if in backfill mode or scanning needed
+    # Load sync-manifest.csv (written by djen-backup, available after download-state step)
+    # Used as fallback when manifest.parquet is unavailable or stale.
+    sync_manifest = load_sync_manifest()
+
+    # Fetch manifest.parquet once if in backfill mode or scanning needed
     manifest = None
     if args.backfill or not args.date:
         manifest = fetch_manifest_records()
-        if manifest:
-            pass
-        else:
-            pass
 
     if args.date:
         # Explicit date — existing behaviour
@@ -1765,6 +1859,7 @@ def main() -> int:
             stats = consolidate_date(
                 args.date,
                 manifest,
+                sync_manifest=sync_manifest,
                 dry_run=args.dry_run,
                 force=args.force,
                 local_zips=args.local_zips,
@@ -1776,7 +1871,6 @@ def main() -> int:
                 total_stats[k] += stats.get(k, 0)
         except Exception as e:
             logger.exception("consolidation_aborted", error=str(e))
-
             traceback.print_exc()
             return 1
 
@@ -1792,7 +1886,7 @@ def main() -> int:
                 if elapsed > deadline_sec - 120:
                     break
 
-            target_date_or_none = find_next_unconsolidated(manifest, ctx=ctx)
+            target_date_or_none = find_next_unconsolidated(manifest, ctx=ctx, sync_manifest=sync_manifest)
             if target_date_or_none is None:
                 break
 
@@ -1802,6 +1896,7 @@ def main() -> int:
                 stats = consolidate_date(
                     target_date,
                     manifest,
+                    sync_manifest=sync_manifest,
                     dry_run=args.dry_run,
                     force=args.force,
                     local_zips=args.local_zips,
@@ -1814,7 +1909,6 @@ def main() -> int:
                 dates_processed += 1
             except Exception as e:
                 logger.exception("consolidation_aborted", date=target_date, error=str(e))
-
                 traceback.print_exc()
                 # Continue to next date instead of aborting the entire run
                 dates_processed += 1
@@ -1826,6 +1920,7 @@ def main() -> int:
             stats = consolidate_date(
                 target_date,
                 manifest,
+                sync_manifest=sync_manifest,
                 dry_run=args.dry_run,
                 force=args.force,
                 local_zips=args.local_zips,
@@ -1837,7 +1932,6 @@ def main() -> int:
                 total_stats[k] += stats.get(k, 0)
         except Exception as e:
             logger.exception("consolidation_aborted", error=str(e))
-
             traceback.print_exc()
             return 1
 

--- a/tests/test_catalog_parsing.py
+++ b/tests/test_catalog_parsing.py
@@ -1,45 +1,45 @@
-import json
 import tempfile
 from datetime import date
 from pathlib import Path
 
 from scripts.generate_catalog import (
     calculate_completed_items,
-    get_items_from_ia_state,
+    get_items_from_sync_manifest,
     is_complete,
     needs_listing,
     parse_filename,
 )
 
 
-def test_get_items_from_ia_state() -> None:
+def test_get_items_from_sync_manifest() -> None:
     # 1. Missing file
-    res = get_items_from_ia_state("non_existent_file.json")
+    res = get_items_from_sync_manifest(Path("non_existent_sync_manifest.csv"))
     assert res == []
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        state_file = Path(tmpdir) / "ia-state.json"
+        manifest_file = Path(tmpdir) / "sync-manifest.csv"
 
-        # 2. Valid file with multiple entries
-        state_data = {
-            "version": 2,
-            "entries": {
-                "2026-01-01": {"TJSP": "uploaded"},
-                "2026-01-02": {"TJMG": "uploaded"},
-            },
-        }
-        state_file.write_text(json.dumps(state_data))
-        res = get_items_from_ia_state(state_file)
-        assert sorted(res) == ["djen-2026-01-01", "djen-2026-01-02"]
+        # 2. Valid CSV with multiple uploaded entries across tribunals/years
+        manifest_file.write_text(
+            "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
+            "TJSP,2026-01-01,uploaded,available,200,2026-01-01T10:00:00Z\n"
+            "TJMG,2026-01-02,uploaded,available,200,2026-01-02T10:00:00Z\n"
+            "TJRO,2025-12-31,uploaded,available,200,2025-12-31T10:00:00Z\n"
+        )
+        res = get_items_from_sync_manifest(manifest_file)
+        assert sorted(res) == ["djen-tjmg-2026", "djen-tjro-2025", "djen-tjsp-2026"]
 
-        # 3. Invalid JSON file
-        state_file.write_text("invalid json")
-        res = get_items_from_ia_state(state_file)
+        # 3. Only non-uploaded entries → empty
+        manifest_file.write_text(
+            "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
+            "TJSP,2026-01-01,pending,available,200,2026-01-01T10:00:00Z\n"
+        )
+        res = get_items_from_sync_manifest(manifest_file)
         assert res == []
 
-        # 4. Valid JSON but missing entries
-        state_file.write_text(json.dumps({"version": 2}))
-        res = get_items_from_ia_state(state_file)
+        # 4. Empty file (header only) → empty
+        manifest_file.write_text("tribunal,date,ia_status,djen_status,djen_raw,updated_at\n")
+        res = get_items_from_sync_manifest(manifest_file)
         assert res == []
 
 

--- a/tests/test_generate_dashboard_cache.py
+++ b/tests/test_generate_dashboard_cache.py
@@ -1,9 +1,7 @@
-import json
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
 
 
 script_path = Path("scripts/generate_dashboard_cache.py")
@@ -16,37 +14,26 @@ spec.loader.exec_module(generate_dashboard_cache)
 
 
 def test_load_absent_coverage_from_ia_state_local_file(tmp_path: Path) -> None:
-    state_path = tmp_path / "ia-state.json"
-    state_path.write_text(
-        json.dumps(
-            {
-                "version": 2,
-                "entries": {
-                    "2026-03-01": {"TJSP": "absent", "TJMG": "uploaded"},
-                    "2026-03-02": {"TJSP": "absent", "TJRO": "absent"},
-                },
-            }
-        ),
+    """load_absent_coverage_from_ia_state reads djen_status=absent from sync-manifest.csv."""
+    manifest_path = tmp_path / "sync-manifest.csv"
+    manifest_path.write_text(
+        "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
+        "TJSP,2026-03-01,uploaded,absent,404,2026-03-01T10:00:00Z\n"
+        "TJMG,2026-03-01,uploaded,available,200,2026-03-01T10:00:00Z\n"
+        "TJSP,2026-03-02,uploaded,absent,404,2026-03-02T10:00:00Z\n"
+        "TJRO,2026-03-02,uploaded,absent,404,2026-03-02T10:00:00Z\n",
         encoding="utf-8",
     )
 
-    result = generate_dashboard_cache.load_absent_coverage_from_ia_state(state_path)
+    result = generate_dashboard_cache.load_absent_coverage_from_ia_state(manifest_path)
 
     assert set(result["TJSP"]) == {"2026-03-01", "2026-03-02"}
     assert result["TJRO"] == ["2026-03-02"]
     assert "TJMG" not in result
 
 
-def test_load_absent_coverage_from_ia_state_fallback_to_remote(tmp_path: Path) -> None:
-    missing_state_path = tmp_path / "missing-ia-state.json"
-    with patch("generate_dashboard_cache.fetch_json") as mock_fetch_json:
-        mock_fetch_json.return_value = {
-            "entries": {
-                "2026-03-10": {"TRF1": "absent"},
-                "2026-03-11": {"TRF1": "uploaded", "TRF2": "absent"},
-            }
-        }
-
-        result = generate_dashboard_cache.load_absent_coverage_from_ia_state(missing_state_path)
-
-    assert result == {"TRF1": ["2026-03-10"], "TRF2": ["2026-03-11"]}
+def test_load_absent_coverage_from_ia_state_missing_file(tmp_path: Path) -> None:
+    """Missing sync-manifest.csv returns empty dict (no remote fallback)."""
+    missing_path = tmp_path / "missing-sync-manifest.csv"
+    result = generate_dashboard_cache.load_absent_coverage_from_ia_state(missing_path)
+    assert result == {}


### PR DESCRIPTION
## Description

This PR migrates the catalog generation and manifest appending scripts from reading the deprecated `ia-state.json` file to reading `sync-manifest.csv`, which is the canonical state file written by the djen-backup engine.

### Key Changes

1. **New sync manifest reader**: Added `get_items_from_sync_manifest()` to replace `get_items_from_ia_state()`, parsing CSV format with tribunal, date, and upload status columns.

2. **Updated item ID handling**: Modified `list_ia_items()` to search for `djen-*` instead of `djen-20*` to support both old (`djen-YYYY-MM-DD`) and new (`djen-{tribunal}-{year}`) item ID formats.

3. **Simplified collect progress generation**: Refactored `generate_collect_progress()` to read directly from `sync-manifest.csv` instead of querying the `djen_state.coverage` DuckDB table, eliminating the database dependency. Updated target end date to `today()` for dynamic range calculation.

4. **Enhanced date extraction**: Updated `get_item_date()` to handle both item ID formats, returning a date for old format items and `None` for new format items.

5. **Updated manifest appending**: Modified `get_new_uploads()` in `append_manifest.py` to parse the CSV format and extract upload metadata.

6. **Added "classificacoes" table**: Added missing table name to `KNOWN_TABLE_NAMES` set.

7. **Simplified main workflow**: Removed database connection requirement for collect progress generation, making the workflow more resilient when the main database doesn't exist.

### Benefits

- Eliminates dependency on deprecated `ia-state.json` format
- Reduces database I/O by reading from CSV instead of DuckDB
- Supports both old and new item ID formats during transition period
- Makes progress tracking work independently of database state

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main.

https://claude.ai/code/session_014K5iNiugmg9wtX99CBACEE