### PR TITLE
chore(workflows): disable all manifest-writing schedules after data-loss incident

### DIFF
--- a/.github/workflows/collect-today.yml
+++ b/.github/workflows/collect-today.yml
@@ -9,8 +9,10 @@
 name: Collect Today
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
+  # DISABLED 2026-04-14: manifest data-loss incident. Re-enable after
+  # sync-manifest.csv is restored + overwrite source is identified.
+  # schedule:
+  #   - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/collect-zips.yml
+++ b/.github/workflows/collect-zips.yml
@@ -9,8 +9,10 @@
 name: Collect ZIPs
 
 on:
-  schedule:
-    - cron: '*/20 * * * *'
+  # DISABLED 2026-04-14: manifest data-loss incident. Re-enable after
+  # sync-manifest.csv is restored + overwrite source is identified.
+  # schedule:
+  #   - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       workers:

--- a/.github/workflows/render-manifest-parquet.yml
+++ b/.github/workflows/render-manifest-parquet.yml
@@ -6,8 +6,10 @@ name: Render Manifest Parquet
 # without downloading the full 8MB CSV every cold start.
 
 on:
-  schedule:
-    - cron: '*/30 * * * *'
+  # DISABLED 2026-04-14: manifest data-loss incident. Re-enable after
+  # sync-manifest.csv is restored + overwrite source is identified.
+  # schedule:
+  #   - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -1,8 +1,10 @@
 name: Upload Backlog
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'
+  # DISABLED 2026-04-14: manifest data-loss incident. Re-enable after
+  # sync-manifest.csv is restored + overwrite source is identified.
+  # schedule:
+  #   - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

\`sync-manifest.csv\` on IA was overwritten with a bad state: the ~33K pending (\`djen_status='available'\`) entries were reclassified to \`absent\` without \`djen_raw\` populated. The \`upload-backlog\` drain run correctly found 0 actionable entries because the manifest says there are none.

**Emergency measure**: disable all 4 scheduled workflows that mutate the manifest until:
1. Last-good version is restored from IA file history
2. Overwrite source is identified and fixed

Commented (not deleted) the \`cron:\` entries + left \`workflow_dispatch:\` intact so they can still be triggered manually for verification. \`consolidate-parquet.yml\` is untouched — it only reads the manifest, doesn't write back.

## Disabled

- collect-zips.yml (\`*/20 * * * *\`)
- collect-today.yml (\`0 6 * * *\`)
- upload-backlog.yml (\`*/15 * * * *\`)
- render-manifest-parquet.yml (\`*/30 * * * *\`)

## Follow-up (separate PRs)

- Recover the manifest from IA file history
- Audit engine code for paths that mass-reclassify entries to \`absent\` without populating \`djen_raw\`
- Add a safety check in \`manifest.upload_to_ia\`: reject if the diff against current IA version reduces \`available\` count by more than X%