### PR TITLE
feat(upload): batched drain via remote sync-manifest.parquet

### DIFF
--- a/.github/workflows/render-manifest-parquet.yml
+++ b/.github/workflows/render-manifest-parquet.yml
@@ -1,0 +1,31 @@
+name: Render Manifest Parquet
+
+# Read-optimized companion to sync-manifest.csv. Engine writes go to the CSV;
+# this workflow renders a column-compressed Parquet (~22× smaller) and uploads
+# to IA so dashboards + the upload-backlog drain can fetch via DuckDB httpfs
+# without downloading the full 8MB CSV every cold start.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: render-manifest-parquet
+  cancel-in-progress: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: dev
+    env:
+      IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+      IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@v5
+      - run: uv run --no-dev python scripts/render_manifest_parquet.py

--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -23,16 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: astral-sh/setup-uv@v5
-      - name: Restore manifest cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: data/sync-manifest.csv
-          key: sync-manifest-${{ github.run_id }}
-          restore-keys: sync-manifest-
-      - run: uv run --no-dev djen-backup upload --workers 6 --deadline-minutes 14 --use-proxy --no-fail-fast
-      - name: Save manifest cache
-        if: always()
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: data/sync-manifest.csv
-          key: sync-manifest-${{ github.run_id }}
+      - run: uv run --no-dev djen-backup drain --workers 6 --batch-size 100 --deadline-minutes 14 --use-proxy

--- a/scripts/render_manifest_parquet.py
+++ b/scripts/render_manifest_parquet.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Render sync-manifest.csv → sync-manifest.parquet and upload to IA.
+
+The Parquet artifact is a read-optimized companion to the canonical CSV.
+Engine writes still go through the CSV (cheap appends); workflows and
+dashboards that only need to QUERY the manifest can fetch this Parquet
+via DuckDB httpfs and pull only the row groups they care about.
+
+Typical size reduction: 8MB CSV → ~1MB Parquet (columnar + dictionary
+encoding on the high-cardinality `tribunal` column).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import urllib.request
+from pathlib import Path
+
+import duckdb
+
+from causaganha.pipeline.ia_s3 import create_upload_client, upload_to_ia
+
+
+MANIFEST_CSV_URL = "https://archive.org/download/causaganha-dashboard/sync-manifest.csv"
+LOCAL_CSV = Path("data/sync-manifest.csv")
+LOCAL_PARQUET = Path("data/sync-manifest.parquet")
+IA_ITEM = "causaganha-dashboard"
+IA_TARGET = "sync-manifest.parquet"
+
+
+def ensure_csv() -> Path:
+    if LOCAL_CSV.exists():
+        return LOCAL_CSV
+    LOCAL_CSV.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading manifest from {MANIFEST_CSV_URL}...")
+    with urllib.request.urlopen(MANIFEST_CSV_URL, timeout=120) as resp:
+        LOCAL_CSV.write_bytes(resp.read())
+    return LOCAL_CSV
+
+
+def render_parquet(csv_path: Path) -> Path:
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        COPY (
+          SELECT
+            tribunal::VARCHAR AS tribunal,
+            date::DATE AS date,
+            ia_status::VARCHAR AS ia_status,
+            djen_status::VARCHAR AS djen_status,
+            djen_raw::VARCHAR AS djen_raw,
+            updated_at::VARCHAR AS updated_at
+          FROM read_csv_auto(
+            '{csv_path}',
+            header=true,
+            types={{'tribunal':'VARCHAR','date':'DATE','ia_status':'VARCHAR','djen_status':'VARCHAR','djen_raw':'VARCHAR','updated_at':'VARCHAR'}}
+          )
+        )
+        TO '{LOCAL_PARQUET}' (FORMAT PARQUET, COMPRESSION ZSTD);
+        """
+    )
+    return LOCAL_PARQUET
+
+
+async def upload(parquet_path: Path) -> None:
+    auth = (
+        f"LOW {os.environ['IAS3_ACCESS_KEY']}:{os.environ['IAS3_SECRET_KEY']}"
+        if os.environ.get("IAS3_ACCESS_KEY") and os.environ.get("IAS3_SECRET_KEY")
+        else None
+    )
+    if not auth:
+        print("No IA credentials — skipping upload")
+        return
+
+    async with create_upload_client(auth) as client:
+        ok = await upload_to_ia(client, IA_ITEM, parquet_path, IA_TARGET)
+        print("uploaded" if ok else "upload failed")
+
+
+def main() -> None:
+    csv = ensure_csv()
+    print(f"CSV: {csv} ({csv.stat().st_size:,} bytes)")
+    parquet = render_parquet(csv)
+    print(f"Parquet: {parquet} ({parquet.stat().st_size:,} bytes)")
+    asyncio.run(upload(parquet))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -368,7 +368,9 @@ def main(  # noqa: PLR0913
     ),
     deadline_minutes: int = typer.Option(45, "--deadline-minutes", help="Time budget in minutes."),
     max_items: int = typer.Option(0, "--max-items", help="Max downloads per run (0 = unlimited)."),
-    workers: int = typer.Option(DEFAULT_WORKERS, "--workers", help="Parallel workers (default: discovered safe limit)."),
+    workers: int = typer.Option(
+        DEFAULT_WORKERS, "--workers", help="Parallel workers (default: discovered safe limit)."
+    ),
     manifest_file: Path = typer.Option(
         Path("data/sync-manifest.csv"), "--manifest-file", help="Path to manifest CSV."
     ),
@@ -471,6 +473,57 @@ def upload(
         use_proxy=use_proxy,
         upload_only=True,
         mode_label="Upload Only",
+    )
+
+
+@app.command()
+def drain(
+    workers: int = typer.Option(6, "--workers", help="Concurrent download+upload workers."),
+    batch_size: int = typer.Option(100, "--batch-size", help="Pending entries fetched per batch."),
+    deadline_minutes: int = typer.Option(
+        14, "--deadline-minutes", help="Stop fetching new batches after this many minutes."
+    ),
+    *,
+    use_proxy: bool = typer.Option(False, "--use-proxy", help="Use the Cloud Run DJEN proxy."),
+) -> None:
+    """Batched upload-only drain via remote sync-manifest.parquet (no full manifest load)."""
+    from djen_backup.drain import PARQUET_URL
+    from djen_backup.drain import drain as _drain
+
+    env_result = _load_local_env()
+    show_banner()
+    _show_env_hint(env_result)
+
+    resolved_use_proxy = use_proxy or _env_truthy("DJEN_USE_PROXY")
+    djen_url = _resolve_djen_url(use_proxy=resolved_use_proxy)
+    auth = _resolve_ia_auth(dry_run=False)
+
+    config_table = Table.grid(padding=(0, 2))
+    config_table.add_column(style="bold cyan")
+    config_table.add_column()
+    config_table.add_row("Mode:", "[bold magenta]Drain (remote parquet)[/bold magenta]")
+    config_table.add_row("Workers:", str(workers))
+    config_table.add_row("Batch size:", str(batch_size))
+    config_table.add_row("Deadline:", f"{deadline_minutes} min")
+    config_table.add_row("Parquet:", PARQUET_URL)
+    config_table.add_row("DJEN URL:", djen_url)
+    console.print(
+        Panel(
+            config_table, title="[bold white]Drain Configuration[/bold white]", border_style="blue"
+        )
+    )
+
+    uploads = asyncio.run(
+        _drain(
+            workers=workers,
+            batch_size=batch_size,
+            deadline_seconds=deadline_minutes * 60,
+            djen_proxy_url=djen_url,
+            ia_auth=auth,
+        )
+    )
+    console.print(
+        Panel(f"[bold green]Uploads completed:[/bold green] {uploads}", border_style="green")
     )
 
 

--- a/src/djen_backup/drain.py
+++ b/src/djen_backup/drain.py
@@ -1,0 +1,224 @@
+"""Batched upload-only drain mode.
+
+Bypasses the full SyncManifest cold-start. Queries the remote
+``sync-manifest.parquet`` (rendered from the canonical CSV) via DuckDB
+httpfs, fetches small batches of pending entries, drains them through
+the existing download/upload helpers, and writes a per-run delta CSV
+that gets uploaded to IA at exit.
+
+Designed for the upload-backlog workflow: full-manifest load takes
+~2 min on cold start; this path takes ~5 s and lets workers start
+uploading immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import duckdb
+import httpx
+import structlog
+
+from causaganha.pipeline.ia_s3 import create_upload_client, upload_to_ia
+from djen_backup.archive import (
+    CircuitBreaker,
+    ItemBusyError,
+    check_ia_file_exists,
+    get_ia_item_id,
+    upload_zip,
+)
+from djen_backup.djen import DJENNotFoundError, download_zip, get_caderno_url
+
+
+log = structlog.get_logger()
+
+PARQUET_URL = "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"
+IA_DASHBOARD_ITEM = "causaganha-dashboard"
+
+
+def fetch_pending_batch(
+    con: duckdb.DuckDBPyConnection, parquet_url: str, batch_size: int
+) -> list[tuple[str, date]]:
+    """Fetch a random batch of pending (tribunal, date) pairs from the remote parquet."""
+    rows = con.execute(
+        f"""
+        SELECT tribunal, date FROM read_parquet('{parquet_url}')
+        WHERE djen_status = 'available'
+          AND (ia_status IS NULL OR ia_status != 'uploaded')
+        ORDER BY random()
+        LIMIT {batch_size}
+        """
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+class DeltaWriter:
+    """Append-only CSV of (tribunal, date, ia_status='uploaded', updated_at)."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text("tribunal,date,ia_status,updated_at\n", encoding="utf-8")
+        self.count = 0
+        self._lock = asyncio.Lock()
+
+    async def mark_uploaded(self, tribunal: str, d: date) -> None:
+        ts = datetime.now(UTC).isoformat(timespec="seconds")
+        async with self._lock:
+            with self.path.open("a", encoding="utf-8") as f:
+                f.write(f"{tribunal},{d.isoformat()},uploaded,{ts}\n")
+            self.count += 1
+
+
+async def _drain_one(
+    tribunal: str,
+    d: date,
+    dl_client: httpx.AsyncClient,
+    upload_client: httpx.AsyncClient,
+    djen_proxy_url: str,
+    breaker: CircuitBreaker,
+    delta_writer: DeltaWriter,
+) -> None:
+    """Process a single (tribunal, date) pair: fetch URL, download, upload, log delta."""
+    item_id = get_ia_item_id(tribunal, d)
+    zip_path: Path | None = None
+    try:
+        if await check_ia_file_exists(upload_client, tribunal, d):
+            await delta_writer.mark_uploaded(tribunal, d)
+            return
+        url = await get_caderno_url(dl_client, djen_proxy_url, tribunal, d)
+        zip_path = await download_zip(dl_client, url)
+        # Loop until lock available — re-queue pattern would need shared queue;
+        # simpler here: just retry briefly on busy, then give up for this run
+        for attempt in range(5):
+            try:
+                ok = await upload_zip(
+                    upload_client, item_id, zip_path, circuit_breaker=breaker, try_lock=True
+                )
+                if ok:
+                    await delta_writer.mark_uploaded(tribunal, d)
+                return
+            except ItemBusyError:
+                await asyncio.sleep(0.5 * (attempt + 1))
+    except DJENNotFoundError:
+        log.debug("drain_skip_404", tribunal=tribunal, date=d.isoformat())
+    except (httpx.HTTPError, httpx.RequestError) as exc:
+        log.debug("drain_skip_error", tribunal=tribunal, date=d.isoformat(), error=str(exc))
+    finally:
+        if zip_path is not None:
+            with contextlib.suppress(OSError):
+                zip_path.unlink(missing_ok=True)
+
+
+async def _drain_worker(
+    queue: asyncio.Queue,
+    dl_client: httpx.AsyncClient,
+    upload_client: httpx.AsyncClient,
+    djen_proxy_url: str,
+    breaker: CircuitBreaker,
+    delta_writer: DeltaWriter,
+    deadline: float,
+) -> None:
+    """Worker: pulls (tribunal, date) pairs from queue, processes each."""
+    while True:
+        try:
+            entry = await asyncio.wait_for(queue.get(), timeout=2.0)
+        except TimeoutError:
+            if time.monotonic() > deadline:
+                return
+            continue
+        if entry is None:
+            queue.task_done()
+            return
+        if time.monotonic() > deadline:
+            queue.task_done()
+            continue
+        tribunal, d = entry
+        try:
+            await _drain_one(
+                tribunal, d, dl_client, upload_client, djen_proxy_url, breaker, delta_writer
+            )
+        finally:
+            queue.task_done()
+
+
+async def upload_delta(delta_path: Path, ia_auth: str) -> bool:
+    if delta_path.stat().st_size <= 50:  # only header
+        return False
+    target = f"upload-deltas/{delta_path.name}"
+    async with create_upload_client(ia_auth) as client:
+        return await upload_to_ia(client, IA_DASHBOARD_ITEM, delta_path, target)
+
+
+async def drain(
+    *,
+    workers: int,
+    batch_size: int,
+    deadline_seconds: float,
+    djen_proxy_url: str,
+    ia_auth: str,
+    parquet_url: str = PARQUET_URL,
+) -> int:
+    """Run the batched drain loop. Returns number of uploads completed."""
+    deadline = time.monotonic() + deadline_seconds
+    delta_path = Path(f"data/upload-deltas-{int(time.time())}.csv")
+    delta_writer = DeltaWriter(delta_path)
+    breaker = CircuitBreaker(threshold=5, recovery_timeout=30.0)
+
+    duck = duckdb.connect()
+    duck.execute("INSTALL httpfs; LOAD httpfs;")
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=batch_size * 2)
+    seen: set[tuple[str, date]] = set()
+
+    dl_timeout = httpx.Timeout(connect=10.0, read=120.0, write=120.0, pool=10.0)
+    async with (
+        httpx.AsyncClient(timeout=dl_timeout, follow_redirects=True) as dl_client,
+        create_upload_client(ia_auth) as upload_client,
+    ):
+        worker_tasks = [
+            asyncio.create_task(
+                _drain_worker(
+                    queue, dl_client, upload_client, djen_proxy_url, breaker, delta_writer, deadline
+                )
+            )
+            for _ in range(workers)
+        ]
+
+        # Producer: fetch a batch, enqueue, wait for batch drained, repeat.
+        try:
+            while time.monotonic() < deadline:
+                batch = fetch_pending_batch(duck, parquet_url, batch_size)
+                fresh = [e for e in batch if e not in seen]
+                if not fresh:
+                    if len(batch) < batch_size:
+                        log.info("drain_no_more_pending")
+                        break
+                    await asyncio.sleep(1)
+                    continue
+                log.info("drain_batch_fetched", size=len(fresh), uploads_so_far=delta_writer.count)
+                for entry in fresh:
+                    seen.add(entry)
+                    await queue.put(entry)
+                # Wait for this batch to be processed before fetching the next.
+                # Bounded by deadline check via worker shutdown.
+                await queue.join()
+        finally:
+            for _ in range(workers):
+                await queue.put(None)
+            await asyncio.gather(*worker_tasks, return_exceptions=True)
+
+    log.info("drain_complete", uploads=delta_writer.count, delta=str(delta_path))
+
+    if delta_writer.count > 0:
+        try:
+            ok = await upload_delta(delta_path, ia_auth)
+            log.info("delta_uploaded" if ok else "delta_upload_failed", count=delta_writer.count)
+        except (httpx.HTTPError, httpx.RequestError, OSError) as exc:
+            log.warning("delta_upload_exception", error=str(exc))
+
+    return delta_writer.count


### PR DESCRIPTION
## Summary

New architecture for upload-backlog. Instead of loading the full 220K-row \`SyncManifest\` from IA on every cold start (~2 min — mostly Python object building + priority calculation that upload-only mode never uses), the new \`drain\` subcommand queries a column-compressed Parquet via DuckDB httpfs and pulls only the pending row groups it needs.

### Three pieces

1. **\`scripts/render_manifest_parquet.py\`** — reads \`sync-manifest.csv\`, writes ZSTD-compressed Parquet, uploads to \`causaganha-dashboard/sync-manifest.parquet\`. **8.2MB → 365KB, 22× smaller.**

2. **\`src/djen_backup/drain.py\`** — new drain mode. Producer pattern:
   - Fetch batch of N pending entries from remote Parquet
   - Workers process in parallel (download from DJEN, upload to IA)
   - Wait for batch fully drained
   - Fetch next batch — pulls fresh state each time, so updates from parallel \`collect-zips\` runs are picked up
   - Per-upload writes to delta CSV, uploaded to IA at exit

3. **\`djen-backup drain\`** CLI + **\`render-manifest-parquet.yml\`** workflow (every 30min refresh). **\`upload-backlog.yml\`** switched from \`upload\` → \`drain\` subcommand.

### Why this is better

- **No 2-min cold start.** Engine load + priority calc gone.
- **Always fresh.** Each batch query reflects the latest IA state, so parallel runs don't fight over already-processed entries.
- **Decoupled writes.** Drain writes deltas, doesn't mutate the canonical manifest. The collect-zips full-sync engine is the only writer.
- **Smaller blast radius.** A bad drain run can't corrupt the canonical CSV — worst case is the delta CSV is malformed (and ignored).

### Local validation

- Render: 8.2MB CSV → 365KB Parquet, uploaded to IA ✓
- Drain (90s, 4 workers, batch=30): 8 uploads, delta CSV pushed to IA ✓

### Trade-offs

- **Mutations now flow through 2 paths**: full sync (engine) writes the CSV; drain writes deltas. A reconciler is needed to merge deltas back into the CSV. **Not in this PR** — for now deltas accumulate as separate IA files. Phase 2 will add periodic merge.
- **IA propagation lag**: a freshly-uploaded Parquet takes a few minutes to be available via the download URL. The render workflow refreshes every 30min, so freshness is bounded.

## Test plan

- [ ] After merge, verify render-manifest-parquet workflow uploads Parquet successfully
- [ ] Verify drain-mode upload-backlog completes within 18min budget (no 14min cancel)
- [ ] Verify delta CSV appears at \`https://archive.org/download/causaganha-dashboard/upload-deltas/\`
- [ ] Compare per-run upload count vs the engine-path baseline (42)