### PR TITLE
fix(web): a11y table headers, hover polish, and primary-hover token

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -93,6 +93,7 @@ p, h1, h2, h3, h4, h5, h6 { overflow-wrap: break-word; }
 
   /* Brand */
   --color-primary: #1A6B3C;
+  --color-primary-hover: #155731;
   --color-primary-content: #FAFAF5;
   --color-secondary: #5C5C52;
   --color-secondary-content: #FAFAF5;
@@ -140,6 +141,7 @@ p, h1, h2, h3, h4, h5, h6 { overflow-wrap: break-word; }
   --color-base-content: #F2EFE8;
 
   --color-primary: #3DA568;
+  --color-primary-hover: #2F8552;
   --color-primary-content: #0F1A14;
   --color-secondary: #A8A89E;
   --color-secondary-content: #0F1A14;
@@ -347,10 +349,10 @@ small { font-size: var(--font-size-sm); }
 [data-theme="causaganhadark"] .heatmap-missing { background: #1A2E1F; }
 [data-theme="causaganhadark"] .heatmap-missing:hover { background: #2A3E2F; }
 
-.heatmap-collected { background: #1A6B3C; box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.08); }
-.heatmap-collected:hover { background: #155731; }
-[data-theme="causaganhadark"] .heatmap-collected { background: #1A6B3C; }
-[data-theme="causaganhadark"] .heatmap-collected:hover { background: #3DA568; }
+.heatmap-collected { background: var(--color-primary); box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.08); }
+.heatmap-collected:hover { background: var(--color-primary-hover); }
+[data-theme="causaganhadark"] .heatmap-collected { background: var(--color-primary); }
+[data-theme="causaganhadark"] .heatmap-collected:hover { background: var(--color-primary-hover); }
 
 .heatmap-absent { background: #C5972C; opacity: 0.9; }
 .heatmap-absent:hover { background: #A67D1E; }

--- a/web/src/pages/dicionario.astro
+++ b/web/src/pages/dicionario.astro
@@ -27,10 +27,10 @@ const dictionary = [
       <table class="data-table">
         <thead>
           <tr>
-            <th>Tabela</th>
-            <th>Campo</th>
-            <th>Tipo</th>
-            <th>Descrição</th>
+            <th scope="col">Tabela</th>
+            <th scope="col">Campo</th>
+            <th scope="col">Tipo</th>
+            <th scope="col">Descrição</th>
           </tr>
         </thead>
         <tbody>
@@ -92,5 +92,9 @@ const dictionary = [
 
   .data-table tbody tr:nth-child(even) {
     background: var(--color-base-200);
+  }
+
+  .data-table tbody tr:hover {
+    background: var(--color-surface-overlay);
   }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -552,7 +552,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
   .search-submit:hover,
   .search-submit:focus-visible {
-    background: #155731;
+    background: var(--color-primary-hover);
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -78,6 +78,13 @@ const base = import.meta.env.BASE_URL;
           {top5.length > 0 ? (
             <div class="table-responsive">
               <table class="ranking-table">
+                <thead class="sr-only">
+                  <tr>
+                    <th scope="col">Posição</th>
+                    <th scope="col">Tribunal</th>
+                    <th scope="col">Taxa de cobertura</th>
+                  </tr>
+                </thead>
                 <tbody>
                   {top5.map((c, i) => (
                     <tr>
@@ -103,6 +110,13 @@ const base = import.meta.env.BASE_URL;
           {bottom5.length > 0 ? (
             <div class="table-responsive">
               <table class="ranking-table">
+                <thead class="sr-only">
+                  <tr>
+                    <th scope="col">Posição</th>
+                    <th scope="col">Tribunal</th>
+                    <th scope="col">Taxa de cobertura</th>
+                  </tr>
+                </thead>
                 <tbody>
                   {bottom5.map((c, i) => (
                     <tr>


### PR DESCRIPTION
## Summary

A handful of low-risk web UI/UX easy wins surfaced while auditing pages and components.

- **`/dicionario`** — `<th>` cells had no `scope="col"`; screen readers couldn't associate them with cells. Added `scope="col"` on all four headers.
- **`/stats`** — both ranking tables (Top 5 Mais Confiáveis / Top 5 Mais Falhas) had no `<thead>` at all, just `<tbody>`. Added a visually-hidden `<thead class="sr-only">` with scoped headers so AT users get column context without changing the visual design.
- **`/dicionario`** — table had zebra striping but no row hover; added `tr:hover` for easier scanning of rows.
- **Design tokens** — introduced `--color-primary-hover` (light + dark themes) and replaced the two hardcoded `#155731` literals (`.heatmap-collected:hover` in `index.css`, `.search-submit:hover` in `index.astro`) with the token, so dark mode also gets a sensible hover shade.

Notes on what was *not* changed:
- The Explore agent flagged "missing `:focus-visible`" on several link selectors, but `index.css:608` already declares a global `:focus-visible` rule (`outline: 2px solid var(--color-accent)`) that covers them — adding per-component rules would be redundant.

## Test plan

- [x] `npm run lint` — passes clean
- [x] `npx astro check` — only preexisting errors (missing `public/data/*.json` from backend codegen and unrelated implicit-any types); no new errors introduced
- [ ] Visual: load `/dicionario` and `/stats` and confirm tables render correctly in light + dark mode
- [ ] Screen reader: confirm `/stats` ranking tables now announce column names

https://claude.ai/code/session_01JqDjy1YKtv9pFn2vdfFrjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqDjy1YKtv9pFn2vdfFrjk)_