### PR TITLE
feat: add neutral classification for agreement and dismissed without merit

### DIFF
--- a/src/causaganha/analysis/analyzer.py
+++ b/src/causaganha/analysis/analyzer.py
@@ -49,6 +49,8 @@ class DecisionAnalyzer:
         • "parcialmente procedente" - claim partially granted -> plaintiff wins
           (even partial victories count as wins for rating purposes)
         • "improcedente"          - claim denied -> defendant wins
+        • "acordo"                - parties settled, judge homologated ("homologação de acordo", "transação") -> draw
+        • "extinto sem mérito"    - dismissed without prejudice (Art. 485 CPC) -> nobody wins
         • "unknown"               - cannot determine from the text
 
         Set plaintiff_won=True for "procedente" or "parcialmente procedente",

--- a/src/causaganha/analysis/models.py
+++ b/src/causaganha/analysis/models.py
@@ -12,6 +12,8 @@ class Outcome(StrEnum):
     PROCEDENTE = "procedente"
     IMPROCEDENTE = "improcedente"
     PARCIALMENTE_PROCEDENTE = "parcialmente procedente"
+    ACORDO = "acordo"
+    EXTINTO_SEM_MERITO = "extinto sem mérito"
     UNKNOWN = "unknown"  # Fallback
 
 
@@ -108,7 +110,8 @@ class DecisionAnalysis(BaseModel):
         description=(
             "Outcome of the decision: 'procedente' (granted in full), "
             "'improcedente' (denied), 'parcialmente procedente' (partially granted), "
-            "or simplified: WIN, LOSS, PARTIAL, UNKNOWN"
+            "'acordo' (settlement), 'extinto sem mérito' (dismissed without prejudice), "
+            "or simplified: WIN, LOSS, PARTIAL, SETTLEMENT, UNKNOWN"
         ),
     )
 
@@ -178,7 +181,7 @@ class DecisionAnalysis(BaseModel):
         v_upper = v_stripped.upper()
 
         # Preserve RAG's simplified English terms (uppercase)
-        if v_upper in ["WIN", "LOSS", "PARTIAL", "UNKNOWN"]:
+        if v_upper in ["WIN", "LOSS", "PARTIAL", "SETTLEMENT", "UNKNOWN"]:
             return v_upper
 
         # Normalize LLM's Portuguese terms to lowercase

--- a/src/causaganha/analysis/rag_analyzer.py
+++ b/src/causaganha/analysis/rag_analyzer.py
@@ -34,6 +34,17 @@ OUTCOME_PHRASES = {
         "defiro em parte",
         "procedência parcial",
     ],
+    "SETTLEMENT": [
+        "homologo por sentença o acordo",
+        "homologação de acordo",
+        "homologo a transação",
+        "as partes transigiram",
+    ],
+    "EXTINTO_SEM_MERITO": [
+        "extingo o processo sem resolução de mérito",
+        "julgo extinto o processo sem julgamento de mérito",
+        "extinção sem mérito",
+    ],
     "UNKNOWN": [
         "despacho processual",
         "intimação para manifestação",

--- a/src/causaganha/cli/__init__.py
+++ b/src/causaganha/cli/__init__.py
@@ -688,6 +688,8 @@ def groundtruth_search(
                     if outcome == "LOSS"
                     else typer.colors.YELLOW
                     if outcome == "PARTIAL"
+                    else typer.colors.BLUE
+                    if outcome == "SETTLEMENT"
                     else typer.colors.WHITE
                 )
 

--- a/src/causaganha/pipeline/score.py
+++ b/src/causaganha/pipeline/score.py
@@ -166,13 +166,17 @@ async def calculate_ratings(
                     loser_wins = 0
                     loser_losses = 0
 
-                # Calculate new ratings (Win for A)
-                # outcome "procedente" -> Winner won (Team A)
+                # Calculate new ratings
+                # "acordo" -> Draw
+                # outcome "procedente" or "parcialmente procedente" -> Winner won (Team A)
+                # outcome "improcedente" -> Winner won (Defendant won, assigned to Team A)
+                match_result = "draw" if analysis["outcome"] == "acordo" else "win_a"
+
                 new_winner, new_loser = rate_teams(
                     model,
                     [winner_rating],
                     [loser_rating],
-                    result="win_a",
+                    result=match_result,
                 )
 
                 # Apply confidence-weighted interpolation for mid-confidence

--- a/src/causaganha/storage/repositories/analysis.py
+++ b/src/causaganha/storage/repositories/analysis.py
@@ -77,7 +77,7 @@ def store_analysis(
 # Outcomes that actually produce a winner/loser and therefore can update
 # OpenSkill ratings. "unknown" and non-ratable outcomes are excluded so the
 # rating isn't polluted by cases the classifier couldn't resolve.
-RATABLE_OUTCOMES = ("procedente", "parcialmente procedente", "improcedente")
+RATABLE_OUTCOMES = ("procedente", "parcialmente procedente", "improcedente", "acordo")
 
 # Decision types that we do NOT feed into the rating system. Interim orders
 # (decisões interlocutórias) are procedural and rarely mark a definitive

--- a/tests/test_score_filters.py
+++ b/tests/test_score_filters.py
@@ -94,8 +94,10 @@ def test_ratable_outcomes_are_sentence_level() -> None:
     assert "procedente" in RATABLE_OUTCOMES
     assert "improcedente" in RATABLE_OUTCOMES
     assert "parcialmente procedente" in RATABLE_OUTCOMES
+    assert "acordo" in RATABLE_OUTCOMES
     # Procedural labels must not leak into the rating pipeline
     assert "unknown" not in RATABLE_OUTCOMES
+    assert "extinto sem mérito" not in RATABLE_OUTCOMES
 
 
 def test_interlocutorias_are_excluded() -> None:

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -177,7 +177,7 @@ const snapVolumeLabel = snapGB === 0
                 <tbody>
                   <tr><td>texto_id</td><td>string</td><td>FK para textos.id</td></tr>
                   <tr><td>metodo</td><td>string</td><td>Método de classificação (keyword_v1, llm_v1)</td></tr>
-                  <tr><td>outcome</td><td>string</td><td>WIN, LOSS, PARTIAL, SETTLEMENT, UNKNOWN</td></tr>
+                  <tr><td>outcome</td><td>string</td><td>WIN, LOSS, PARTIAL, SETTLEMENT, EXTINTO_SEM_MERITO, UNKNOWN</td></tr>
                   <tr><td>decision_type</td><td>string</td><td>sentença, acórdão, decisão interlocutória</td></tr>
                   <tr><td>confidence</td><td>float64</td><td>Score de confiança (0.0 a 1.0)</td></tr>
                   <tr><td>winner_advogado_id</td><td>string</td><td>FK para advogados.id (quando identificado)</td></tr>

--- a/web/src/pages/dicionario.astro
+++ b/web/src/pages/dicionario.astro
@@ -9,7 +9,7 @@ const dictionary = [
   { tabela: 'comunicacoes', campo: 'numero_processo', tipo: 'string', descricao: 'Número CNJ do processo judicial.' },
   { tabela: 'comunicacoes', campo: 'data_disponibilizacao', tipo: 'date', descricao: 'Data de disponibilização no DJEN.' },
   { tabela: 'advogados', campo: 'numero_oab', tipo: 'string', descricao: 'Número da OAB do advogado quando identificado.' },
-  { tabela: 'classificacoes', campo: 'outcome', tipo: 'string', descricao: 'Resultado inferido: WIN, LOSS, PARTIAL, SETTLEMENT ou UNKNOWN.' },
+  { tabela: 'classificacoes', campo: 'outcome', tipo: 'string', descricao: 'Resultado inferido: WIN, LOSS, PARTIAL, SETTLEMENT, EXTINTO_SEM_MERITO ou UNKNOWN.' },
   { tabela: 'processos', campo: 'comunicacao_id', tipo: 'string', descricao: 'Referência para comunicacoes.id.' },
   { tabela: 'representacoes', campo: 'polo', tipo: 'string', descricao: 'Polo processual da representação (ativo/passivo).' },
 ];


### PR DESCRIPTION
Implements the backend rules, DB mapping, rating updates, and frontend exposition for new judicial outcome types: "Acordo" (Settlement) and "Extinto sem mérito" (Dismissed without merit). This prevents these outcomes from skewing lawyer ratings or confusing users of the dashboard.

---
*PR created automatically by Jules for task [5077875789156234785](https://jules.google.com/task/5077875789156234785) started by @franklinbaldo*