### PR TITLE
Harden tribunal-code validation in advogados detail route

### DIFF
--- a/web/src/pages/advogados/[oab].astro
+++ b/web/src/pages/advogados/[oab].astro
@@ -32,8 +32,13 @@ export function getStaticPaths() {
 const { oab } = Astro.params;
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const key = String(oab ?? '').toUpperCase();
-const tribunal = tribunalStats.find((item: any) => item.tribunal === key);
-const query = `SELECT numero_oab, uf_oab, COUNT(*) AS aparicoes\nFROM advogados\nWHERE tribunal = '${key}'\nGROUP BY numero_oab, uf_oab\nORDER BY aparicoes DESC\nLIMIT 25;`;
+const TRIBUNAL_CODE_PATTERN = /^[A-Z0-9]{2,10}$/;
+const allowedTribunalCodes = new Set(tribunalStats.map((item: any) => item.tribunal));
+const isValidTribunalCode = TRIBUNAL_CODE_PATTERN.test(key) && allowedTribunalCodes.has(key);
+const tribunal = isValidTribunalCode ? tribunalStats.find((item: any) => item.tribunal === key) : null;
+const query = isValidTribunalCode
+  ? `SELECT numero_oab, uf_oab, COUNT(*) AS aparicoes\nFROM advogados\nWHERE tribunal = '${key}'\nGROUP BY numero_oab, uf_oab\nORDER BY aparicoes DESC\nLIMIT 25;`
+  : '';
 ---
 
 <Layout title={`${key} - Advogados - CausaGanha`} description={`Guia de consulta de advogados/OAB para ${key}.`}>


### PR DESCRIPTION
### Motivation
- Prevent unsafe or unexpected route values from being interpolated into the SQL helper text by validating tribunal codes against a format allowlist and known tribunal codes before constructing the query.

### Description
- Added a format allowlist `TRIBUNAL_CODE_PATTERN` with the regex `^[A-Z0-9]{2,10}$`.
- Built `allowedTribunalCodes` as `new Set(tribunalStats.map(...))` and derived `isValidTribunalCode` from both the regex and whitelist membership.
- Only resolve `tribunal` and build the SQL `query` when `isValidTribunalCode` is true; otherwise `tribunal` is `null` and `query` is `''`.
- Preserved existing `getStaticPaths` and unchanged behavior for existing valid static routes.

### Testing
- Ran `npm run -s lint` in `web/`, which could not complete in this environment due to a missing dependency (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fffaf1b48325b0c8fbe9cce8dfba)