### PR TITLE
fix(web): UI/UX easy wins — SEO, a11y, and sharing polish

### DIFF
--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -15,10 +15,10 @@ interface Props {
   showNetworkBanner?: boolean;
 }
 
-const { title, description = 'CausaGanha - Judicial Data Intelligence Pipeline', ogImage, fullWidth = false, showNetworkBanner = true } = Astro.props;
+const { title, description = 'CausaGanha — Arquivo público das comunicações judiciais brasileiras (DJEN) no Internet Archive.', ogImage, fullWidth = false, showNetworkBanner = true } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const ogImageUrl = ogImage || new URL('/og-image.png', Astro.site).toString();
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+const ogImageUrl = ogImage || new URL(`${BASE}favicon.svg`, Astro.site).toString();
 ---
 
 <!doctype html>
@@ -45,6 +45,9 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href={`${BASE}favicon.svg`} />
+    <link rel="apple-touch-icon" href={`${BASE}favicon.svg`} />
+    <meta name="theme-color" content="#1A6B3C" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#3DA568" media="(prefers-color-scheme: dark)" />
     <title>{title}</title>
     <ClientRouter />
     <script is:inline>

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -85,7 +85,7 @@ const snapVolumeLabel = snapGB === 0
                 Formato: <code class="badge">djen-YYYY-MM-DD-TRIBUNAL.zip</code>
               </p>
               <div class="card-actions">
-                <a href="https://archive.org/search?query=creator%3A%22causaganha%22" target="_blank" rel="noopener" class="btn btn-outline">
+                <a href="https://archive.org/search?query=creator%3A%22causaganha%22" target="_blank" rel="noopener noreferrer" class="btn btn-outline">
                   Buscar no Internet Archive
                 </a>
               </div>
@@ -113,7 +113,7 @@ const snapVolumeLabel = snapGB === 0
                 Baixe e consulte localmente sem downloads pesados.
               </p>
               <div class="card-actions">
-                <a href="https://archive.org/download/causaganha-catalog/catalog.duckdb" target="_blank" rel="noopener" class="btn btn-outline">
+                <a href="https://archive.org/download/causaganha-catalog/catalog.duckdb" target="_blank" rel="noopener noreferrer" class="btn btn-outline">
                   Baixar catalog.duckdb
                 </a>
               </div>

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -24,7 +24,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     <section class="intro-section">
       <p>
         Execute consultas SQL diretamente nos arquivos Parquet hospedados no
-        <a href="https://archive.org/details/causaganha-dashboard" target="_blank" rel="noopener">Internet Archive</a>
+        <a href="https://archive.org/details/causaganha-dashboard" target="_blank" rel="noopener noreferrer">Internet Archive</a>
         (um item por tribunal/ano, ex.: <code>djen-tjro-2026</code>).
         O <strong>DuckDB-WASM</strong> roda inteiramente no seu navegador — nenhum dado é enviado para servidores externos.
       </p>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -120,6 +120,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
             type="search"
             class="search-input"
             placeholder="Busque por processo, tribunal ou palavra-chave..."
+            aria-label="Busque por processo, tribunal ou palavra-chave"
             autocomplete="off"
             autocorrect="off"
             spellcheck="false"
@@ -388,7 +389,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
           Nosso código é aberto e nossos dados são seus.
         </p>
         <div class="cta-actions">
-          <a href="https://github.com/franklinbaldo/causaganha" target="_blank" rel="noopener" class="btn btn-outline-light">
+          <a href="https://github.com/franklinbaldo/causaganha" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light">
             <GitHubIcon /> Contribuir no GitHub
           </a>
           <a href={BASE + 'dados'} class="btn btn-outline-light">
@@ -536,8 +537,8 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   .search-submit {
     position: absolute;
     right: 0.375rem;
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2.75rem;
+    height: 2.75rem;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/web/src/pages/robots.txt.ts
+++ b/web/src/pages/robots.txt.ts
@@ -1,12 +1,8 @@
 import type { APIRoute } from 'astro';
 
-const robotsTxt = `
-User-agent: *
-Allow: /
-Sitemap: https://franklinbaldo.github.io/causaganha/sitemap.xml
-`.trim();
-
-export const GET: APIRoute = () => {
+export const GET: APIRoute = ({ site }) => {
+  const sitemapUrl = new URL(`${import.meta.env.BASE_URL.replace(/\/$/, '')}/sitemap.xml`, site).toString();
+  const robotsTxt = `User-agent: *\nAllow: /\nSitemap: ${sitemapUrl}\n`;
   return new Response(robotsTxt, {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',

--- a/web/src/pages/sitemap.xml.ts
+++ b/web/src/pages/sitemap.xml.ts
@@ -2,9 +2,9 @@ import type { APIRoute } from 'astro';
 import { TRIBUNAIS } from '../lib/tribunais';
 import { readJson } from '../lib/readJson';
 
-const BASE_URL = 'https://franklinbaldo.github.io/causaganha';
-
-export const GET: APIRoute = () => {
+export const GET: APIRoute = ({ site }) => {
+  const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const BASE_URL = new URL(basePath, site).toString().replace(/\/$/, '');
   const sitemapUrls: string[] = [];
   const now = new Date().toISOString();
   const backfill = readJson<any>('cache/backfill.json');


### PR DESCRIPTION
## Summary

A bundle of low-risk, high-value UI/UX fixes I found by auditing the dashboard for accessibility, SEO, and sharing polish. Each change is surgical — no architectural shifts.

### SEO / sharing
- **robots.txt and sitemap.xml.ts** now build URLs from `Astro.site` + `BASE_URL` instead of hardcoding `https://franklinbaldo.github.io/causaganha`. Preview deploys and any future custom domain will now point crawlers at the right sitemap.
- **og:image fallback** previously pointed at `/og-image.png`, which doesn't exist in `web/public/`. Falls back to `favicon.svg` so Twitter/Facebook cards no longer render broken.
- **Default meta description** changed from English ("Judicial Data Intelligence Pipeline") to a Portuguese sentence consistent with the site's audience.

### Accessibility
- **Homepage search input** had only a placeholder; added `aria-label` so screen readers announce it.
- **Search submit button** was 40×40 px — below the 44×44 WCAG 2.5.5 minimum. Bumped to 44×44 (still fits within the input's right padding).
- **External links** (`index.astro`, `dados.astro`, `explorador.astro`) had `rel="noopener"` without `noreferrer`. Now both, so the referrer doesn't leak.

### Mobile / PWA
- Added `apple-touch-icon` and light/dark `theme-color` meta tags in `Layout.astro` so iOS home-screen pinning and Android browser chrome pick up the brand color (`#1A6B3C` / `#3DA568`).

## What I deliberately did **not** touch

The audit surfaced a few items that turned out to already be correct or out of scope:
- `:focus-visible` suppression is already inside an `@supports` block.
- The Google Fonts URL already uses `&display=swap`.
- `.skip-link` already has working `:focus` reveal styles.
- `IncidentBanner.astro` and `SystemStatus.svelte` mix English/Portuguese, but neither component is mounted anywhere — left alone.
- Pre-existing `astro check` errors in `stats.astro` (missing `public/data/*.json` modules) are unrelated.

## Test plan

- [x] `npx eslint .` — clean
- [x] `npx astro check` — only pre-existing errors in `stats.astro` remain, none in touched files
- [x] `npx vitest run` — 101/101 tests pass
- [ ] Visual smoke-test on a deploy preview (homepage hero, search bar tap target on mobile, social share preview)

https://claude.ai/code/session_013GXmk8MGfj88RfdatzmMsG

---
_Generated by [Claude Code](https://claude.ai/code/session_013GXmk8MGfj88RfdatzmMsG)_