### PR TITLE
fix(web): translate stray English UI strings and tighten a11y

### DIFF
--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -16,7 +16,7 @@ const {
   title,
   subtitle,
   backHref = import.meta.env.BASE_URL,
-  backLabel = 'Back',
+  backLabel = 'Voltar',
   tile,
 } = Astro.props;
 
@@ -96,8 +96,8 @@ const recursosLinks = [
       <div class="drawer drawer-end mobile-only">
         <input id="mobile-drawer-home" type="checkbox" class="drawer-toggle" />
         <div class="drawer-content">
-          <label for="mobile-drawer-home" class="btn-menu">
-            <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+          <label for="mobile-drawer-home" class="btn-menu" aria-label="Abrir menu de navegação">
+            <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
               <line x1="3" y1="12" x2="21" y2="12"></line>
               <line x1="3" y1="6" x2="21" y2="6"></line>
               <line x1="3" y1="18" x2="21" y2="18"></line>
@@ -105,7 +105,7 @@ const recursosLinks = [
           </label>
         </div>
         <div class="drawer-side">
-          <label for="mobile-drawer-home" aria-label="close sidebar" class="drawer-overlay"></label>
+          <label for="mobile-drawer-home" aria-label="Fechar menu" class="drawer-overlay"></label>
           <ul class="drawer-menu">
             <li class="menu-title">Principal</li>
             {primaryLinks.map(link => (
@@ -148,7 +148,7 @@ const recursosLinks = [
           </div>
         ) : tile ? (
           <a href={backHref} aria-label={backLabel} class="tile-icon-link">
-            <img src={`${BASE}tiles/${tile}.svg`} alt="" width="40" height="40" class="tile-icon" />
+            <img src={`${BASE}tiles/${tile}.svg`} alt="" width="40" height="40" class="tile-icon" aria-hidden="true" />
           </a>
         ) : (
           <a href={backHref} aria-label={backLabel} class="btn-back">
@@ -209,8 +209,8 @@ const recursosLinks = [
         <div class="drawer drawer-end">
           <input id="mobile-drawer-page" type="checkbox" class="drawer-toggle" />
           <div class="drawer-content">
-            <label for="mobile-drawer-page" class="btn-menu">
-              <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+            <label for="mobile-drawer-page" class="btn-menu" aria-label="Abrir menu de navegação">
+              <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
                 <line x1="3" y1="12" x2="21" y2="12"></line>
                 <line x1="3" y1="6" x2="21" y2="6"></line>
                 <line x1="3" y1="18" x2="21" y2="18"></line>
@@ -218,7 +218,7 @@ const recursosLinks = [
             </label>
           </div>
           <div class="drawer-side">
-            <label for="mobile-drawer-page" aria-label="close sidebar" class="drawer-overlay"></label>
+            <label for="mobile-drawer-page" aria-label="Fechar menu" class="drawer-overlay"></label>
             <ul class="drawer-menu">
               <li><a href={BASE}>Início</a></li>
               <div class="divider-horizontal"></div>

--- a/web/src/components/IncidentBanner.astro
+++ b/web/src/components/IncidentBanner.astro
@@ -19,31 +19,31 @@ const { incident } = Astro.props;
     class="incident-banner" role="alert"
     aria-live="polite">
     <header class="incident-header">
-      <svg class="incident-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg class="incident-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <circle cx="12" cy="12" r="10" />
         <line x1="12" y1="8" x2="12" y2="12" />
         <line x1="12" y1="16" x2="12.01" y2="16" />
       </svg>
       <hgroup>
         <h3 class="incident-title">
-          Critical Pipeline Failure
+          Falha crítica no pipeline
         </h3>
         <p class="incident-description">
-          Collect ZIPs on <code>main</code> has failed
-          <span class="streak-count"> {incident.streak} consecutive times</span>.
+          A coleta de ZIPs em <code>main</code> falhou
+          <span class="streak-count"> {incident.streak} {incident.streak === 1 ? 'vez consecutiva' : 'vezes consecutivas'}</span>.
         </p>
       </hgroup>
     </header>
 
     <div class="incident-details">
       <div class="detail-row">
-        <span class="detail-label">Fix Ready:</span>
+        <span class="detail-label">Correção pronta:</span>
         <a
           href={incident.pr_url} target="_blank"
           rel="noopener noreferrer"
           class="pr-link">
           PR #{incident.pr_number}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1em; height: 1em; display: inline-block; vertical-align: middle;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 1em; height: 1em; display: inline-block; vertical-align: middle;" aria-hidden="true">
             <path d="M15 3h6v6" />
             <path d="M10 14 21 3" />
             <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
@@ -51,7 +51,7 @@ const { incident } = Astro.props;
         </a>
       </div>
       <div class="detail-row">
-        <span class="detail-label">Blocked by:</span>
+        <span class="detail-label">Bloqueado por:</span>
         <span class="blocked-badge">
           {incident.pr_blocked_by}
         </span>
@@ -61,7 +61,7 @@ const { incident } = Astro.props;
            <a
              href={incident.latest_failing_run_url} target="_blank"
              rel="noopener noreferrer">
-             View latest failing run
+             Ver última execução com falha
            </a>
          </div>
       )}

--- a/web/src/components/PageHeader.astro
+++ b/web/src/components/PageHeader.astro
@@ -12,7 +12,7 @@ const {
   title,
   subtitle,
   backHref = import.meta.env.BASE_URL,
-  backLabel = 'Back',
+  backLabel = 'Voltar',
 } = Astro.props;
 ---
 

--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -4,12 +4,12 @@
 <button
   id="theme-toggle"
   class="theme-toggle-btn"
-  aria-label="Toggle theme"
+  aria-label="Alternar tema"
 >
-  <svg id="theme-toggle-sun" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;">
+  <svg id="theme-toggle-sun" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;" aria-hidden="true">
     <circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
   </svg>
-  <svg id="theme-toggle-moon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;">
+  <svg id="theme-toggle-moon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
   </svg>
 </button>
@@ -28,7 +28,7 @@
       document.documentElement.setAttribute('data-theme', isDark ? 'causaganhadark' : 'causaganha');
       sun!.style.display = isDark ? 'block' : 'none';
       moon!.style.display = isDark ? 'none' : 'block';
-      btn!.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      btn!.setAttribute('aria-label', isDark ? 'Mudar para modo claro' : 'Mudar para modo escuro');
     }
 
     applyTheme();

--- a/web/src/pages/admin/perf.astro
+++ b/web/src/pages/admin/perf.astro
@@ -32,30 +32,30 @@ const qualityScores = readJson<Record<string, QualityScore>>('tribunal_quality_s
 ---
 
 <Layout
-  title="CausaGanha - Performance Dashboard"
-  description="System health and performance metrics for the CausaGanha backfill pipeline."
+  title="CausaGanha — Painel de Performance"
+  description="Saúde do sistema e métricas de performance do pipeline de backfill da CausaGanha."
 >
   <Header
     variant="page"
-    title="Performance Monitoring"
-    subtitle="System latency, upload success rates, and tribunal data quality scores"
+    title="Monitoramento de Performance"
+    subtitle="Latência do sistema, taxas de sucesso de upload e qualidade dos dados por tribunal"
   />
 
   <div class="page-container space-y-6">
     <PerfDashboard client:visible perfMetrics={perfMetrics} qualityScores={qualityScores} />
 
     <div role="tablist" class="tabs tabs-bordered w-full sm:w-auto overflow-x-auto mb-4">
-      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Coverage Heatmap" checked="checked" />
+      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Mapa de cobertura" checked="checked" />
       <div role="tabpanel" class="tab-content pt-4">
         <TribunalCoverageHeatmap client:visible />
       </div>
 
-      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Latency Heatmap" />
+      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Mapa de latência" />
       <div role="tabpanel" class="tab-content pt-4">
         <LatencyHeatmap client:visible />
       </div>
 
-      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Parquet Density" />
+      <input type="radio" name="heatmap_tabs" role="tab" class="tab min-w-max" aria-label="Densidade Parquet" />
       <div role="tabpanel" class="tab-content pt-4">
         <ParquetDensityHeatmap client:only="svelte" />
       </div>


### PR DESCRIPTION
## Summary

Easy UI/UX wins after auditing the Astro/Svelte web app — text consistency and accessibility nits that should not have shipped on a pt-BR site.

**Translations (English → Portuguese):**
- `Header.astro` / `PageHeader.astro`: `backLabel` default `'Back'` → `'Voltar'`. Also `aria-label="close sidebar"` → `"Fechar menu"` on both mobile drawer overlays.
- `IncidentBanner.astro`: full body translated (title, streak description with proper singular/plural, "Fix Ready" → "Correção pronta", "Blocked by" → "Bloqueado por", "View latest failing run" → "Ver última execução com falha").
- `ThemeToggle.astro`: `"Toggle theme"` / `"Switch to light mode"` / `"Switch to dark mode"` → `"Alternar tema"` / `"Mudar para modo claro"` / `"Mudar para modo escuro"`.
- `admin/perf.astro`: page title, description, header title/subtitle, and three heatmap tab `aria-label`s.

**Accessibility:**
- Mobile hamburger labels (`<label class="btn-menu">`) had no accessible name — added `aria-label="Abrir menu de navegação"`.
- Decorative SVGs in `Header`, `ThemeToggle`, and `IncidentBanner` now carry `aria-hidden="true"` so screen readers skip them rather than announcing path data or duplicating the parent's label.
- Decorative tile `<img>` in the page header gets `aria-hidden="true"` to complement the existing empty `alt`.

**Bonus fix (no FOUC on theme toggle):**
- `ThemeToggle` previously rendered both sun and moon SVGs with `style="display: none;"`, leaving the button blank until JS swapped one in. The moon icon (default light theme) is now visible by default; JS still swaps to the sun for users with dark theme saved.

## Test plan

- [ ] Open any non-home page (e.g. `/sobre`, `/dados`) — back link tooltip shows "Voltar", not "Back".
- [ ] On mobile viewport, focus the hamburger button — screen reader announces "Abrir menu de navegação".
- [ ] Toggle theme — button `aria-label` updates to the matching pt-BR string.
- [ ] First paint: theme toggle button shows an icon (moon) instead of being blank.
- [ ] When `cache/incident.json` reports a streak, the banner renders entirely in pt-BR.

https://claude.ai/code/session_01KtKqfGQmwPPcEyfsjNAi1A

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtKqfGQmwPPcEyfsjNAi1A)_