### PR TITLE
feat(workflows): add upload-backlog to drain confirmed-available ZIPs

### DIFF
--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -1,0 +1,86 @@
+# ============================================================================
+# UPLOAD BACKLOG — Drain already-confirmed-available ZIPs to Internet Archive
+# ============================================================================
+#
+# Runs in parallel with collect-zips. Skips DJEN checks entirely — only
+# processes entries where the manifest already has djen_status=available,
+# downloading from DJEN and pushing to IA. Shares state with collect-zips
+# via the manifest stored on IA.
+# ============================================================================
+
+name: Upload Backlog
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      workers:
+        description: 'Parallel workers (1-8)'
+        required: false
+        default: '4'
+      tribunal:
+        description: 'Specific tribunal (e.g. TJSP) — optional'
+        required: false
+      deadline_minutes:
+        description: 'Deadline in minutes'
+        required: false
+        default: '12'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upload-backlog
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Download + Upload confirmed-available ZIPs
+    runs-on: ubuntu-latest
+    timeout-minutes: 14
+    environment: dev
+
+    env:
+      IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+      IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+        with:
+          dev: "false"
+
+      - name: Restore manifest cache
+        uses: actions/cache/restore@v4
+        with:
+          path: data/sync-manifest.csv
+          key: sync-manifest-${{ github.run_id }}
+          restore-keys: sync-manifest-
+
+      - name: Run djen-backup upload
+        run: |
+          WORKERS="${{ github.event.inputs.workers || '4' }}"
+          DEADLINE="${{ github.event.inputs.deadline_minutes || '12' }}"
+          TRIBUNAL="${{ github.event.inputs.tribunal || '' }}"
+
+          CMD="uv run --no-dev djen-backup upload"
+          CMD="$CMD --workers $WORKERS"
+          CMD="$CMD --deadline-minutes $DEADLINE"
+          CMD="$CMD --use-proxy"
+          CMD="$CMD --no-fail-fast"
+
+          if [ -n "$TRIBUNAL" ]; then
+            CMD="$CMD --tribunal $TRIBUNAL"
+          fi
+
+          echo "Running: $CMD"
+          $CMD
+
+      - name: Save manifest cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: data/sync-manifest.csv
+          key: sync-manifest-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The engine periodically (every 10 min) uploads the manifest and a compact `manif
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| [collect-zips.yml](.github/workflows/collect-zips.yml) | Every 20 min | Download DJEN ZIPs → upload to IA |
+| [collect-zips.yml](.github/workflows/collect-zips.yml) | Every 20 min | Check DJEN + download + upload to IA |
+| [upload-backlog.yml](.github/workflows/upload-backlog.yml) | Every 15 min | Drain confirmed-available ZIPs (no DJEN checks) |
 | [collect-today.yml](.github/workflows/collect-today.yml) | Daily 06:00 UTC | Today's publications |
 | [consolidate-parquet.yml](.github/workflows/consolidate-parquet.yml) | Daily 07:00 UTC | Convert ZIPs → Parquet |
 | [update-catalog.yml](.github/workflows/update-catalog.yml) | After consolidate | Refresh catalog metadata |


### PR DESCRIPTION
## Summary

With ~30K entries already marked `djen_status=available` in the manifest but not yet uploaded to IA, running the full `check + download + upload` pipeline is wasteful — every iteration spends CloudFront-rate-limited check calls before reaching the download/upload work that actually drains the backlog.

This PR adds a dedicated `upload-backlog.yml` workflow that invokes the existing `djen-backup upload` subcommand: it skips DJEN checks entirely, pulls entries with `djen_status=available`, downloads from DJEN, and pushes to IA. Runs every 15 min in parallel with `collect-zips`; shared state flows through the manifest stored on IA.

- Cadence: `*/15 * * * *`
- Timeout: 14 min (internal deadline 12 min)
- Workers: 4 by default, configurable via `workflow_dispatch`
- Uses the same `sync-manifest-*` cache prefix for a warm start

## Test plan

- [ ] Manually dispatch the workflow and confirm it processes available entries without any DJEN check calls
- [ ] Verify `collect-zips` and `upload-backlog` don't step on each other (manifest state reconciles via IA)