### PR TITLE
[codex] fix FRONTEND.md violations

### DIFF
--- a/web/src/components/BackfillDetailedStatus.svelte
+++ b/web/src/components/BackfillDetailedStatus.svelte
@@ -1,22 +1,35 @@
 <script lang="ts">
-  let { data = null }: { data: any } = $props();
+  interface BackfillTribunal {
+    tribunal: string;
+    state: string;
+    genesis_date: string;
+    cursor_date: string | null;
+    completion_pct: number;
+  }
 
-  let tribunals = $derived(data?.tribunals || []);
+  interface BackfillData {
+    tribunals?: BackfillTribunal[];
+    updated_at?: string;
+  }
+
+  let { data = null }: { data: BackfillData | null } = $props();
+
+  let tribunals = $derived(data?.tribunals ?? []);
   let updatedAt = $derived(data?.updated_at ? new Date(data.updated_at).toLocaleString('pt-BR') : 'N/A');
 </script>
 
-<div class="card bg-base-100 shadow-sm border border-base-300">
-  <div class="card-body p-6">
-    <div class="flex justify-between items-center mb-4">
-      <h2 class="card-title text-xl">Detalhes de Backfill por Tribunal</h2>
-      <span class="text-xs opacity-70">Última verificação: {updatedAt}</span>
+<div class="card backfill-card">
+  <div class="card-body backfill-card-body">
+    <div class="backfill-header">
+      <h2 class="card-title backfill-title">Detalhes de Backfill por Tribunal</h2>
+      <span class="backfill-updated-at">Última verificação: {updatedAt}</span>
     </div>
 
     {#if tribunals.length === 0}
-      <div class="alert alert-info">Nenhum dado de backfill disponível.</div>
+      <div class="backfill-empty">Nenhum dado de backfill disponível.</div>
     {:else}
       <div class="table-responsive">
-        <table class="table table-zebra w-full">
+        <table class="table backfill-table">
           <thead>
             <tr>
               <th>Tribunal</th>
@@ -29,7 +42,7 @@
           <tbody>
             {#each tribunals as t}
               <tr>
-                <td class="font-bold">{t.tribunal}</td>
+                <td class="backfill-tribunal">{t.tribunal}</td>
                 <td>
                   {#if t.state === 'Active'}
                     <span class="badge badge-success badge-sm">Ativo</span>
@@ -41,12 +54,12 @@
                     <span class="badge badge-ghost badge-sm">{t.state}</span>
                   {/if}
                 </td>
-                <td class="text-xs opacity-80">{t.genesis_date}</td>
-                <td class="font-mono text-sm">{t.cursor_date || 'N/A'}</td>
-                <td class="w-1/3 min-w-[150px]">
-                  <div class="flex items-center gap-2">
-                    <progress class="progress flex-1" value={t.completion_pct} max="100"></progress>
-                    <span class="text-xs font-medium w-10 text-right">{t.completion_pct}%</span>
+                <td class="backfill-meta">{t.genesis_date}</td>
+                <td class="backfill-mono">{t.cursor_date || 'N/A'}</td>
+                <td class="backfill-progress-cell">
+                  <div class="backfill-progress">
+                    <progress class="progress backfill-progress-bar" value={t.completion_pct} max="100"></progress>
+                    <span class="backfill-progress-value">{t.completion_pct}%</span>
                   </div>
                 </td>
               </tr>
@@ -57,3 +70,84 @@
     {/if}
   </div>
 </div>
+
+<style>
+  .backfill-card {
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .backfill-card-body {
+    padding: var(--space-lg);
+  }
+
+  .backfill-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-md);
+    flex-wrap: wrap;
+  }
+
+  .backfill-title {
+    font-size: var(--font-size-xl);
+  }
+
+  .backfill-updated-at {
+    font-size: var(--font-size-xs);
+    opacity: 0.7;
+  }
+
+  .backfill-empty {
+    padding: var(--space-md);
+    border-radius: var(--radius-box);
+    background: color-mix(in srgb, var(--color-info) 10%, var(--color-base-100));
+    color: var(--color-info-content, var(--color-base-content));
+  }
+
+  .backfill-table {
+    width: 100%;
+  }
+
+  .backfill-table tbody tr:nth-child(even) {
+    background: var(--color-base-200);
+  }
+
+  .backfill-tribunal {
+    font-weight: 700;
+  }
+
+  .backfill-meta {
+    font-size: var(--font-size-xs);
+    opacity: 0.8;
+  }
+
+  .backfill-mono {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+  }
+
+  .backfill-progress-cell {
+    width: 33%;
+    min-width: 150px;
+  }
+
+  .backfill-progress {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .backfill-progress-bar {
+    flex: 1;
+  }
+
+  .backfill-progress-value {
+    width: 2.5rem;
+    text-align: right;
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+  }
+</style>

--- a/web/src/components/JulesSessionStatus.svelte
+++ b/web/src/components/JulesSessionStatus.svelte
@@ -48,8 +48,8 @@
       sessions = data.sessions || [];
       // Keep only the last 5
       sessions = sessions.slice(0, 5);
-    } catch (err: any) {
-      error = err.message || 'Failed to fetch sessions';
+    } catch (err: unknown) {
+      error = err instanceof Error ? err.message : 'Failed to fetch sessions';
     } finally {
       loading = false;
     }
@@ -71,32 +71,32 @@
   }
 </script>
 
-<div class="card bg-base-100 shadow-sm border border-base-300">
+<div class="card jules-card">
   <div class="card-body">
-    <h3 class="card-title mb-4 flex justify-between items-center">
+    <h3 class="card-title jules-header">
       Jules Sessions
-      <button class="btn btn-sm btn-ghost" on:click={fetchSessions} disabled={loading || !apiKey}>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <button class="btn btn-sm btn-ghost" onclick={fetchSessions} disabled={loading || !apiKey}>
+        <svg xmlns="http://www.w3.org/2000/svg" class="jules-refresh-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
         </svg>
       </button>
     </h3>
 
     {#if error}
-      <div class="alert alert-error text-sm">
-        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-4 w-4" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+      <div class="jules-alert jules-alert-error">
+        <svg xmlns="http://www.w3.org/2000/svg" class="jules-alert-icon" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
         <span>{error}</span>
       </div>
     {:else if loading}
-      <div class="flex justify-center py-4" aria-busy="true">
-        <span class="loading loading-spinner loading-md text-primary"></span>
+      <div class="jules-loading" aria-busy="true">
+        <span class="jules-spinner"></span>
       </div>
     {:else if sessions.length === 0}
-      <div class="text-center py-4 text-base-content/50 text-sm">
+      <div class="jules-empty">
         No active sessions found.
       </div>
     {:else}
-      <div class="overflow-x-auto">
+      <div class="jules-table-wrap">
         <table class="table table-sm">
           <thead>
             <tr>
@@ -109,19 +109,18 @@
           <tbody>
             {#each sessions as session}
               <tr>
-                <td class="font-mono text-xs">
+                <td class="jules-id-cell">
                   <a href="#" class="link link-hover link-primary" title="Open in console">
-                    <!-- Extracting ID if it's in the format 'sessions/ID' -->
                     {session.name ? session.name.split('/').pop() : 'Unknown'}
                   </a>
                 </td>
-                <td class="whitespace-nowrap max-w-xs truncate" title={session.title}>{session.title || 'Untitled'}</td>
+                <td class="jules-title-cell" title={session.title}>{session.title || 'Untitled'}</td>
                 <td>
                   <span class="badge badge-sm {getStateColor(session.state)}">
                     {session.state || 'UNKNOWN'}
                   </span>
                 </td>
-                <td class="text-xs text-base-content/70 whitespace-nowrap">
+                <td class="jules-created-at">
                   {formatDate(session.createTime)}
                 </td>
               </tr>
@@ -132,3 +131,94 @@
     {/if}
   </div>
 </div>
+
+<style>
+  .jules-card {
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .jules-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-md);
+  }
+
+  .jules-refresh-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .jules-alert {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-sm);
+    border-radius: var(--radius-box);
+    font-size: var(--font-size-sm);
+  }
+
+  .jules-alert-error {
+    background: color-mix(in srgb, var(--color-error) 10%, var(--color-base-100));
+    color: var(--color-error-content, var(--color-base-content));
+  }
+
+  .jules-alert-icon {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+  }
+
+  .jules-loading {
+    display: flex;
+    justify-content: center;
+    padding: var(--space-md) 0;
+  }
+
+  .jules-spinner {
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid var(--color-base-300);
+    border-top-color: var(--color-primary);
+    border-radius: 9999px;
+    animation: jules-spin 0.8s linear infinite;
+  }
+
+  .jules-empty {
+    padding: var(--space-md) 0;
+    text-align: center;
+    color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
+    font-size: var(--font-size-sm);
+  }
+
+  .jules-table-wrap {
+    overflow-x: auto;
+  }
+
+  .jules-id-cell {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+  }
+
+  .jules-title-cell {
+    max-width: 16rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .jules-created-at {
+    white-space: nowrap;
+    font-size: var(--font-size-xs);
+    color: color-mix(in srgb, var(--color-base-content) 70%, transparent);
+  }
+
+  @keyframes jules-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>


### PR DESCRIPTION
## What changed
- rebased the PR branch onto the current `main`
- kept the remaining frontend-guide fixes in the current diff: `BackfillDetailedStatus.svelte` and `JulesSessionStatus.svelte`
- migrated the backfill component to typed Svelte 5 `$props` / `$derived`
- replaced legacy utility-class styling in both remaining touched components with local token-based CSS

## Why
`main` had already absorbed or superseded most of the original changes while the branch drifted. The rebased PR now carries only the remaining `FRONTEND.md` cleanup that is still applicable on top of current `main`.

## Impact
- PR #658 is now based on the latest `main`
- the diff is reduced from seven files to two files
- the remaining edited components follow the repo's Svelte 5 and token-based styling guidance

## Validation
- `git merge-base --is-ancestor origin/main HEAD` passes, confirming the branch contains current `main`
- targeted grep found no conflict markers, `/causaganha/`, `export let`, `$:` reactive statements, or inline `style="..."` in the relevant frontend files
- `git diff --check origin/main...HEAD` passes
- full frontend `typecheck`, `lint`, and `build` could not run in this runner because `node`, `npm`, `bun`, and `pnpm` are unavailable here