### PR TITLE
perf(upload-backlog): cache manifest, raise workers + deadline budget

### DIFF
--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    timeout-minutes: 14
+    timeout-minutes: 18
     environment: dev
     env:
       IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
@@ -23,4 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: astral-sh/setup-uv@v5
-      - run: uv run --no-dev djen-backup upload --workers 4 --deadline-minutes 10 --use-proxy --no-fail-fast
+      - name: Restore manifest cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: data/sync-manifest.csv
+          key: sync-manifest-${{ github.run_id }}
+          restore-keys: sync-manifest-
+      - run: uv run --no-dev djen-backup upload --workers 6 --deadline-minutes 14 --use-proxy --no-fail-fast
+      - name: Save manifest cache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: data/sync-manifest.csv
+          key: sync-manifest-${{ github.run_id }}


### PR DESCRIPTION
## Summary

Last cron run uploaded 42 ZIPs in 14 min before the GH timeout cancelled it. Three changes from log analysis:

### 1. Timeout 14 → 18 min, deadline 10 → 14 min
Engine deadline was triggering at 10 min but in-flight \`upload_zip()\` couldn't be interrupted, so workers kept running past the GH 14-min cap. Bumping the budget gives clean drain. Concurrency group prevents the every-15-min cron from overlapping.

### 2. Workers 4 → 6
IA rate limit is 30 uploads/min (4 per 8s burst). We were at ~3/min — workers idle ~45s between cycles. 6 workers ≈ 2x parallelism, still well under IA's ceiling.

### 3. Manifest cache restore/save
\`collect-zips.yml\` already does this. \`upload-backlog\` was downloading + parsing the 8MB \`sync-manifest.csv\` from IA on every cold start (~2 min). Warm cache cuts startup to seconds.

## Expected impact

| | Before | After |
|---|---|---|
| Startup | ~2 min | ~15s |
| Useful work window | ~12 min | ~17 min |
| Workers | 4 | 6 |
| Per-run uploads | ~42 | ~150-200 (estimate) |

## Test plan

- [ ] First scheduled run after merge completes without cancel
- [ ] Compare \`upload_complete\` count vs the 42-baseline