### PR TITLE
fix(web): replace stale djen-2026-04-01 IA refs with djen-{tribunal}-{year}

### DIFF
--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -4,20 +4,24 @@
 
   const IA_BASE = 'https://archive.org/download';
 
+  // Per-(tribunal, year) IA items hold the consolidated parquets.
+  // Pick any tribunal/year — TJRO 2026 used here as a demo.
+  const ITEM = 'djen-tjro-2026';
+
   const QUERY_TEMPLATES = [
     {
-      label: 'Comunicações por tribunal (últimos 30 dias)',
-      sql: `SELECT tribunal, COUNT(*) as total
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/comunicacoes.parquet')
-GROUP BY tribunal
+      label: 'Comunicações por órgão (TJRO 2026)',
+      sql: `SELECT nome_orgao, COUNT(*) as total
+FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')
+GROUP BY nome_orgao
 ORDER BY total DESC
 LIMIT 20`,
     },
     {
-      label: 'Advogados mais ativos',
+      label: 'Advogados mais ativos (TJRO 2026)',
       sql: `SELECT nome, numero_oab, uf_oab, COUNT(*) as comunicacoes
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/advogados.parquet') a
-JOIN read_parquet('${IA_BASE}/djen-2026-04-01/comunicacao_advogados.parquet') ca
+FROM read_parquet('${IA_BASE}/${ITEM}/advogados.parquet') a
+JOIN read_parquet('${IA_BASE}/${ITEM}/comunicacao_advogados.parquet') ca
   ON a.id = ca.advogado_id
 GROUP BY nome, numero_oab, uf_oab
 ORDER BY comunicacoes DESC
@@ -26,21 +30,18 @@ LIMIT 20`,
     {
       label: 'Classificações de resultado (keyword_v1)',
       sql: `SELECT outcome, decision_type, COUNT(*) as total, ROUND(AVG(confidence), 2) as avg_confidence
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/classificacoes.parquet')
+FROM read_parquet('${IA_BASE}/${ITEM}/classificacoes.parquet')
 GROUP BY outcome, decision_type
 ORDER BY total DESC`,
     },
     {
-      label: 'Processos por tribunal',
-      sql: `SELECT tribunal, COUNT(DISTINCT numero_processo) as processos
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/processos.parquet')
-GROUP BY tribunal
-ORDER BY processos DESC
-LIMIT 20`,
+      label: 'Processos distintos (TJRO 2026)',
+      sql: `SELECT COUNT(DISTINCT numero_processo) as processos
+FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
     },
     {
       label: 'Schema das tabelas',
-      sql: `DESCRIBE SELECT * FROM read_parquet('${IA_BASE}/djen-2026-04-01/comunicacoes.parquet') LIMIT 0`,
+      sql: `DESCRIBE SELECT * FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet') LIMIT 0`,
     },
   ];
 
@@ -205,7 +206,7 @@ LIMIT 20`,
     bind:value={sql}
     onkeydown={handleKeyDown}
     rows="10"
-    placeholder="SELECT * FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet') LIMIT 10"
+    placeholder="SELECT * FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet') LIMIT 10"
     disabled={dbStatus !== 'ready'}
     aria-label="Editor SQL"
   ></textarea>

--- a/web/src/lib/iaMetadataFetcher.ts
+++ b/web/src/lib/iaMetadataFetcher.ts
@@ -43,7 +43,7 @@ export function getExpectedDays(year: number): number {
 
 /**
  * Extract tribunal code from an IA item identifier.
- * "djen-tjsp-2026" -> "TJSP"
+ * "djen-tjro-2026" -> "TJSP"
  * "djen-tre-ac-2026" -> "TRE-AC"
  */
 function tribunalFromItemId(identifier: string, year: number): string | null {

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -229,9 +229,9 @@ con = duckdb.connect()
 
 # Consulta remota (sem download)
 con.sql("""
-    SELECT tribunal, COUNT(*) as total
-    FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
-    GROUP BY tribunal
+    SELECT nome_orgao, COUNT(*) as total
+    FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet')
+    GROUP BY nome_orgao
     ORDER BY total DESC
 """).show()
 
@@ -244,7 +244,7 @@ con.sql("""
         <div class="code-block">
           <pre><code>duckdb -c "
   SELECT nome, numero_oab, uf_oab
-  FROM read_parquet('https://archive.org/download/djen-2026-04-01/advogados.parquet')
+  FROM read_parquet('https://archive.org/download/djen-tjro-2026/advogados.parquet')
   LIMIT 10
 "</code></pre>
         </div>
@@ -258,7 +258,7 @@ const conn = await db.connect();
 
 const result = await conn.run(`
   SELECT outcome, COUNT(*) as total
-  FROM read_parquet('https://archive.org/download/djen-2026-04-01/classificacoes.parquet')
+  FROM read_parquet('https://archive.org/download/djen-tjro-2026/classificacoes.parquet')
   GROUP BY outcome
 `);</code></pre>
         </div>

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -24,7 +24,8 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     <section class="intro-section">
       <p>
         Execute consultas SQL diretamente nos arquivos Parquet hospedados no
-        <a href="https://archive.org/details/djen-2026-04-01" target="_blank" rel="noopener">Internet Archive</a>.
+        <a href="https://archive.org/details/causaganha-dashboard" target="_blank" rel="noopener">Internet Archive</a>
+        (um item por tribunal/ano, ex.: <code>djen-tjro-2026</code>).
         O <strong>DuckDB-WASM</strong> roda inteiramente no seu navegador — nenhum dado é enviado para servidores externos.
       </p>
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -79,9 +79,9 @@ if (topTribunaisLive.length > 0) {
 }
 const topTribunaisHeader = topTribunais[0]?.label ?? 'Lotes';
 
-const PROOF_QUERY_SQL = `SELECT tribunal, COUNT(*) as total
-FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
-GROUP BY tribunal
+const PROOF_QUERY_SQL = `SELECT nome_orgao, COUNT(*) as total
+FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet')
+GROUP BY nome_orgao
 ORDER BY total DESC
 LIMIT 5`;
 


### PR DESCRIPTION
## Summary

Page audit turned up that every sample SQL on the dashboard pointed at \`https://archive.org/download/djen-2026-04-01/...\` — a date-based IA item that doesn't exist anymore. The new consolidate pipeline writes per-(tribunal, year) items (\`djen-tjro-2026/comunicacoes.parquet\`, etc.).

Switched all examples to \`djen-tjro-2026\`:
- TJRO 2026 is small, so demo queries return quickly in DuckDB-WASM
- Single \`ITEM\` constant in \`DuckDBExplorer.svelte\` makes future tribunal swaps trivial
- Same item used across \`dados.astro\`, \`explorador.astro\`, \`index.astro\` for consistency

Also nudged the \`explorador\` intro to mention the per-tribunal-year pattern.

## Test plan

- [x] \`npm run build\` — 125 pages, no errors
- [ ] After deploy: open \`/explorador\`, run "Comunicações por órgão" — should return rows from TJRO 2026