### PR TITLE
chore: drop dead IA fallback, fix backfill genesis date, tighten upload deadline

### DIFF
--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv run --no-dev djen-backup upload --workers 4 --deadline-minutes 12 --use-proxy --no-fail-fast
+      - run: uv run --no-dev djen-backup upload --workers 4 --deadline-minutes 10 --use-proxy --no-fail-fast

--- a/web/src/components/LiveStatusWidget.svelte
+++ b/web/src/components/LiveStatusWidget.svelte
@@ -12,7 +12,6 @@
   const NTFY_TOPIC = 'causaganha-a7f3b2e9c1d4';
   const NTFY_SSE_URL = `https://ntfy.sh/${NTFY_TOPIC}/sse`;
   const NTFY_POLL_URL = `https://ntfy.sh/${NTFY_TOPIC}/json?poll=1&since=1h`;
-  const IA_FALLBACK_URL = 'https://archive.org/download/causaganha-live-status/status.json';
 
   let data = $state<LiveStatusData | null>(null);
   let error = $state<boolean>(false);
@@ -79,7 +78,6 @@
       source = 'polling';
 
       const poll = async () => {
-        // Try ntfy poll first
         try {
           const resp = await fetchWithRetry(NTFY_POLL_URL) as Response;
           if (resp.ok) {
@@ -91,18 +89,6 @@
                 applyMessage(last.message);
               } catch { /* ignore parse errors */ }
               return;
-            }
-          }
-        } catch { /* ignore poll errors */ }
-
-        // Last resort: IA static file
-        try {
-          const resp = await fetchWithRetry(IA_FALLBACK_URL + '?t=' + performance.now()) as Response;
-          if (resp.ok) {
-            const json: LiveStatusData = await resp.json();
-            if (isMounted) {
-              data = json;
-              error = false;
             }
           }
         } catch {

--- a/web/src/lib/fetchData.ts
+++ b/web/src/lib/fetchData.ts
@@ -255,7 +255,7 @@ export function deriveData(
   const tribunalAbsentCoverage = effectiveBackfill?.tribunal_absent_coverage || {};
   const tribunalEtas = effectiveBackfill?.tribunal_etas || {};
   const today = new Date().toISOString().split('T')[0];
-  const targetRange = effectiveBackfill?.target_range || { start: "2024-01-01", end: today };
+  const targetRange = effectiveBackfill?.target_range || { start: "2020-01-01", end: today };
 
   // Derive calendar heatmap data
   const calendarData = (() => {


### PR DESCRIPTION
## Summary

Three small fixes from the audit + the upload-backlog timeout I caught while merging #629:

- **LiveStatusWidget**: remove \`causaganha-live-status/status.json\` fallback. That IA item returns 503 — it has never existed. ntfy is the only working source.
- **fetchData.ts:258**: backfill range start \`"2024-01-01"\` → \`"2020-01-01"\` (genesis date). The wrong default narrowed the displayed coverage window when no live backfill data was loaded.
- **upload-backlog.yml**: internal deadline \`12min\` → \`10min\`. Last 3 production runs all hit the 14-min GH timeout because the engine triggered shutdown at 12min but draining in-flight uploads took >2min. Now there's 4min of headroom.

## Test plan

- [x] \`npm test\` → 94/94
- [x] \`npm run build\` → 125 pages clean
- [ ] After merge, observe next upload-backlog run completes cleanly (no 14-min cancel)