### PR TITLE
fix(djen-backup): re-queue busy items, incremental counts, narrower excepts

### DIFF
--- a/src/djen_backup/djen.py
+++ b/src/djen_backup/djen.py
@@ -252,7 +252,7 @@ async def _download_simple(
             if total_bytes == 0:
                 await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
                 _raise_not_found(resp.status_code, "Empty ZIP response")
-        except (OSError, httpx.HTTPError, DJENNotFoundError):
+        except (OSError, httpx.HTTPError, DJENNotFoundError, ValueError):
             await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
             raise
 

--- a/src/djen_backup/djen.py
+++ b/src/djen_backup/djen.py
@@ -1,12 +1,6 @@
-from __future__ import annotations
-
-import httpx
-
-
-HTTP_500_INTERNAL_SERVER_ERROR = 500
-
 """DJEN proxy client — caderno info lookup and ZIP download."""
 
+from __future__ import annotations
 
 import asyncio
 import contextlib
@@ -14,6 +8,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
 import structlog
 
 from djen_backup.retry import request_with_retry
@@ -24,6 +19,13 @@ if TYPE_CHECKING:
 
 
 log = structlog.get_logger()
+
+
+# HTTP status constants
+HTTP_NOT_FOUND = 404
+HTTP_FORBIDDEN = 403
+HTTP_BAD_REQUEST = 400
+HTTP_INTERNAL_SERVER_ERROR = 500
 
 
 def _raise_not_found(status_code: int, reason: str) -> None:
@@ -37,10 +39,6 @@ def _raise_server_error(status_code: int) -> None:
     raise httpx.HTTPError(msg)
 
 
-# HTTP status constants
-HTTP_NOT_FOUND = 404
-
-
 class DJENNotFoundError(Exception):
     """Raised when the DJEN proxy returns 404 or an empty response."""
 
@@ -49,6 +47,13 @@ class DJENNotFoundError(Exception):
         super().__init__(reason)
         self.status_code = status_code
         self.reason = reason
+
+
+class DJENRateLimitedError(Exception):
+    """Raised when DJEN/CloudFront returns 403 (transient WAF block).
+
+    This is *not* a circuit-trip event — the next run should retry.
+    """
 
 
 async def get_caderno_url(
@@ -75,15 +80,14 @@ async def get_caderno_url(
     # 404 = no publication for this date (genuine "not found")
     # 400 = holiday/non-publication day (DJEN returns 400 instead of 404)
     # 403 = CloudFront/WAF block — NOT treated as absent, will retry next run
-    if resp.status_code in (HTTP_NOT_FOUND, 400):
+    if resp.status_code in (HTTP_NOT_FOUND, HTTP_BAD_REQUEST):
         raise DJENNotFoundError(status_code=resp.status_code, reason="Not Found")
-    if resp.status_code == 403:
-        msg = "CloudFront block (403) — rate limited"
-        raise httpx.HTTPError(msg)
+    if resp.status_code == HTTP_FORBIDDEN:
+        raise DJENRateLimitedError("CloudFront block (403) — rate limited")
 
     # Transient server errors (5xx, etc.) should propagate as HTTPStatusError
     # so the caller retries rather than permanently marking absent.
-    if resp.status_code >= HTTP_500_INTERNAL_SERVER_ERROR:
+    if resp.status_code >= HTTP_INTERNAL_SERVER_ERROR:
         msg = f"Server error: {resp.status_code}"
         raise httpx.HTTPError(msg)
     resp.raise_for_status()
@@ -130,7 +134,7 @@ async def _download_segment(
         retry_404=True,
     )
 
-    if resp.status_code >= HTTP_500_INTERNAL_SERVER_ERROR:
+    if resp.status_code >= HTTP_INTERNAL_SERVER_ERROR:
         msg = f"Server error on segment: {resp.status_code}"
         raise httpx.HTTPError(msg)
     resp.raise_for_status()
@@ -193,7 +197,7 @@ async def download_zip(
         try:
             for seg in segments:
                 tmp.write(seg)
-        except Exception:
+        except OSError:
             await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
             raise
 
@@ -227,7 +231,7 @@ async def _download_simple(
                 await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
                 _raise_not_found(HTTP_NOT_FOUND, "ZIP download 404")
 
-            if resp.status_code >= HTTP_500_INTERNAL_SERVER_ERROR:
+            if resp.status_code >= HTTP_INTERNAL_SERVER_ERROR:
                 await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
                 _raise_server_error(resp.status_code)
 
@@ -248,7 +252,7 @@ async def _download_simple(
             if total_bytes == 0:
                 await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
                 _raise_not_found(resp.status_code, "Empty ZIP response")
-        except Exception:
+        except (OSError, httpx.HTTPError, DJENNotFoundError):
             await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
             raise
 

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -20,12 +20,18 @@ from aiolimiter import AsyncLimiter
 from causaganha.pipeline.ia_s3 import create_upload_client
 from djen_backup.archive import (
     CircuitBreaker,
+    ItemBusyError,
     check_ia_file_exists,
     fetch_ia_existing,
     get_ia_item_id,
     upload_zip,
 )
-from djen_backup.djen import DJENNotFoundError, download_zip, get_caderno_url
+from djen_backup.djen import (
+    DJENNotFoundError,
+    DJENRateLimitedError,
+    download_zip,
+    get_caderno_url,
+)
 from djen_backup.manifest import ManifestCounts, ManifestEntry, SyncManifest
 from djen_backup.tribunais import get_tribunal_list
 
@@ -48,7 +54,7 @@ def load_djen_safe_concurrency() -> int:
 
         data = json.loads(DJEN_SAFE_CONCURRENCY_FILE.read_text())
         return max(1, int(data.get("safe_concurrency", DEFAULT_DJEN_CONCURRENCY)))
-    except Exception:
+    except (OSError, ValueError):
         return DEFAULT_DJEN_CONCURRENCY
 
 
@@ -168,7 +174,7 @@ async def run_pipeline(
                     if len(parts) == 2 and parts[1].isdigit():
                         existing_items.add((parts[0][5:].upper(), int(parts[1])))
                 log.info("ia_items_discovered", count=len(existing_items))
-            except Exception as exc:
+            except (httpx.HTTPError, ValueError, KeyError) as exc:
                 log.warning("ia_search_failed_fallback", error=str(exc))
                 existing_items = {
                     (e.tribunal, e.date.year)
@@ -249,8 +255,8 @@ async def run_pipeline(
         try:
             if await manifest.upload_to_ia(config.ia_auth):
                 await manifest.upload_summary_to_ia(config.ia_auth)
-        except Exception:
-            pass
+        except (httpx.HTTPError, OSError) as exc:
+            log.warning("manifest_upload_background_failed", error=str(exc))
         finally:
             _ia_upload_running = False
 
@@ -292,8 +298,13 @@ async def run_pipeline(
                                 )
                             synced_ia_items.add(item_key)
                             _notify_counts()
-                        except Exception:
-                            pass
+                        except httpx.HTTPError as exc:
+                            log.warning(
+                                "ia_metadata_sync_failed",
+                                tribunal=entry.tribunal,
+                                year=entry.date.year,
+                                error=str(exc),
+                            )
 
             if entry.ia_status == "uploaded":
                 continue
@@ -306,13 +317,22 @@ async def run_pipeline(
                 raw_status = "200"
             except DJENNotFoundError as exc:
                 raw_status = str(exc.status_code)
-            except Exception:
+            except DJENRateLimitedError:
+                # 403 / CloudFront block — transient, do NOT trip the breaker.
+                raw_status = "403"
+            except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+                log.warning(
+                    "djen_check_error",
+                    tribunal=entry.tribunal,
+                    date=entry.date.isoformat(),
+                    error=str(exc),
+                )
                 raw_status = "error"
 
             await manifest.mark_djen_raw(entry.tribunal, entry.date, raw_status)
-            if raw_status in ("403", "429", "timeout", "error"):
+            if raw_status in ("429", "timeout", "error"):
                 await djen_breaker.record_failure()
-            else:
+            elif raw_status != "403":
                 await djen_breaker.record_success()
 
             _notify_counts()
@@ -357,7 +377,7 @@ async def run_pipeline(
                 await asyncio.to_thread(shutil.move, str(zip_path), str(final_path))
                 await summary.inc_download()
                 await upload_queue.put(StagedItem(item_id, entry.date, entry.tribunal, final_path))
-            except Exception as exc:
+            except (httpx.HTTPError, OSError, DJENNotFoundError, DJENRateLimitedError) as exc:
                 log.warning(
                     "download_failed",
                     tribunal=entry.tribunal,
@@ -380,21 +400,42 @@ async def run_pipeline(
                     await summary.inc_upload()
                     if config.observer:
                         config.observer.on_log(f"[dim]Already on IA[/dim] {item.tribunal} {item.d}")
-                elif await upload_zip(
-                    upload_client,
-                    item.item_id,
-                    item.path,
-                    circuit_breaker=circuit_breaker,
-                    try_lock=True,
-                ):
-                    await manifest.mark_uploaded(item.tribunal, item.d)
-                    await summary.inc_upload()
-                    if config.observer:
-                        config.observer.on_log(f"[green]Uploaded[/green] {item.tribunal} {item.d}")
-                elif config.fail_fast:
-                    abort_event.set()
-                item.path.unlink(missing_ok=True)
-            except Exception as exc:
+                    item.path.unlink(missing_ok=True)
+                else:
+                    try:
+                        ok = await upload_zip(
+                            upload_client,
+                            item.item_id,
+                            item.path,
+                            circuit_breaker=circuit_breaker,
+                            try_lock=True,
+                        )
+                    except ItemBusyError:
+                        # Another worker holds the per-item lock — re-queue this
+                        # item and pick a different one rather than blocking on
+                        # the same bucket. Use put_nowait to avoid deadlocking
+                        # the bounded queue; if it's saturated, drop the staged
+                        # file (the manifest still flags the entry as available
+                        # so the next run re-feeds it).
+                        log.debug("upload_item_busy_requeue", item_id=item.item_id)
+                        await asyncio.sleep(0.25)
+                        try:
+                            upload_queue.put_nowait(item)
+                        except asyncio.QueueFull:
+                            log.info("upload_requeue_dropped", item_id=item.item_id)
+                            item.path.unlink(missing_ok=True)
+                    else:
+                        if ok:
+                            await manifest.mark_uploaded(item.tribunal, item.d)
+                            await summary.inc_upload()
+                            if config.observer:
+                                config.observer.on_log(
+                                    f"[green]Uploaded[/green] {item.tribunal} {item.d}"
+                                )
+                        elif config.fail_fast:
+                            abort_event.set()
+                        item.path.unlink(missing_ok=True)
+            except (httpx.HTTPError, OSError) as exc:
                 log.warning("upload_exception", item_id=item.item_id, error=str(exc))
             finally:
                 upload_queue.task_done()

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -54,7 +54,7 @@ def load_djen_safe_concurrency() -> int:
 
         data = json.loads(DJEN_SAFE_CONCURRENCY_FILE.read_text())
         return max(1, int(data.get("safe_concurrency", DEFAULT_DJEN_CONCURRENCY)))
-    except (OSError, ValueError):
+    except (OSError, ValueError, TypeError):
         return DEFAULT_DJEN_CONCURRENCY
 
 

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -174,7 +174,7 @@ async def run_pipeline(
                     if len(parts) == 2 and parts[1].isdigit():
                         existing_items.add((parts[0][5:].upper(), int(parts[1])))
                 log.info("ia_items_discovered", count=len(existing_items))
-            except (httpx.HTTPError, ValueError, KeyError) as exc:
+            except (httpx.HTTPError, ValueError, KeyError, TypeError, AttributeError) as exc:
                 log.warning("ia_search_failed_fallback", error=str(exc))
                 existing_items = {
                     (e.tribunal, e.date.year)
@@ -377,7 +377,13 @@ async def run_pipeline(
                 await asyncio.to_thread(shutil.move, str(zip_path), str(final_path))
                 await summary.inc_download()
                 await upload_queue.put(StagedItem(item_id, entry.date, entry.tribunal, final_path))
-            except (httpx.HTTPError, OSError, DJENNotFoundError, DJENRateLimitedError) as exc:
+            except (
+                httpx.HTTPError,
+                OSError,
+                ValueError,
+                DJENNotFoundError,
+                DJENRateLimitedError,
+            ) as exc:
                 log.warning(
                     "download_failed",
                     tribunal=entry.tribunal,

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -83,8 +83,10 @@ class SyncManifest:
     def __init__(self) -> None:
         self._entries: dict[str, ManifestEntry] = {}
         self._lock = asyncio.Lock()
-        # Cached counts — invalidated on any mark_* call
-        self._counts_cache: ManifestCounts | None = None
+        # Maintained tally — updated incrementally by mark_* (O(1) per mark).
+        # Populated lazily on first counts() call; bulk operations (build,
+        # prune, load_*) reset to None to force a full rebuild.
+        self._counts_tally: dict[str, int] | None = None
         # Cache of (tribunal, year) pairs that have uploaded entries
         self._uploaded_items: set[tuple[str, int]] | None = None
 
@@ -125,8 +127,31 @@ class SyncManifest:
             self._invalidate_caches()
         return added
 
+    @staticmethod
+    def _categorize(entry: ManifestEntry) -> str:
+        """Bucket an entry into uploaded/available/absent/unknown."""
+        if entry.ia_status == "uploaded":
+            return "uploaded"
+        if entry.djen_status == "available":
+            return "available"
+        if entry.djen_status == "absent":
+            return "absent"
+        return "unknown"
+
+    def _adjust_counts(self, old_cat: str | None, new_cat: str | None) -> None:
+        """Incrementally adjust the maintained tally (no-op if not built yet)."""
+        if self._counts_tally is None:
+            return
+        if old_cat == new_cat:
+            return
+        if old_cat is not None:
+            self._counts_tally[old_cat] -= 1
+        if new_cat is not None:
+            self._counts_tally[new_cat] += 1
+
     def _invalidate_caches(self) -> None:
-        self._counts_cache = None
+        # Force a full counts rebuild on next counts() call.
+        self._counts_tally = None
         self._uploaded_items = None
 
     def prune(self) -> int:
@@ -153,11 +178,13 @@ class SyncManifest:
                 k = self._key(tribunal, d)
                 entry = self._entries.get(k)
                 if entry and entry.ia_status != "uploaded":
+                    old_cat = self._categorize(entry)
                     entry.ia_status = "uploaded"
                     entry.updated_at = now
+                    self._adjust_counts(old_cat, "uploaded")
                     changed += 1
             if changed:
-                self._invalidate_caches()
+                self._uploaded_items = None
         return changed
 
     async def mark_ia_checked(self, tribunal: str, year: int, found_dates: set[date]) -> None:
@@ -170,10 +197,11 @@ class SyncManifest:
             k = self._key(tribunal, d)
             entry = self._entries.get(k)
             if entry:
+                old_cat = self._categorize(entry)
                 entry.djen_raw = raw
                 entry.djen_status = interpret_djen_raw(raw)
                 entry.updated_at = datetime.now(UTC).isoformat(timespec="seconds")
-                self._invalidate_caches()
+                self._adjust_counts(old_cat, self._categorize(entry))
 
     async def mark_djen_available(self, tribunal: str, d: date) -> None:
         """Shortcut: mark djen_raw=200 → status=available."""
@@ -188,10 +216,12 @@ class SyncManifest:
         async with self._lock:
             k = self._key(tribunal, d)
             entry = self._entries.get(k)
-            if entry:
+            if entry and entry.ia_status != "uploaded":
+                old_cat = self._categorize(entry)
                 entry.ia_status = "uploaded"
                 entry.updated_at = datetime.now(UTC).isoformat(timespec="seconds")
-                self._invalidate_caches()
+                self._adjust_counts(old_cat, "uploaded")
+                self._uploaded_items = None
 
     # ── Query methods ────────────────────────────────────────────────
 
@@ -206,29 +236,20 @@ class SyncManifest:
         return (tribunal.upper(), year) in self._uploaded_items
 
     def counts(self) -> ManifestCounts:
-        if self._counts_cache is not None:
-            return self._counts_cache
-        uploaded = 0
-        available = 0
-        absent = 0
-        unknown = 0
-        for e in self._entries.values():
-            if e.ia_status == "uploaded":
-                uploaded += 1
-            elif e.djen_status == "available":
-                available += 1
-            elif e.djen_status == "absent":
-                absent += 1
-            else:
-                unknown += 1
-        self._counts_cache = ManifestCounts(
+        """Return aggregate counts. O(1) when tally is warm, O(N) on rebuild."""
+        if self._counts_tally is None:
+            tally = {"uploaded": 0, "available": 0, "absent": 0, "unknown": 0}
+            for e in self._entries.values():
+                tally[self._categorize(e)] += 1
+            self._counts_tally = tally
+        t = self._counts_tally
+        return ManifestCounts(
             total=len(self._entries),
-            uploaded=uploaded,
-            available=available,
-            absent=absent,
-            unknown=unknown,
+            uploaded=t["uploaded"],
+            available=t["available"],
+            absent=t["absent"],
+            unknown=t["unknown"],
         )
-        return self._counts_cache
 
     def items_needing_ia_check(self) -> list[tuple[str, int]]:
         """Return (tribunal, year) pairs that have fully unknown entries.
@@ -408,8 +429,9 @@ class SyncManifest:
                 self._load_manifest_line(parts, overwrite=overwrite)
 
         loaded = len(self._entries) - before
-        if loaded:
-            self._invalidate_caches()
+        # Always invalidate: even when no entries were added, overwrite-mode
+        # mutates existing entries' status which changes counts.
+        self._invalidate_caches()
         return loaded
 
     def _load_legacy_line(self, parts: list[str]) -> None:

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -138,16 +138,14 @@ class SyncManifest:
             return "absent"
         return "unknown"
 
-    def _adjust_counts(self, old_cat: str | None, new_cat: str | None) -> None:
+    def _adjust_counts(self, old_cat: str, new_cat: str) -> None:
         """Incrementally adjust the maintained tally (no-op if not built yet)."""
         if self._counts_tally is None:
             return
         if old_cat == new_cat:
             return
-        if old_cat is not None:
-            self._counts_tally[old_cat] -= 1
-        if new_cat is not None:
-            self._counts_tally[new_cat] += 1
+        self._counts_tally[old_cat] -= 1
+        self._counts_tally[new_cat] += 1
 
     def _invalidate_caches(self) -> None:
         # Force a full counts rebuild on next counts() call.

--- a/tests/djen_backup/test_djen_403.py
+++ b/tests/djen_backup/test_djen_403.py
@@ -1,0 +1,40 @@
+"""DJEN 403 handling — CloudFront blocks must surface as DJENRateLimitedError."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import pytest
+import respx
+
+from djen_backup.djen import DJENNotFoundError, DJENRateLimitedError, get_caderno_url
+
+
+@pytest.mark.asyncio
+async def test_get_caderno_url_raises_rate_limited_on_403() -> None:
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith="https://djen.example/").respond(403)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(DJENRateLimitedError):
+                await get_caderno_url(client, "https://djen.example", "TJSP", date(2024, 1, 2))
+
+
+@pytest.mark.asyncio
+async def test_get_caderno_url_raises_not_found_on_404() -> None:
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith="https://djen.example/").respond(404)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(DJENNotFoundError) as exc_info:
+                await get_caderno_url(client, "https://djen.example", "TJSP", date(2024, 1, 2))
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_caderno_url_raises_not_found_on_400_holiday() -> None:
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith="https://djen.example/").respond(400)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(DJENNotFoundError) as exc_info:
+                await get_caderno_url(client, "https://djen.example", "TJSP", date(2024, 1, 2))
+    assert exc_info.value.status_code == 400

--- a/tests/djen_backup/test_manifest_counts.py
+++ b/tests/djen_backup/test_manifest_counts.py
@@ -1,0 +1,69 @@
+"""Test that incremental counts stay in sync with from-scratch recounts."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from djen_backup.manifest import ManifestCounts, SyncManifest
+
+
+def _recount(m: SyncManifest) -> ManifestCounts:
+    """From-scratch recount via the slow path (force tally rebuild)."""
+    m._counts_tally = None  # test inspects internal state to force rebuild
+    return m.counts()
+
+
+@pytest.mark.asyncio
+async def test_incremental_counts_match_recount_after_marks() -> None:
+    m = SyncManifest()
+    m.build(["TJSP", "TJBA"], date(2024, 1, 1), date(2024, 1, 5))
+    # Warm the tally so subsequent mark_* calls exercise the incremental path.
+    initial = m.counts()
+    assert initial.total == 10  # 2 tribunals x 5 weekdays
+    assert initial.unknown == 10
+
+    await m.mark_djen_raw("TJSP", date(2024, 1, 1), "200")
+    await m.mark_djen_raw("TJSP", date(2024, 1, 2), "404")
+    await m.mark_djen_raw("TJSP", date(2024, 1, 3), "403")  # transient → unknown
+    await m.mark_uploaded("TJBA", date(2024, 1, 1))
+    await m.mark_djen_raw("TJSP", date(2024, 1, 1), "200")  # idempotent
+
+    incremental = m.counts()
+    assert incremental == _recount(m)
+    assert incremental.uploaded == 1
+    assert incremental.available == 1
+    assert incremental.absent == 1
+    assert incremental.unknown == 7
+
+
+@pytest.mark.asyncio
+async def test_uploading_after_available_transitions_categories() -> None:
+    m = SyncManifest()
+    m.build(["TJSP"], date(2024, 1, 1), date(2024, 1, 1))
+    m.counts()  # warm tally
+
+    await m.mark_djen_raw("TJSP", date(2024, 1, 1), "200")
+    assert m.counts().available == 1
+
+    await m.mark_uploaded("TJSP", date(2024, 1, 1))
+    c = m.counts()
+    assert c.uploaded == 1
+    assert c.available == 0
+    assert c == _recount(m)
+
+
+@pytest.mark.asyncio
+async def test_bulk_load_invalidates_tally() -> None:
+    m = SyncManifest()
+    m.build(["TJSP"], date(2024, 1, 1), date(2024, 1, 2))
+    m.counts()  # warm tally
+
+    csv = (
+        "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
+        "TJSP,2024-01-01,uploaded,available,200,2024-01-02T00:00:00+00:00\n"
+    )
+    m.load_from_csv(csv, overwrite=True)
+    assert m.counts() == _recount(m)
+    assert m.counts().uploaded == 1

--- a/tests/djen_backup/test_upload_lock.py
+++ b/tests/djen_backup/test_upload_lock.py
@@ -1,0 +1,59 @@
+"""Per-item upload lock behavior — try_lock must raise ItemBusyError.
+
+CLAUDE.md mandates re-queueing on ItemBusyError; the engine's upload_worker
+implements that re-queue, but the contract upload_zip relies on is that the
+exception fires when the lock is held.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from djen_backup.archive import ItemBusyError, _lock_for, upload_zip
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_upload_zip_try_lock_raises_when_item_busy(tmp_path: Path) -> None:
+    item_id = "djen-tjsp-2024"
+    zip_path = tmp_path / "djen-2024-01-02-TJSP.zip"
+    zip_path.write_bytes(b"PK\x03\x04")
+
+    # Pre-acquire the per-item lock to simulate a concurrent uploader.
+    lock = await _lock_for(item_id)
+    await lock.acquire()
+    try:
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(ItemBusyError):
+                await upload_zip(client, item_id, zip_path, try_lock=True)
+    finally:
+        lock.release()
+
+
+@pytest.mark.asyncio
+async def test_lock_for_returns_same_instance_for_same_item() -> None:
+    a = await _lock_for("djen-test-2024")
+    b = await _lock_for("djen-test-2024")
+    assert a is b
+    c = await _lock_for("djen-test-2025")
+    assert c is not a
+
+
+@pytest.mark.asyncio
+async def test_distinct_items_can_upload_concurrently() -> None:
+    # Two distinct item_ids should have independent locks — both can be held.
+    lock_a = await _lock_for("djen-tjsp-2024")
+    lock_b = await _lock_for("djen-tjba-2024")
+    await asyncio.wait_for(lock_a.acquire(), timeout=1)
+    try:
+        await asyncio.wait_for(lock_b.acquire(), timeout=1)
+        lock_b.release()
+    finally:
+        lock_a.release()


### PR DESCRIPTION
## Summary

A fresh-eyes audit of `src/djen_backup/` surfaced five gaps where the implementation diverged from `CLAUDE.md` or carried correctness bugs. This PR addresses them in one sweep.

### Fixes

1. **`ItemBusyError` re-queue** (`engine.py`). The upload worker silently counted busy items as errors. CLAUDE.md says "ItemBusyError → re-queue, don't block." Now uses `put_nowait` with a QueueFull fallback so the bounded staging queue can't deadlock.
2. **Incremental counts** (`manifest.py`). `_counts_cache` was invalidated on every `mark_*`, defeating the 2 Hz throttle on `_notify_counts()` — every tick triggered a full 157 K-entry scan. The cache is now a maintained tally updated O(1) per mark. Also fixes a pre-existing bug where `load_from_csv(overwrite=True)` failed to invalidate when it only mutated existing rows.
3. **403 handling** (`djen.py` + `engine.py`). DJEN 403 (CloudFront/WAF) raised a generic `httpx.HTTPError` and tripped the circuit breaker through the `"error"` raw_status branch. Now raises a dedicated `DJENRateLimitedError`, recorded as `raw_status="403"` without a breaker hit.
4. **Narrower exceptions**. Replaced broad `except Exception:` with specific types (`httpx.HTTPError`, `OSError`, `ValueError`, `KeyError`, `asyncio.TimeoutError`, …) per the BLE001 rule. Net ruff error count in `src/djen_backup` drops 105 → 97.
5. **`djen.py` cleanup**. Docstring/`__future__`/imports ordered correctly, duplicate `from __future__` removed, `HTTP_*` constants consolidated.

### Tests added

- `tests/djen_backup/test_manifest_counts.py` — incremental tally matches from-scratch recount across `mark_*` sequences and bulk loads.
- `tests/djen_backup/test_djen_403.py` — 403 → `DJENRateLimitedError`; 400/404 → `DJENNotFoundError`.
- `tests/djen_backup/test_upload_lock.py` — `try_lock=True` raises `ItemBusyError` when held; per-item locks independent across buckets.

### Out of scope

- Deduplicating `CircuitBreaker` between `archive.py` (async) and `causaganha/pipeline/ia_s3.py` (sync) — the sync version is wired into 7+ files in `consolidate/` and `scripts/`, so it's a separate change.

## Test plan

- [x] `uv run ruff check src/djen_backup tests/djen_backup` (no new errors; 8 fewer overall)
- [x] `uv run ruff format --check`
- [x] `uv run pytest tests/djen_backup -q` — 27 passed (was 18)
- [x] `uv run pytest -q` — 85 passed, 1 skipped
- [ ] Smoke run: `uv run --env-file ~/workspace/.env djen-backup check --workers 4` — watch for 403s recorded as `djen_raw="403"` without circuit_breaker_open events, and progress logs ticking smoothly under load.

https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq)_