### PR TITLE
chore(workflows): add one-off recover-manifest workflow

### DIFF
--- a/.github/workflows/recover-manifest.yml
+++ b/.github/workflows/recover-manifest.yml
@@ -1,0 +1,48 @@
+name: Recover Manifest
+
+# One-off workflow to restore a sync-manifest.csv from the GitHub Actions
+# cache and upload it as an artifact. Use to recover from data-loss
+# incidents when IA's current sync-manifest.csv has been corrupted.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: 'Cache key to restore (e.g. sync-manifest-24421736565)'
+        required: true
+      restore_keys:
+        description: 'Restore-keys prefix fallback'
+        required: false
+        default: 'sync-manifest-'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: data/sync-manifest.csv
+          key: ${{ inputs.cache_key }}
+          restore-keys: ${{ inputs.restore_keys }}
+          fail-on-cache-miss: true
+      - name: Inspect
+        run: |
+          set -e
+          ls -la data/sync-manifest.csv
+          head -1 data/sync-manifest.csv
+          wc -l data/sync-manifest.csv
+          echo "--- status counts (top 10) ---"
+          awk -F',' 'NR>1 {key=$3"|"$4; c[key]++} END {for (k in c) print c[k], k}' data/sync-manifest.csv | sort -rn | head -10
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-manifest-recovered
+          path: data/sync-manifest.csv
+          retention-days: 7


### PR DESCRIPTION
Restores sync-manifest.csv from GH Actions cache as a workflow artifact. Needed to recover from the data-loss incident.