### PR TITLE
perf(web): client:visible for PublicationSearch, TribunalView, IASearchBar

### DIFF
--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -49,7 +49,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <p class="section-description">
           Pesquise publicações diretamente na API pública do CNJ por OAB, número de processo, parte, advogado ou texto livre.
         </p>
-        <PublicationSearch client:idle />
+        <PublicationSearch client:visible />
       </div>
 
       <input type="radio" id="mode-arquivo" name="pub_mode" class="mode-tab-input" />
@@ -61,7 +61,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <div class="overview-card">
           <h2 class="overview-title">Visão Geral do Arquivo</h2>
           <TribunalView
-            client:idle
+            client:visible
             initialPipeline={data?.cacheData?.today?.pipeline}
             initialProgressByYear={data?.progressByYear}
             initialVolume={data?.volume}
@@ -74,7 +74,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
           <p class="explorer-description">
             Busque diretamente nos buckets do Internet Archive por tribunal ou ano.
           </p>
-          <IASearchBar client:idle />
+          <IASearchBar client:visible />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## O que muda

Troca `client:idle` → `client:visible` nos três componentes interativos de `/publicacoes`.

A página usa CSS-only radio tabs (`display:none` → `display:block` no `:checked`), o mesmo padrão já validado em `admin/perf.astro` (#645).

| Componente | Aba | Comportamento |
|-----------|-----|---------------|
| `PublicationSearch` | Ao vivo (1ª, ativa por default) | IntersectionObserver dispara imediatamente — sem delay perceptível |
| `TribunalView` | Arquivo (2ª, oculta) | Hidrata no clique em "Arquivo" |
| `IASearchBar` | Arquivo (2ª, oculta) | Hidrata no clique em "Arquivo" |

## Por que é seguro

- A 1ª aba está `checked` no HTML, então `PublicationSearch` está visível ao carregar a página — `client:visible` é equivalente a `client:idle` em termos de UX
- Para as abas ocultas: `display:none` → `display:block` dispara o IntersectionObserver, então os componentes hidratam exatamente quando o usuário precisa deles, não antes

https://claude.ai/code/session_01Dp3FG2Aa5bMUr3kfrbByue