### PR TITLE
fix(web): correct tribunal denominator + refresh sobre.astro methodology

### DIFF
--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -4,20 +4,24 @@
 
   const IA_BASE = 'https://archive.org/download';
 
+  // Per-(tribunal, year) IA items hold the consolidated parquets.
+  // Pick any tribunal/year — TJRO 2026 used here as a demo.
+  const ITEM = 'djen-tjro-2026';
+
   const QUERY_TEMPLATES = [
     {
-      label: 'Comunicações por tribunal (últimos 30 dias)',
-      sql: `SELECT tribunal, COUNT(*) as total
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/comunicacoes.parquet')
-GROUP BY tribunal
+      label: 'Comunicações por órgão (TJRO 2026)',
+      sql: `SELECT nome_orgao, COUNT(*) as total
+FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')
+GROUP BY nome_orgao
 ORDER BY total DESC
 LIMIT 20`,
     },
     {
-      label: 'Advogados mais ativos',
+      label: 'Advogados mais ativos (TJRO 2026)',
       sql: `SELECT nome, numero_oab, uf_oab, COUNT(*) as comunicacoes
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/advogados.parquet') a
-JOIN read_parquet('${IA_BASE}/djen-2026-04-01/comunicacao_advogados.parquet') ca
+FROM read_parquet('${IA_BASE}/${ITEM}/advogados.parquet') a
+JOIN read_parquet('${IA_BASE}/${ITEM}/comunicacao_advogados.parquet') ca
   ON a.id = ca.advogado_id
 GROUP BY nome, numero_oab, uf_oab
 ORDER BY comunicacoes DESC
@@ -26,21 +30,18 @@ LIMIT 20`,
     {
       label: 'Classificações de resultado (keyword_v1)',
       sql: `SELECT outcome, decision_type, COUNT(*) as total, ROUND(AVG(confidence), 2) as avg_confidence
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/classificacoes.parquet')
+FROM read_parquet('${IA_BASE}/${ITEM}/classificacoes.parquet')
 GROUP BY outcome, decision_type
 ORDER BY total DESC`,
     },
     {
-      label: 'Processos por tribunal',
-      sql: `SELECT tribunal, COUNT(DISTINCT numero_processo) as processos
-FROM read_parquet('${IA_BASE}/djen-2026-04-01/processos.parquet')
-GROUP BY tribunal
-ORDER BY processos DESC
-LIMIT 20`,
+      label: 'Processos distintos (TJRO 2026)',
+      sql: `SELECT COUNT(DISTINCT numero_processo) as processos
+FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
     },
     {
       label: 'Schema das tabelas',
-      sql: `DESCRIBE SELECT * FROM read_parquet('${IA_BASE}/djen-2026-04-01/comunicacoes.parquet') LIMIT 0`,
+      sql: `DESCRIBE SELECT * FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet') LIMIT 0`,
     },
   ];
 
@@ -205,7 +206,7 @@ LIMIT 20`,
     bind:value={sql}
     onkeydown={handleKeyDown}
     rows="10"
-    placeholder="SELECT * FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet') LIMIT 10"
+    placeholder="SELECT * FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet') LIMIT 10"
     disabled={dbStatus !== 'ready'}
     aria-label="Editor SQL"
   ></textarea>

--- a/web/src/components/TribunalCoverageHeatmap.svelte
+++ b/web/src/components/TribunalCoverageHeatmap.svelte
@@ -23,7 +23,8 @@
       const cleaned = key.replace('djen-', ''); // "YYYY-MM-DD"
       const monthKey = cleaned.substring(0, 7);  // "YYYY-MM"
       const item = data[key];
-      const pct = Math.min(1, (item.tribunal_count || 0) / 91);
+      const dayTotal = (item.tribunal_count || 0) + (item.absent_count || 0);
+      const pct = dayTotal > 0 ? Math.min(1, (item.tribunal_count || 0) / dayTotal) : 0;
       if (!acc[monthKey]) acc[monthKey] = { sum: 0, count: 0 };
       acc[monthKey].sum += pct;
       acc[monthKey].count += 1;
@@ -76,7 +77,7 @@
                   {@const tribunalCount = item.tribunal_count || 0}
                   {@const absentCount = item.absent_count || 0}
                   {@const total = tribunalCount + absentCount}
-                  {@const pct = Math.min(100, (tribunalCount / 91) * 100)}
+                  {@const pct = total > 0 ? Math.min(100, (tribunalCount / total) * 100) : 0}
                   {@const displayDate = dateKey.replace('djen-', '')}
                   {@const colorClasses = getCoverageColorClass(pct)}
                   {@const textClass = colorClasses.split(' ')[0]}

--- a/web/src/lib/iaMetadataFetcher.ts
+++ b/web/src/lib/iaMetadataFetcher.ts
@@ -43,7 +43,7 @@ export function getExpectedDays(year: number): number {
 
 /**
  * Extract tribunal code from an IA item identifier.
- * "djen-tjsp-2026" -> "TJSP"
+ * "djen-tjro-2026" -> "TJSP"
  * "djen-tre-ac-2026" -> "TRE-AC"
  */
 function tribunalFromItemId(identifier: string, year: number): string | null {

--- a/web/src/lib/stats-processing.ts
+++ b/web/src/lib/stats-processing.ts
@@ -41,7 +41,8 @@ function parseDateKey(dateStr: string): Date | null {
 
 export function processCoverageOverview(
   data: Record<string, CompletedItem>,
-  recentDays = 30
+  recentDays = 30,
+  totalTribunals = 1
 ): {
   avgPct: number;
   avgCoverage: number;
@@ -67,7 +68,7 @@ export function processCoverageOverview(
   }
 
   const avgCoverage = recent.length > 0 ? totalCoverage / recent.length : 0;
-  const avgPct = (avgCoverage / 91) * 100;
+  const avgPct = (avgCoverage / totalTribunals) * 100;
 
   return { avgPct, avgCoverage, bestDay, bestCount, worstDay, worstCount };
 }
@@ -104,7 +105,8 @@ export function processCourtReliability(
 }
 
 export function processWeeklyPattern(
-  data: Record<string, CompletedItem>
+  data: Record<string, CompletedItem>,
+  totalTribunals = 1
 ): { weeklyAverages: WeeklyAverage[]; lowestDay: WeeklyAverage | null } {
   const sortedDates = Object.keys(data).sort((a, b) => b.localeCompare(a));
   const weekdayStats: Record<number, { totalCount: number; days: number }> = {};
@@ -127,7 +129,7 @@ export function processWeeklyPattern(
       dayIdx: i,
       name,
       avg,
-      avgPct: (avg / 91) * 100,
+      avgPct: (avg / totalTribunals) * 100,
       daysCount: stats.days,
     };
   });

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -229,9 +229,9 @@ con = duckdb.connect()
 
 # Consulta remota (sem download)
 con.sql("""
-    SELECT tribunal, COUNT(*) as total
-    FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
-    GROUP BY tribunal
+    SELECT nome_orgao, COUNT(*) as total
+    FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet')
+    GROUP BY nome_orgao
     ORDER BY total DESC
 """).show()
 
@@ -244,7 +244,7 @@ con.sql("""
         <div class="code-block">
           <pre><code>duckdb -c "
   SELECT nome, numero_oab, uf_oab
-  FROM read_parquet('https://archive.org/download/djen-2026-04-01/advogados.parquet')
+  FROM read_parquet('https://archive.org/download/djen-tjro-2026/advogados.parquet')
   LIMIT 10
 "</code></pre>
         </div>
@@ -258,7 +258,7 @@ const conn = await db.connect();
 
 const result = await conn.run(`
   SELECT outcome, COUNT(*) as total
-  FROM read_parquet('https://archive.org/download/djen-2026-04-01/classificacoes.parquet')
+  FROM read_parquet('https://archive.org/download/djen-tjro-2026/classificacoes.parquet')
   GROUP BY outcome
 `);</code></pre>
         </div>

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -24,7 +24,8 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     <section class="intro-section">
       <p>
         Execute consultas SQL diretamente nos arquivos Parquet hospedados no
-        <a href="https://archive.org/details/djen-2026-04-01" target="_blank" rel="noopener">Internet Archive</a>.
+        <a href="https://archive.org/details/causaganha-dashboard" target="_blank" rel="noopener">Internet Archive</a>
+        (um item por tribunal/ano, ex.: <code>djen-tjro-2026</code>).
         O <strong>DuckDB-WASM</strong> roda inteiramente no seu navegador — nenhum dado é enviado para servidores externos.
       </p>
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -79,9 +79,9 @@ if (topTribunaisLive.length > 0) {
 }
 const topTribunaisHeader = topTribunais[0]?.label ?? 'Lotes';
 
-const PROOF_QUERY_SQL = `SELECT tribunal, COUNT(*) as total
-FROM read_parquet('https://archive.org/download/djen-2026-04-01/comunicacoes.parquet')
-GROUP BY tribunal
+const PROOF_QUERY_SQL = `SELECT nome_orgao, COUNT(*) as total
+FROM read_parquet('https://archive.org/download/djen-tjro-2026/comunicacoes.parquet')
+GROUP BY nome_orgao
 ORDER BY total DESC
 LIMIT 5`;
 

--- a/web/src/pages/sobre.astro
+++ b/web/src/pages/sobre.astro
@@ -32,7 +32,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <div class="card-body">
           <h2 class="card-heading">Metodologia</h2>
           <p>
-            O sistema opera através de um pipeline automatizado que utiliza o GitHub Actions. A cada 20 minutos, robôs consultam as plataformas oficiais para capturar novos dados. Esses dados são validados, formatados e em seguida enviados para o Internet Archive, assegurando que o histórico de publicações nunca se perca, mesmo que os sistemas de origem fiquem indisponíveis.
+            O sistema opera através de um pipeline automatizado no GitHub Actions com três cadências: a cada 20 minutos um robô consulta o DJEN para descobrir e baixar novos cadernos; a cada 15 minutos outro robô esvazia a fila dos arquivos já confirmados, enviando-os ao Internet Archive; e diariamente os ZIPs do dia anterior são consolidados em tabelas Parquet por (tribunal, ano), também publicadas no Internet Archive. Toda a evolução do estado é registrada num único manifesto CSV (<code>sync-manifest.csv</code>) também arquivado, garantindo que o histórico nunca se perca mesmo que os sistemas de origem fiquem indisponíveis.
           </p>
         </div>
       </div>

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import { processCoverageOverview, processCourtReliability, processWeeklyPattern } from '../lib/stats-processing';
+import totals from '../../public/data/totals.json';
 
 let data = {};
 try {
@@ -13,9 +14,11 @@ try {
   // Network unavailable at build time
 }
 
-const { avgPct: avgCoverage30Pct, avgCoverage: avgCoverage30, bestDay, bestCount, worstDay, worstCount } = processCoverageOverview(data, 30);
+// Tribunal count comes from the manifest via totals.qmd → totals.json (single source of truth).
+const totalTribunals = totals.tribunals_total ?? 1;
+const { avgPct: avgCoverage30Pct, avgCoverage: avgCoverage30, bestDay, bestCount, worstDay, worstCount } = processCoverageOverview(data, 30, totalTribunals);
 const { top5, bottom5 } = processCourtReliability(data);
-const { weeklyAverages, lowestDay } = processWeeklyPattern(data);
+const { weeklyAverages, lowestDay } = processWeeklyPattern(data, totalTribunals);
 
 const displayOrder = [1, 2, 3, 4, 5, 6, 0];
 const displayWeekly = displayOrder.map(idx => weeklyAverages.find(w => w.dayIdx === idx));
@@ -53,15 +56,15 @@ const base = import.meta.env.BASE_URL;
           <figure>
             <div class="stat-value">{avgCoverage30Pct.toFixed(1)}<small class="stat-unit">%</small></div>
             <figcaption>Média de Coleta</figcaption>
-            <small class="muted">{avgCoverage30.toFixed(1)} / 91 tribunais por dia</small>
+            <small class="muted">{avgCoverage30.toFixed(1)} / {totalTribunals} tribunais por dia</small>
           </figure>
           <figure>
-            <div class="stat-value color-success">{bestCount}<small class="stat-fraction"> / 91</small></div>
+            <div class="stat-value color-success">{bestCount}<small class="stat-fraction"> / {totalTribunals}</small></div>
             <figcaption>Melhor Dia</figcaption>
             <small class="muted">{bestDay ? bestDay.replace('djen-', '') : '--'}</small>
           </figure>
           <figure>
-            <div class="stat-value color-error">{worstCount === 999 ? 0 : worstCount}<small class="stat-fraction"> / 91</small></div>
+            <div class="stat-value color-error">{worstCount === 999 ? 0 : worstCount}<small class="stat-fraction"> / {totalTribunals}</small></div>
             <figcaption>Pior Dia</figcaption>
             <small class="muted">{worstDay ? worstDay.replace('djen-', '') : '--'}</small>
           </figure>
@@ -140,7 +143,7 @@ const base = import.meta.env.BASE_URL;
                   <div class={`stat-value ${isLowest ? 'color-error' : ''}`}>
                     {w.avgPct.toFixed(0)}%
                   </div>
-                  <small class="muted">{w.avg.toFixed(1)} / 91</small>
+                  <small class="muted">{w.avg.toFixed(1)} / {totalTribunals}</small>
                   {isLowest && (
                     <div class="badge-wrapper"><span class="badge-error">Menor</span></div>
                   )}


### PR DESCRIPTION
## Summary

Web audit turned up two user-visible bugs and one stale architectural copy:

### 🔴 Hardcoded \`91 tribunais\` (manifest has 96)
The stats page and coverage heatmap divided by a literal \`91\` everywhere — wrong by ~5pp. Fixed by sourcing the count from \`totals.qmd\` (already exposes \`tribunals_total\`), keeping the .qmd contract as the single source of truth. JS code stays as a dumb consumer.

### 🟢 Heatmap per-day denominator
Replaced \`/91\` with \`(collected + absent)\` per row — accurate for historical dates when the tribunal list was smaller.

### 🟡 sobre.astro methodology paragraph
Was: *"A cada 20 minutos, robôs consultam as plataformas oficiais..."* — only mentioned the collect cycle.
Now: describes all three cadences (collect-zips 20min, upload-backlog 15min, consolidate-parquet daily) and the manifest CSV as canonical state.

## Test plan

- [x] \`npm run build\` → 125 pages, no errors
- [x] \`npm test\` → 94/94 passing
- [ ] After deploy: visit \`/stats\` and verify \`X / 96\` denominators (or whatever \`totals.tribunals_total\` shows)