### PR TITLE
Wire network banner retry to dashboard query invalidation

### DIFF
--- a/web/src/components/NetworkStatusBanner.astro
+++ b/web/src/components/NetworkStatusBanner.astro
@@ -137,10 +137,7 @@
     if (retryBtn) {
       retryBtn.addEventListener('click', () => {
         handleSuccess(); // Hide banner immediately
-        // Force refetch by dispatching an event that fetchData uses, or import fetchAllData dynamically
-        import('../lib/fetchData').then(({ fetchAllData }) => {
-          fetchAllData().catch(console.error);
-        });
+        window.dispatchEvent(new CustomEvent('cg-network-force-refresh'));
       });
     }
 

--- a/web/src/lib/useDashboard.svelte.ts
+++ b/web/src/lib/useDashboard.svelte.ts
@@ -4,6 +4,8 @@ import { fetchAllData } from './fetchData';
 import { getQueryClient } from './queryClient';
 
 const IA_META_URL = 'https://archive.org/download/causaganha-dashboard/meta.json';
+const NETWORK_FORCE_REFRESH_EVENT = 'cg-network-force-refresh';
+let forceRefreshListenerAttached = false;
 
 /**
  * Initializes the TanStack QueryClient context for the current Svelte island,
@@ -19,6 +21,12 @@ export function useDashboardWithPolling() {
   setQueryClientContext(getQueryClient());
 
   const queryClient = useQueryClient();
+  if (typeof window !== 'undefined' && !forceRefreshListenerAttached) {
+    window.addEventListener(NETWORK_FORCE_REFRESH_EVENT, () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.dashboard });
+    });
+    forceRefreshListenerAttached = true;
+  }
 
   // Lightweight 3-min sentinel — fetches only meta.json
   const metaQuery = createQuery(() => ({


### PR DESCRIPTION
### Motivation
- The network error banner currently calls `fetchAllData()` directly which bypasses the dashboard query state and can produce stale UI behavior. 
- The goal is to route user-triggered retries through the shared dashboard state layer so all dashboard consumers update consistently.

### Description
- Replaced direct `fetchAllData()` invocation in `web/src/components/NetworkStatusBanner.astro` with dispatch of a custom event `cg-network-force-refresh`. 
- Added an event listener in `web/src/lib/useDashboard.svelte.ts` that invalidates `QUERY_KEYS.dashboard` via the page's `QueryClient` when `cg-network-force-refresh` is received. 
- The listener is attached once per browser runtime using a `forceRefreshListenerAttached` guard so duplicate subscriptions are avoided. 
- The banner still calls `handleSuccess()` to hide immediately, preserving the existing UX behavior.

### Testing
- Manual verification (recommended): open the app in the browser, trigger a network error state, click `Tentar Novamente`, confirm the banner hides immediately and the dashboard query is invalidated/refetched. 
- Automated lint attempt with `npm run lint` in `web/` failed in this environment due to a missing dev dependency (`@eslint/js`) so lint could not complete. 
- No new unit or integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ffe6a0388325baf561bc79c640c0)