### PR TITLE
fix(web): easy-win UX and a11y polish

### DIFF
--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -242,7 +242,32 @@
   const parties = $derived(uniquePartyNames(pub));
   const lawyers = $derived(uniqueLawyers(pub));
 
-  function handleShare(e: MouseEvent, context: "main" | "reader" | "compact") {
+  async function copyToClipboard(text: string): Promise<boolean> {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch {
+        // fall through to legacy path
+      }
+    }
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleShare(e: MouseEvent, context: "main" | "reader" | "compact") {
     e.preventDefault();
     e.stopPropagation();
     const base = window.location.pathname;
@@ -250,7 +275,8 @@
     if (page) hash += `/${page}`;
     if (seq) hash += `/${seq}`;
     const url = `${window.location.origin}${base}#${hash}`;
-    navigator.clipboard?.writeText(url);
+    const ok = await copyToClipboard(url);
+    if (!ok) return;
     if (shareTimeoutId) clearTimeout(shareTimeoutId);
     activeCopied = context;
     shareTimeoutId = setTimeout(() => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -274,6 +274,28 @@ small { font-size: var(--font-size-sm); }
   border-width: 0;
 }
 
+.skip-link {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 100;
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: var(--color-primary-content);
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 0 0 var(--radius-btn) 0;
+  transform: translateY(-120%);
+  transition: transform 120ms ease-out;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--color-primary-content);
+  outline-offset: -4px;
+}
+
 .container {
   width: 100%;
   max-width: 1280px;

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -55,9 +55,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </script>
   </head>
   <body>
-    <a href="#main-content" class="sr-only">
-      Skip to main content
-    </a>
+    <a href="#main-content" class="skip-link">Pular para o conteúdo</a>
     {showNetworkBanner && <NetworkStatusBanner />}
     <main id="main-content" class:list={[{ container: !fullWidth }]}>
       <slot />

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -13,10 +13,10 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <p class="error-code">404</p>
         <h2 class="error-heading">Página não encontrada</h2>
         <p class="error-message">
-          Este conteúdo pode ainda não ter sido coletado ou o snapshot ainda não foi atualizado.
+          O endereço não existe ou foi movido. Se você chegou por um link antigo, este conteúdo pode ainda não ter sido coletado — tente a busca ou volte ao início.
         </p>
         <div class="action-buttons">
-          <a href={BASE + 'publicacoes'} class="btn btn-primary">Dashboard</a>
+          <a href={BASE + 'publicacoes'} class="btn btn-primary">Buscar publicações</a>
           <a href={BASE} class="btn btn-secondary">Início</a>
         </div>
       </div>

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -2,8 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
-import DatabaseCloudIcon from '../components/icons/DatabaseCloudIcon.astro';
 import { readArchiveSnapshot, type IaSnapshot } from '../lib/readJson';
+import { formatNumber } from '../lib/homepage-content';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const iaSnapshot = readArchiveSnapshot<IaSnapshot>();
@@ -42,13 +42,13 @@ const snapVolumeLabel = snapGB === 0
         <div class="stats-grid">
           <div class="card">
             <div class="card-body-compact">
-              <strong class="stat-value">{snap.total_zips?.toLocaleString()}</strong>
+              <strong class="stat-value">{formatNumber(snap.total_zips ?? 0)}</strong>
               <small class="stat-label">ZIPs arquivados</small>
             </div>
           </div>
           <div class="card">
             <div class="card-body-compact">
-              <strong class="stat-value">{snap.tribunals_with_data}</strong>
+              <strong class="stat-value">{formatNumber(snap.tribunals_with_data ?? 0)}</strong>
               <small class="stat-label">Tribunais</small>
             </div>
           </div>
@@ -61,7 +61,7 @@ const snapVolumeLabel = snapGB === 0
           {(snap.total_parquets ?? 0) > 0 && (
             <div class="card">
               <div class="card-body-compact">
-                <strong class="stat-value">{snap.total_parquets}</strong>
+                <strong class="stat-value">{formatNumber(snap.total_parquets ?? 0)}</strong>
                 <small class="stat-label">Parquets consolidados</small>
               </div>
             </div>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -111,7 +111,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       <!-- Search form -->
       <form class="search-form" id="home-search-form" action={BASE + 'publicacoes'} method="get">
         <div class="search-input-wrapper">
-          <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
           </svg>
           <input
@@ -125,7 +125,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
             spellcheck="false"
           />
           <button type="submit" class="search-submit" aria-label="Buscar">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M5 12h14M12 5l7 7-7 7"/>
             </svg>
           </button>
@@ -157,7 +157,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
               </span>
               <span class="quick-access-cta" aria-hidden="true">
                 {card.cta}
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
               </span>
             </a>
           </li>
@@ -230,9 +230,12 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       <WorkflowStatusBadge />
       <DataSourceIndicator />
       <small class="trust-fact">
-        Próxima coleta: diária · Tribunais com lacunas:
-        <strong>{Math.max(0, totalTribunals - tribunalsWithData)}</strong>
-        de {totalTribunals}
+        Próxima coleta: diária ·
+        <span title="Tribunais sem nenhuma publicação arquivada na série histórica.">
+          Tribunais com lacunas:
+          <strong>{Math.max(0, totalTribunals - tribunalsWithData)}</strong>
+          de {totalTribunals}
+        </span>
       </small>
     </div>
   </section>
@@ -255,7 +258,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         </p>
         <a href={BASE + 'stats'} class="cta-link">
           Explorar mapa judicial
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Surgical UX / a11y fixes across the web frontend — no behavior changes, no new features.

- **Skip link is finally useful.** `Layout.astro` rendered it with `sr-only`, so it stayed hidden on focus too. It now slides into view when focused and is labeled in pt-BR.
- **Consistent totals on /dados.** The homepage uses `formatNumber()` ("157K") while `/dados` used raw `.toLocaleString()` ("157.000"). Unified on `formatNumber()`; dropped a dead `DatabaseCloudIcon` import.
- **Clipboard share no longer lies.** `PublicationCard.handleShare` previously showed "Copiado!" even when `navigator.clipboard.writeText` rejected (permissions, insecure context). Now awaits the result, falls back to a hidden-textarea `execCommand`, and only flashes the confirmation on real success.
- **A11y polish on homepage.** `aria-hidden="true"` on decorative inline SVGs in the hero search, quick-access CTAs, and malha cta-link; title tooltip on the "Tribunais com lacunas" abbreviation.
- **404 copy.** Previous message only covered not-yet-collected content; rewritten to also address mistyped URLs and point at search.

## Test plan

- [x] `npx vitest run` — 101/101 passing
- [x] `npx astro check` — only pre-existing errors in `stats.astro` (missing generated JSON); no new diagnostics in touched files
- [ ] Manual keyboard check: Tab from page load → skip link appears → Enter jumps to `#main-content`
- [ ] Manual check: share button on `PublicationCard` still flashes "Copiado!" in a normal browser; no phantom success in a denied-clipboard context
- [ ] Visual regression on homepage and /dados totals

https://claude.ai/code/session_01UbtFHCQSxBYLQLHp5qoqZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbtFHCQSxBYLQLHp5qoqZG)_