### PR TITLE
chore(workflows): pin actions/checkout + actions/cache to known SHAs

### DIFF
--- a/.github/workflows/collect-today.yml
+++ b/.github/workflows/collect-today.yml
@@ -32,14 +32,14 @@ jobs:
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup
         with:
           dev: "false"
 
       - name: Restore manifest cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/sync-manifest.csv
           key: sync-manifest-${{ github.run_id }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Save manifest cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/sync-manifest.csv
           key: sync-manifest-${{ github.run_id }}

--- a/.github/workflows/collect-zips.yml
+++ b/.github/workflows/collect-zips.yml
@@ -51,14 +51,14 @@ jobs:
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup
         with:
           dev: "false"
 
       - name: Restore manifest cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/sync-manifest.csv
           key: sync-manifest-${{ github.run_id }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Save manifest cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: data/sync-manifest.csv
           key: sync-manifest-${{ github.run_id }}

--- a/.github/workflows/consolidate-parquet.yml
+++ b/.github/workflows/consolidate-parquet.yml
@@ -52,7 +52,7 @@ jobs:
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -23,7 +23,7 @@ jobs:
     environment: dev
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -21,6 +21,6 @@ jobs:
       IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: astral-sh/setup-uv@v5
       - run: uv run --no-dev djen-backup upload --workers 4 --deadline-minutes 10 --use-proxy --no-fail-fast


### PR DESCRIPTION
## Summary

Mixed pinning across the 7 workflows:

- **test.yml + deploy-web.yml**: \`actions/checkout@v6\` + \`actions/cache/restore@v5\` SHA-pinned
- **collect-zips, collect-today, consolidate-parquet, update-catalog, upload-backlog**: floating \`@v4\` tags

This PR normalizes the 5 workflows in the second group to use the same SHAs already proven working in the first group. Other actions (\`github-script\`, \`setup-uv\`) appear in only one place each, so consistency isn't a problem there.

## Test plan

- [ ] First scheduled run after merge succeeds (collect-zips fires every 20 min — quick verification)