### PR TITLE
fix(web): UI/UX easy wins (responsive stats, search spinner, pagination, dropdown chevron)

### DIFF
--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -226,7 +226,7 @@ FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
         Exportar CSV
       </button>
       <small class="result-meta">
-        {result.rowCount} linha{result.rowCount !== 1 ? 's' : ''} em {result.duration}ms
+        {result.rowCount.toLocaleString('pt-BR')} linha{result.rowCount !== 1 ? 's' : ''} em {result.duration.toLocaleString('pt-BR')}ms
       </small>
     {/if}
   </div>
@@ -290,7 +290,7 @@ FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
       </table>
       {#if result.rows.length > 500}
         <small class="truncation-notice">
-          Mostrando 500 de {result.rowCount} linhas. Use LIMIT na query para controlar.
+          Mostrando 500 de {result.rowCount.toLocaleString('pt-BR')} linhas. Use LIMIT na query para controlar.
         </small>
       {/if}
     </div>

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -336,18 +336,18 @@ const recursosLinks = [
     cursor: pointer;
   }
 
-  .menu summary {
+  .menu details summary {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
     list-style: none;
   }
 
-  .menu summary::-webkit-details-marker {
+  .menu details summary::-webkit-details-marker {
     display: none;
   }
 
-  .menu summary::after {
+  .menu details summary::after {
     content: "";
     width: 0.5rem;
     height: 0.5rem;

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -336,6 +336,32 @@ const recursosLinks = [
     cursor: pointer;
   }
 
+  .menu summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    list-style: none;
+  }
+
+  .menu summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .menu summary::after {
+    content: "";
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateY(-2px) rotate(45deg);
+    opacity: 0.6;
+    transition: transform var(--transition-base, 0.15s ease);
+  }
+
+  .menu details[open] summary::after {
+    transform: translateY(1px) rotate(225deg);
+  }
+
   .menu a:hover,
   .menu summary:hover {
     background: var(--color-base-200);

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -282,8 +282,21 @@
     >
       {showFilters ? 'Ocultar filtros' : 'Filtros avançados'}
     </button>
-    <button type="button" class="submit-btn" disabled={!canSubmit} onclick={handleSubmit}>
-      {status === 'loading' ? 'Buscando…' : cooldownRemaining > 0 ? `Aguarde ${cooldownRemaining}s` : 'Buscar'}
+    <button
+      type="button"
+      class="submit-btn"
+      disabled={!canSubmit}
+      aria-busy={status === 'loading'}
+      onclick={handleSubmit}
+    >
+      {#if status === 'loading'}
+        <span class="submit-spinner" aria-hidden="true"></span>
+        Buscando…
+      {:else if cooldownRemaining > 0}
+        Aguarde {cooldownRemaining}s
+      {:else}
+        Buscar
+      {/if}
     </button>
     <div class="toolbar-spacer"></div>
     <RateLimitBadge limit={rateLimit.limit} remaining={rateLimit.remaining} {usedFallback} />
@@ -328,18 +341,21 @@
         <p>Ajuste os filtros ou amplie o período.</p>
       </div>
     {:else if status === 'success'}
+      {@const perPage = filters.itensPorPagina ?? 30}
+      {@const currentPage = filters.pagina ?? 1}
+      {@const totalPages = Math.max(1, Math.ceil(totalCount / perPage))}
       <div class="results-header" id={resultsHeadingId}>
         <span class="result-count">{totalCount.toLocaleString('pt-BR')} resultado(s)</span>
         <div class="pagination">
           <button
             type="button"
-            disabled={(filters.pagina ?? 1) <= 1}
+            disabled={currentPage <= 1}
             onclick={() => handlePageChange(-1)}
           >‹ Anterior</button>
-          <span>Página {filters.pagina ?? 1}</span>
+          <span>Página {currentPage} de {totalPages.toLocaleString('pt-BR')}</span>
           <button
             type="button"
-            disabled={results.length < (filters.itensPorPagina ?? 30)}
+            disabled={currentPage >= totalPages || results.length < perPage}
             onclick={() => handlePageChange(1)}
           >Próxima ›</button>
         </div>
@@ -450,6 +466,10 @@
     background: var(--color-primary, #3b82f6);
     color: white;
     border-color: transparent;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
   }
 
   .submit-btn:disabled {
@@ -459,6 +479,25 @@
 
   .submit-btn:not(:disabled):hover {
     filter: brightness(0.95);
+  }
+
+  .submit-spinner {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: submit-spin 0.7s linear infinite;
+  }
+
+  @keyframes submit-spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .submit-spinner {
+      animation-duration: 1.8s;
+    }
   }
 
   .status-region {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -742,6 +742,12 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     }
   }
 
+  @media (max-width: 420px) {
+    .stats-row {
+      grid-template-columns: 1fr;
+    }
+  }
+
   /* ── Activity strip (widget 1) ── */
   .activity-strip-section {
     padding-top: var(--space-sm);


### PR DESCRIPTION
## Summary

Five low-risk, low-effort polish fixes across the web frontend. No backend or design changes.

- **Responsive stats row**: collapses to a single column at `<=420px` so the four-up grid stops looking cramped on small phones (`web/src/pages/index.astro`).
- **Search loading feedback**: submit button in `PublicationSearch` now shows an inline spinner next to "Buscando…" and exposes `aria-busy` to assistive tech.
- **Pagination clarity**: shows "Página X de Y" using the total result count and disables the next button at the last page (instead of relying solely on a partial-page heuristic).
- **Dropdown discoverability**: the "Ferramentas" header dropdown gets a chevron that flips when open, hinting it's expandable.
- **Number formatting**: DuckDB explorer formats row counts and durations with pt-BR thousands separators.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 101/101 tests pass
- [ ] Smoke test in dev (`npm run dev`):
  - Homepage stats row reflows to 1 column on a narrow viewport (<420px)
  - Search button shows spinner during a slow query
  - Pagination shows "Página X de Y" and disables next at the last page
  - "Ferramentas" header dropdown chevron flips open/closed
  - DuckDB result meta shows formatted numbers (e.g. `1.234 linhas em 567ms`)

Note: `npm run build` fails locally on an unrelated, pre-existing missing `web/public/data/*.json` (generated by the Python `render_queries.py` pipeline) — not caused by these changes.

https://claude.ai/code/session_017pAChW4jjAn6YGej67iPUY

---
_Generated by [Claude Code](https://claude.ai/code/session_017pAChW4jjAn6YGej67iPUY)_