### PR TITLE
refactor: dedupe CircuitBreaker; extract upload-handler for testability

### DIFF
--- a/src/causaganha/pipeline/ia_s3.py
+++ b/src/causaganha/pipeline/ia_s3.py
@@ -23,6 +23,12 @@ import httpx
 import structlog
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
+# Re-export the canonical CircuitBreaker so legacy callers
+# (`from causaganha.pipeline.ia_s3 import CircuitBreaker`) keep working
+# without duplicating the implementation. The class supports both sync
+# (is_open / record_*) and async (allow_request) APIs.
+from djen_backup.circuit_breaker import CircuitBreaker as CircuitBreaker  # noqa: PLC0414
+
 
 logger = structlog.get_logger()
 
@@ -109,34 +115,6 @@ def parse_deadline(duration_str: str) -> int:
         return int(float(duration_str))
     except ValueError:
         return 0
-
-
-# ---------------------------------------------------------------------------
-# Circuit breaker (optional, for resilience during IA outages)
-# ---------------------------------------------------------------------------
-
-
-class CircuitBreaker:
-    """Lightweight circuit breaker for IA upload operations.
-
-    After *threshold* consecutive failures the breaker opens and
-    ``is_open`` returns ``True``, allowing callers to skip further
-    attempts and avoid wasting requests during an IA outage.
-    """
-
-    def __init__(self, threshold: int = 5) -> None:
-        self.consecutive_failures = 0
-        self.threshold = threshold
-
-    def record_success(self) -> None:
-        self.consecutive_failures = 0
-
-    def record_failure(self) -> None:
-        self.consecutive_failures += 1
-
-    @property
-    def is_open(self) -> bool:
-        return self.consecutive_failures >= self.threshold
 
 
 # ---------------------------------------------------------------------------

--- a/src/djen_backup/archive.py
+++ b/src/djen_backup/archive.py
@@ -1,10 +1,13 @@
-"""Internet Archive S3 upload, metadata queries, and circuit breaker."""
+"""Internet Archive S3 upload and metadata queries.
+
+The circuit-breaker class lives in ``djen_backup.circuit_breaker`` and is
+re-exported here for backward compatibility with existing imports.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import time
-from enum import StrEnum
 from typing import TYPE_CHECKING
 
 import httpx
@@ -12,7 +15,21 @@ import structlog
 from aiolimiter import AsyncLimiter
 
 from causaganha.pipeline import ia_s3
+from djen_backup.circuit_breaker import CircuitBreaker, CircuitState
 from djen_backup.retry import RETRIABLE_STATUS_CODES, _backoff, request_with_retry
+
+
+__all__ = [
+    "CircuitBreaker",
+    "CircuitState",
+    "ItemBusyError",
+    "check_ia_file_exists",
+    "fetch_ia_existing",
+    "get_ia_item_id",
+    "get_ia_item_tribunal",
+    "put_ia_bytes",
+    "upload_zip",
+]
 
 
 if TYPE_CHECKING:
@@ -244,114 +261,19 @@ async def upload_zip(
                 error=str(exc),
             )
             if circuit_breaker is not None:
-                await circuit_breaker.record_failure()
+                circuit_breaker.record_failure()
             return False
 
     elapsed = round(time.monotonic() - start, 1)
     if ok:
         log.info("upload_complete", item_id=item_id, file=zip_path.name, elapsed_s=elapsed)
         if circuit_breaker is not None:
-            await circuit_breaker.record_success()
+            circuit_breaker.record_success()
     else:
         log.warning("upload_failed", item_id=item_id, file=zip_path.name, elapsed_s=elapsed)
         if circuit_breaker is not None:
-            await circuit_breaker.record_failure()
+            circuit_breaker.record_failure()
     return ok
 
 
-# ── Circuit breaker ──────────────────────────────────────────────────
-
-
-class CircuitState(StrEnum):
-    """States for the circuit breaker."""
-
-    CLOSED = "closed"
-    OPEN = "open"
-    HALF_OPEN = "half_open"
-
-
-class CircuitBreaker:
-    """Circuit breaker with half-open recovery for IA uploads.
-
-    - CLOSED: normal operation, count consecutive failures.
-    - OPEN: after *threshold* failures, refuse requests for *recovery_timeout* seconds.
-    - HALF_OPEN: after timeout elapses, allow **one** test request.
-      Success → CLOSED.  Failure → OPEN with doubled timeout (capped at 5 min).
-    """
-
-    def __init__(
-        self,
-        threshold: int = 5,
-        recovery_timeout: float = 60.0,
-    ) -> None:
-        """Initialize the circuit breaker with failure threshold and recovery timeout."""
-        self._threshold = threshold
-        self._base_recovery = recovery_timeout
-        self._recovery_timeout = recovery_timeout
-        self._failure_count = 0
-        self._state = CircuitState.CLOSED
-        self._opened_at = 0.0
-        self._lock = asyncio.Lock()
-
-    @property
-    def state(self) -> CircuitState:
-        """Return the current state (for external inspection / tests)."""
-        if (
-            self._state == CircuitState.OPEN
-            and time.monotonic() - self._opened_at >= self._recovery_timeout
-        ):
-            return CircuitState.HALF_OPEN
-        return self._state
-
-    def _state_locked(self) -> CircuitState:
-        """Compute state while the lock is held (avoids TOCTOU)."""
-        if (
-            self._state == CircuitState.OPEN
-            and time.monotonic() - self._opened_at >= self._recovery_timeout
-        ):
-            return CircuitState.HALF_OPEN
-        return self._state
-
-    async def allow_request(self) -> bool:
-        """Check if a request is allowed by the circuit breaker."""
-        async with self._lock:
-            s = self._state_locked()
-            if s == CircuitState.CLOSED:
-                return True
-            if s == CircuitState.HALF_OPEN:
-                # Consume the probe slot — transition to OPEN so only one
-                # worker gets through while the test request is in-flight.
-                self._state = CircuitState.OPEN
-                self._opened_at = time.monotonic()
-                return True
-            return False
-
-    async def record_success(self) -> None:
-        """Record a successful request and reset the circuit."""
-        async with self._lock:
-            self._failure_count = 0
-            self._state = CircuitState.CLOSED
-            self._recovery_timeout = self._base_recovery
-
-    async def record_failure(self) -> None:
-        """Record a failed request and update circuit state accordingly."""
-        async with self._lock:
-            self._failure_count += 1
-            was_open = self._state == CircuitState.OPEN
-            if self._state_locked() == CircuitState.HALF_OPEN:
-                # Test request failed — reopen with increased timeout
-                self._recovery_timeout = min(self._recovery_timeout * 2, 300.0)
-                self._state = CircuitState.OPEN
-                self._opened_at = time.monotonic()
-                log.warning(
-                    "circuit_breaker_reopen",
-                    next_retry_s=self._recovery_timeout,
-                )
-            elif self._failure_count >= self._threshold and not was_open:
-                self._state = CircuitState.OPEN
-                self._opened_at = time.monotonic()
-                log.error(
-                    "circuit_breaker_open",
-                    failures=self._failure_count,
-                    recovery_s=self._recovery_timeout,
-                )
+# Circuit breaker class lives in djen_backup.circuit_breaker (imported above).

--- a/src/djen_backup/circuit_breaker.py
+++ b/src/djen_backup/circuit_breaker.py
@@ -1,0 +1,129 @@
+"""Circuit breaker for IA uploads — single source of truth.
+
+Lives in its own module so both ``djen_backup.archive`` (async upload
+pipeline) and ``causaganha.pipeline.ia_s3`` (sync legacy callers) can
+import it without creating a cycle.
+
+``record_success`` / ``record_failure`` / ``is_open`` are sync so the
+same instance can be shared by sync and async callers. ``allow_request``
+stays async because async callers expect to ``await`` it; internally it
+uses the same threading lock as the sync methods.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from enum import StrEnum
+
+import structlog
+
+
+log = structlog.get_logger()
+
+
+class CircuitState(StrEnum):
+    """States for the circuit breaker."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    """Circuit breaker with half-open recovery.
+
+    - CLOSED: normal operation, count consecutive failures.
+    - OPEN: after *threshold* failures, refuse requests for *recovery_timeout* seconds.
+    - HALF_OPEN: after timeout elapses, allow **one** test request.
+      Success → CLOSED.  Failure → OPEN with doubled timeout (capped at 5 min).
+    """
+
+    def __init__(
+        self,
+        threshold: int = 5,
+        recovery_timeout: float = 60.0,
+    ) -> None:
+        """Initialize the circuit breaker with failure threshold and recovery timeout."""
+        self._threshold = threshold
+        self._base_recovery = recovery_timeout
+        self._recovery_timeout = recovery_timeout
+        self._failure_count = 0
+        self._state = CircuitState.CLOSED
+        self._opened_at = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def state(self) -> CircuitState:
+        """Return the current state (for external inspection / tests)."""
+        if (
+            self._state == CircuitState.OPEN
+            and time.monotonic() - self._opened_at >= self._recovery_timeout
+        ):
+            return CircuitState.HALF_OPEN
+        return self._state
+
+    @property
+    def is_open(self) -> bool:
+        """Sync open-check for callers that don't drive the async probe slot.
+
+        Returns True only for OPEN — HALF_OPEN is "ready to probe" so callers
+        that drive the state machine via ``allow_request`` see a chance to
+        recover. Sync callers that only check ``is_open`` resume once a
+        ``record_success`` resets the counter.
+        """
+        return self._state == CircuitState.OPEN
+
+    def _state_locked(self) -> CircuitState:
+        """Compute state while the lock is held (avoids TOCTOU)."""
+        if (
+            self._state == CircuitState.OPEN
+            and time.monotonic() - self._opened_at >= self._recovery_timeout
+        ):
+            return CircuitState.HALF_OPEN
+        return self._state
+
+    async def allow_request(self) -> bool:
+        """Check if a request is allowed by the circuit breaker."""
+        # threading.Lock is held briefly for state mutation; safe in async.
+        with self._lock:
+            s = self._state_locked()
+            if s == CircuitState.CLOSED:
+                return True
+            if s == CircuitState.HALF_OPEN:
+                # Consume the probe slot — transition to OPEN so only one
+                # worker gets through while the test request is in-flight.
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                return True
+            return False
+
+    def record_success(self) -> None:
+        """Record a successful request and reset the circuit."""
+        with self._lock:
+            self._failure_count = 0
+            self._state = CircuitState.CLOSED
+            self._recovery_timeout = self._base_recovery
+
+    def record_failure(self) -> None:
+        """Record a failed request and update circuit state accordingly."""
+        with self._lock:
+            self._failure_count += 1
+            was_open = self._state == CircuitState.OPEN
+            if self._state_locked() == CircuitState.HALF_OPEN:
+                # Test request failed — reopen with increased timeout
+                self._recovery_timeout = min(self._recovery_timeout * 2, 300.0)
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                log.warning(
+                    "circuit_breaker_reopen",
+                    next_retry_s=self._recovery_timeout,
+                )
+            elif self._failure_count >= self._threshold and not was_open:
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                log.error(
+                    "circuit_breaker_open",
+                    failures=self._failure_count,
+                    recovery_s=self._recovery_timeout,
+                )

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -141,6 +141,71 @@ class SyncSummary:
             self.errors += 1
 
 
+# ── Upload item handler (extracted for testability) ─────────────────
+
+
+async def _process_upload_item(
+    item: StagedItem,
+    *,
+    upload_client: httpx.AsyncClient,
+    upload_queue: asyncio.Queue[StagedItem | None],
+    manifest: SyncManifest,
+    summary: SyncSummary,
+    circuit_breaker: CircuitBreaker,
+    abort_event: asyncio.Event,
+    fail_fast: bool,
+    observer: ManifestObserver | None,
+) -> None:
+    """Handle a single staged upload item.
+
+    Resolves to: already-on-IA short-circuit, real upload, busy re-queue,
+    or saturated-queue drop. The behaviour mirrors what was previously
+    inline in ``upload_worker`` — extracted so it can be unit-tested.
+    """
+    try:
+        if await check_ia_file_exists(upload_client, item.tribunal, item.d):
+            await manifest.mark_uploaded(item.tribunal, item.d)
+            await summary.inc_upload()
+            if observer:
+                observer.on_log(f"[dim]Already on IA[/dim] {item.tribunal} {item.d}")
+            item.path.unlink(missing_ok=True)
+            return
+
+        try:
+            ok = await upload_zip(
+                upload_client,
+                item.item_id,
+                item.path,
+                circuit_breaker=circuit_breaker,
+                try_lock=True,
+            )
+        except ItemBusyError:
+            # Another worker holds the per-item lock — re-queue and pick a
+            # different item rather than blocking on the same bucket. Use
+            # put_nowait so a saturated bounded queue can't deadlock; if it
+            # is full, drop the staged file (the manifest still flags the
+            # entry as available so the next run re-feeds it).
+            log.debug("upload_item_busy_requeue", item_id=item.item_id)
+            await asyncio.sleep(0.25)
+            try:
+                upload_queue.put_nowait(item)
+            except asyncio.QueueFull:
+                log.info("upload_requeue_dropped", item_id=item.item_id)
+                item.path.unlink(missing_ok=True)
+            return
+
+        if ok:
+            await manifest.mark_uploaded(item.tribunal, item.d)
+            await summary.inc_upload()
+            if observer:
+                observer.on_log(f"[green]Uploaded[/green] {item.tribunal} {item.d}")
+        elif fail_fast:
+            abort_event.set()
+        item.path.unlink(missing_ok=True)
+    except (httpx.HTTPError, OSError) as exc:
+        log.warning("upload_exception", item_id=item.item_id, error=str(exc))
+
+
 # ── Unified check + download + upload pipeline ──────────────────────
 
 
@@ -331,9 +396,9 @@ async def run_pipeline(
 
             await manifest.mark_djen_raw(entry.tribunal, entry.date, raw_status)
             if raw_status in ("429", "timeout", "error"):
-                await djen_breaker.record_failure()
+                djen_breaker.record_failure()
             elif raw_status != "403":
-                await djen_breaker.record_success()
+                djen_breaker.record_success()
 
             _notify_counts()
             if time.monotonic() - last_save > save_interval:
@@ -401,48 +466,17 @@ async def run_pipeline(
                 upload_queue.task_done()
                 return
             try:
-                if await check_ia_file_exists(upload_client, item.tribunal, item.d):
-                    await manifest.mark_uploaded(item.tribunal, item.d)
-                    await summary.inc_upload()
-                    if config.observer:
-                        config.observer.on_log(f"[dim]Already on IA[/dim] {item.tribunal} {item.d}")
-                    item.path.unlink(missing_ok=True)
-                else:
-                    try:
-                        ok = await upload_zip(
-                            upload_client,
-                            item.item_id,
-                            item.path,
-                            circuit_breaker=circuit_breaker,
-                            try_lock=True,
-                        )
-                    except ItemBusyError:
-                        # Another worker holds the per-item lock — re-queue this
-                        # item and pick a different one rather than blocking on
-                        # the same bucket. Use put_nowait to avoid deadlocking
-                        # the bounded queue; if it's saturated, drop the staged
-                        # file (the manifest still flags the entry as available
-                        # so the next run re-feeds it).
-                        log.debug("upload_item_busy_requeue", item_id=item.item_id)
-                        await asyncio.sleep(0.25)
-                        try:
-                            upload_queue.put_nowait(item)
-                        except asyncio.QueueFull:
-                            log.info("upload_requeue_dropped", item_id=item.item_id)
-                            item.path.unlink(missing_ok=True)
-                    else:
-                        if ok:
-                            await manifest.mark_uploaded(item.tribunal, item.d)
-                            await summary.inc_upload()
-                            if config.observer:
-                                config.observer.on_log(
-                                    f"[green]Uploaded[/green] {item.tribunal} {item.d}"
-                                )
-                        elif config.fail_fast:
-                            abort_event.set()
-                        item.path.unlink(missing_ok=True)
-            except (httpx.HTTPError, OSError) as exc:
-                log.warning("upload_exception", item_id=item.item_id, error=str(exc))
+                await _process_upload_item(
+                    item,
+                    upload_client=upload_client,
+                    upload_queue=upload_queue,
+                    manifest=manifest,
+                    summary=summary,
+                    circuit_breaker=circuit_breaker,
+                    abort_event=abort_event,
+                    fail_fast=config.fail_fast,
+                    observer=config.observer,
+                )
             finally:
                 upload_queue.task_done()
 

--- a/tests/djen_backup/test_circuit_breaker.py
+++ b/tests/djen_backup/test_circuit_breaker.py
@@ -50,11 +50,8 @@ def given_recovery_timeout(circuit_breaker: CircuitBreaker, n: int) -> None:
 
 @when(parsers.parse("{n:d} consecutive IA uploads fail"))
 def when_n_failures(circuit_breaker: CircuitBreaker, n: int) -> None:
-    async def _run() -> None:
-        for _ in range(n):
-            await circuit_breaker.record_failure()
-
-    asyncio.run(_run())
+    for _ in range(n):
+        circuit_breaker.record_failure()
 
 
 @when("I wait for the recovery timeout")
@@ -68,9 +65,9 @@ def when_test_succeeds(circuit_breaker: CircuitBreaker) -> None:
     async def _run() -> None:
         allowed = await circuit_breaker.allow_request()
         assert allowed, "Expected half-open circuit to allow a test request"
-        await circuit_breaker.record_success()
 
     asyncio.run(_run())
+    circuit_breaker.record_success()
 
 
 # ── Then ─────────────────────────────────────────────────────────────

--- a/tests/djen_backup/test_upload_worker.py
+++ b/tests/djen_backup/test_upload_worker.py
@@ -1,0 +1,215 @@
+"""Tests for the upload worker item handler.
+
+Covers the extracted ``_process_upload_item`` so we exercise the re-queue,
+saturated-queue drop, success, fail-fast, and already-on-IA branches without
+spinning up the full pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import TYPE_CHECKING
+
+import pytest
+
+from djen_backup import engine as engine_module
+from djen_backup.archive import ItemBusyError
+from djen_backup.circuit_breaker import CircuitBreaker
+from djen_backup.engine import StagedItem, SyncSummary, _process_upload_item
+from djen_backup.manifest import SyncManifest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _staged(
+    tmp_path: Path,
+    item_id: str = "djen-tjsp-2024",
+    d: date = date(2024, 1, 2),
+) -> StagedItem:
+    zip_path = tmp_path / f"djen-{d.isoformat()}-{item_id.split('-')[1].upper()}.zip"
+    zip_path.write_bytes(b"PK\x03\x04")
+    return StagedItem(item_id=item_id, d=d, tribunal="TJSP", path=zip_path)
+
+
+@pytest.fixture
+def manifest() -> SyncManifest:
+    m = SyncManifest()
+    m.build(["TJSP"], date(2024, 1, 1), date(2024, 1, 5))
+    return m
+
+
+@pytest.mark.asyncio
+async def test_already_on_ia_marks_uploaded_and_skips_upload(
+    manifest: SyncManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(engine_module, "check_ia_file_exists", _ia_hit)
+    monkeypatch.setattr(
+        engine_module, "upload_zip", _async_raise(AssertionError("must not be called"))
+    )
+
+    item = _staged(tmp_path)
+    summary = SyncSummary()
+    queue: asyncio.Queue[StagedItem | None] = asyncio.Queue(maxsize=4)
+
+    await _process_upload_item(
+        item,
+        upload_client=_FakeClient(),
+        upload_queue=queue,
+        manifest=manifest,
+        summary=summary,
+        circuit_breaker=CircuitBreaker(),
+        abort_event=asyncio.Event(),
+        fail_fast=True,
+        observer=None,
+    )
+
+    assert summary.uploads == 1
+    assert manifest.get_status("TJSP", date(2024, 1, 2)).ia_status == "uploaded"
+    assert not item.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_busy_item_is_requeued(
+    manifest: SyncManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(engine_module, "check_ia_file_exists", _ia_miss)
+    monkeypatch.setattr(engine_module, "upload_zip", _async_raise(ItemBusyError("djen-tjsp-2024")))
+
+    item = _staged(tmp_path)
+    queue: asyncio.Queue[StagedItem | None] = asyncio.Queue(maxsize=4)
+    summary = SyncSummary()
+
+    await _process_upload_item(
+        item,
+        upload_client=_FakeClient(),
+        upload_queue=queue,
+        manifest=manifest,
+        summary=summary,
+        circuit_breaker=CircuitBreaker(),
+        abort_event=asyncio.Event(),
+        fail_fast=True,
+        observer=None,
+    )
+
+    assert queue.qsize() == 1
+    assert queue.get_nowait() is item
+    assert summary.uploads == 0
+    assert item.path.exists()  # not unlinked — still pending
+
+
+@pytest.mark.asyncio
+async def test_busy_item_dropped_when_queue_saturated(
+    manifest: SyncManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(engine_module, "check_ia_file_exists", _ia_miss)
+    monkeypatch.setattr(engine_module, "upload_zip", _async_raise(ItemBusyError("djen-tjsp-2024")))
+
+    item = _staged(tmp_path)
+    # Pre-fill a maxsize=1 queue so the requeue can't fit.
+    filler_dir = tmp_path / "filler"
+    filler_dir.mkdir()
+    queue: asyncio.Queue[StagedItem | None] = asyncio.Queue(maxsize=1)
+    queue.put_nowait(_staged(filler_dir, "djen-tjba-2024", date(2024, 1, 3)))
+
+    await _process_upload_item(
+        item,
+        upload_client=_FakeClient(),
+        upload_queue=queue,
+        manifest=manifest,
+        summary=SyncSummary(),
+        circuit_breaker=CircuitBreaker(),
+        abort_event=asyncio.Event(),
+        fail_fast=True,
+        observer=None,
+    )
+
+    # The original filler is still there; our busy item was dropped (and unlinked).
+    assert queue.qsize() == 1
+    assert not item.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_successful_upload_marks_manifest_and_unlinks(
+    manifest: SyncManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(engine_module, "check_ia_file_exists", _ia_miss)
+    monkeypatch.setattr(engine_module, "upload_zip", _upload_succeeds)
+
+    item = _staged(tmp_path)
+    summary = SyncSummary()
+
+    await _process_upload_item(
+        item,
+        upload_client=_FakeClient(),
+        upload_queue=asyncio.Queue(maxsize=4),
+        manifest=manifest,
+        summary=summary,
+        circuit_breaker=CircuitBreaker(),
+        abort_event=asyncio.Event(),
+        fail_fast=True,
+        observer=None,
+    )
+
+    assert summary.uploads == 1
+    assert manifest.get_status("TJSP", date(2024, 1, 2)).ia_status == "uploaded"
+    assert not item.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_failed_upload_with_fail_fast_sets_abort(
+    manifest: SyncManifest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(engine_module, "check_ia_file_exists", _ia_miss)
+    monkeypatch.setattr(engine_module, "upload_zip", _upload_fails)
+
+    item = _staged(tmp_path)
+    abort_event = asyncio.Event()
+
+    await _process_upload_item(
+        item,
+        upload_client=_FakeClient(),
+        upload_queue=asyncio.Queue(maxsize=4),
+        manifest=manifest,
+        summary=SyncSummary(),
+        circuit_breaker=CircuitBreaker(),
+        abort_event=abort_event,
+        fail_fast=True,
+        observer=None,
+    )
+
+    assert abort_event.is_set()
+    assert manifest.get_status("TJSP", date(2024, 1, 2)).ia_status != "uploaded"
+    assert not item.path.exists()
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+class _FakeClient:
+    """Stand-in httpx.AsyncClient — we monkey-patch the only methods we touch."""
+
+
+async def _ia_hit(*_args: object, **_kwargs: object) -> bool:
+    return True
+
+
+async def _ia_miss(*_args: object, **_kwargs: object) -> bool:
+    return False
+
+
+async def _upload_succeeds(*_args: object, **_kwargs: object) -> bool:
+    return True
+
+
+async def _upload_fails(*_args: object, **_kwargs: object) -> bool:
+    return False
+
+
+def _async_raise(exc: BaseException):  # type: ignore[no-untyped-def]
+    async def _fn(*_args: object, **_kwargs: object) -> object:
+        raise exc
+
+    return _fn


### PR DESCRIPTION
## Summary

Two improvements deferred from #671 (which is the base branch for this PR — merge after #671).

### 1. Deduplicate `CircuitBreaker`

The async class in `djen_backup/archive.py` and the simpler sync class in `causaganha/pipeline/ia_s3.py` were duplicates with overlapping concerns. This PR consolidates them.

- **New module** `src/djen_backup/circuit_breaker.py` holds the canonical class. No other deps → breaks the `archive ↔ ia_s3` import cycle.
- `record_success` / `record_failure` / `is_open` are now **sync** (using `threading.Lock`); `allow_request` stays **async**. The same instance can be shared by sync (consolidate scripts) and async (engine pipeline) callers.
- `archive.py` and `ia_s3.py` both re-export from `circuit_breaker` so existing imports keep working — no changes needed in `consolidate/`, `scripts/pipeline/`, or `pipeline/ia_parquet_uploader.py`.
- Async callers in `engine.py` (`checker_worker`) and `archive.py` (`upload_zip`) drop `await` on `record_*`. Sync `is_open` callers retain their existing API.

Behaviour preserved: state-machine recovery via `allow_request` still works for async callers; sync callers' `is_open` returns True only for `OPEN`, so they re-enter once a `record_success` resets the counter (matching the old simple semantics).

### 2. Extract `_process_upload_item` for testability

The upload-worker closure inside `run_pipeline` was untestable in isolation. Lift the per-item handling (already-on-IA, real upload, `ItemBusyError` re-queue, saturated-queue drop, fail-fast) into a top-level async function with explicit deps. `upload_worker` becomes a thin loop.

New tests in `tests/djen_backup/test_upload_worker.py` cover all five branches:
- `test_already_on_ia_marks_uploaded_and_skips_upload`
- `test_busy_item_is_requeued`
- `test_busy_item_dropped_when_queue_saturated`
- `test_successful_upload_marks_manifest_and_unlinks`
- `test_failed_upload_with_fail_fast_sets_abort`

Existing `test_circuit_breaker.py` adjusted to drop `asyncio.run` around the now-sync `record_*` calls.

## Test plan

- [x] `uv run pytest -q` — 90 passed, 1 skipped (was 85)
- [x] `uv run ruff check` — net -3 errors (106 → 103) in touched files
- [x] `uv run ruff format --check`
- [x] No changes required in any of the 7 downstream files that import `CircuitBreaker` from `causaganha.pipeline.ia_s3` (consolidate, scripts, parquet uploader).

## Note

This is stacked on #671. If #671 lands first, GitHub will auto-update the base; otherwise rebase on main is straightforward (no overlapping touches outside `engine.py`).

https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq)_