### PR TITLE
refactor(engine): extract DJEN classify and download-stage helpers

### DIFF
--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -206,6 +206,76 @@ async def _process_upload_item(
         log.warning("upload_exception", item_id=item.item_id, error=str(exc))
 
 
+# ── DJEN check + download helpers (extracted for testability) ───────
+
+
+async def _classify_djen_status(
+    client: httpx.AsyncClient,
+    proxy_url: str,
+    tribunal: str,
+    d: date,
+    djen_limiter: AsyncLimiter,
+) -> str:
+    """Call DJEN once and map the outcome to a raw_status string.
+
+    Returns:
+        "200" — caderno available
+        "404" / "400" — genuine absence (404 not found, 400 holiday)
+        "403" — CloudFront/WAF block (transient, do NOT trip the breaker)
+        "error" — any other HTTP/timeout failure (caller should record it)
+    """
+    try:
+        async with djen_limiter:
+            await get_caderno_url(client, proxy_url, tribunal, d)
+    except DJENNotFoundError as exc:
+        return str(exc.status_code)
+    except DJENRateLimitedError:
+        return "403"
+    except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+        log.warning(
+            "djen_check_error",
+            tribunal=tribunal,
+            date=d.isoformat(),
+            error=str(exc),
+        )
+        return "error"
+    return "200"
+
+
+async def _stage_download(
+    entry: ManifestEntry,
+    client: httpx.AsyncClient,
+    proxy_url: str,
+    djen_limiter: AsyncLimiter,
+    staging_dir: Path,
+) -> StagedItem:
+    """Resolve the caderno URL, download the ZIP, and stage it on disk.
+
+    Retries up to 3 times on ``DJENNotFoundError`` (the proxy occasionally
+    returns 404 transiently for newly-published cadernos). Returns the
+    final ``StagedItem``; raises on exhaustion or other transport errors.
+    """
+    async with djen_limiter:
+        async for attempt in tenacity.AsyncRetrying(
+            stop=tenacity.stop_after_attempt(3),
+            wait=tenacity.wait_exponential(multiplier=2, min=4, max=10),
+            retry=tenacity.retry_if_exception_type(DJENNotFoundError),
+            reraise=True,
+        ):
+            with attempt:
+                # IMPORTANT: The proxy URL is used to fetch the file, NOT the
+                # direct DJEN URL — avoids CloudFront 403s on GitHub Runners.
+                url = await get_caderno_url(client, proxy_url, entry.tribunal, entry.date)
+                zip_path = await download_zip(client, url)
+
+    item_id = get_ia_item_id(entry.tribunal, entry.date)
+    dest_dir = staging_dir / item_id
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    final_path = dest_dir / f"djen-{entry.date.isoformat()}-{entry.tribunal.upper()}.zip"
+    await asyncio.to_thread(shutil.move, str(zip_path), str(final_path))
+    return StagedItem(item_id, entry.date, entry.tribunal, final_path)
+
+
 # ── Unified check + download + upload pipeline ──────────────────────
 
 
@@ -376,23 +446,9 @@ async def run_pipeline(
             if not await _check_djen_breaker():
                 return
 
-            try:
-                async with djen_limiter:
-                    await get_caderno_url(client, config.djen_proxy_url, entry.tribunal, entry.date)
-                raw_status = "200"
-            except DJENNotFoundError as exc:
-                raw_status = str(exc.status_code)
-            except DJENRateLimitedError:
-                # 403 / CloudFront block — transient, do NOT trip the breaker.
-                raw_status = "403"
-            except (httpx.HTTPError, asyncio.TimeoutError) as exc:
-                log.warning(
-                    "djen_check_error",
-                    tribunal=entry.tribunal,
-                    date=entry.date.isoformat(),
-                    error=str(exc),
-                )
-                raw_status = "error"
+            raw_status = await _classify_djen_status(
+                client, config.djen_proxy_url, entry.tribunal, entry.date, djen_limiter
+            )
 
             await manifest.mark_djen_raw(entry.tribunal, entry.date, raw_status)
             if raw_status in ("429", "timeout", "error"):
@@ -418,30 +474,11 @@ async def run_pipeline(
                 download_queue.task_done()
                 continue
             try:
-                async with djen_limiter:
-                    async for attempt in tenacity.AsyncRetrying(
-                        stop=tenacity.stop_after_attempt(3),
-                        wait=tenacity.wait_exponential(multiplier=2, min=4, max=10),
-                        retry=tenacity.retry_if_exception_type(DJENNotFoundError),
-                        reraise=True,
-                    ):
-                        with attempt:
-                            # IMPORTANT: The proxy URL is used to fetch the file, NOT the direct DJEN URL
-                            # to avoid Geofencing 403s on GitHub Runners.
-                            url = await get_caderno_url(
-                                client, config.djen_proxy_url, entry.tribunal, entry.date
-                            )
-                            zip_path = await download_zip(client, url)
-
-                item_id = get_ia_item_id(entry.tribunal, entry.date)
-                dest_dir = STAGING_DIR / item_id
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                final_path = (
-                    dest_dir / f"djen-{entry.date.isoformat()}-{entry.tribunal.upper()}.zip"
+                staged = await _stage_download(
+                    entry, client, config.djen_proxy_url, djen_limiter, STAGING_DIR
                 )
-                await asyncio.to_thread(shutil.move, str(zip_path), str(final_path))
                 await summary.inc_download()
-                await upload_queue.put(StagedItem(item_id, entry.date, entry.tribunal, final_path))
+                await upload_queue.put(staged)
             except (
                 httpx.HTTPError,
                 OSError,

--- a/tests/djen_backup/test_classify_djen.py
+++ b/tests/djen_backup/test_classify_djen.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``_classify_djen_status`` — the DJEN-call → raw_status map.
+
+Verifies the contract documented in CLAUDE.md:
+- 200 → "200" (available)
+- 404 / 400 → status code (genuine absent)
+- 403 → "403" (transient WAF, no breaker hit)
+- transport / 5xx → "error" (caller records it)
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from aiolimiter import AsyncLimiter
+
+from djen_backup import engine as engine_module
+from djen_backup.djen import DJENNotFoundError, DJENRateLimitedError
+from djen_backup.engine import _classify_djen_status
+
+
+def _limiter() -> AsyncLimiter:
+    # generous limiter so tests aren't gated on real-clock waits
+    return AsyncLimiter(max_rate=100, time_period=1)
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_200_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _ok(*_args: object, **_kwargs: object) -> str:
+        return "https://example/zip"
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _ok)
+
+    raw = await _classify_djen_status(
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        tribunal="TJSP",
+        d=date(2024, 1, 2),
+        djen_limiter=_limiter(),
+    )
+    assert raw == "200"
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_status_code_on_djen_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _missing(*_args: object, **_kwargs: object) -> str:
+        raise DJENNotFoundError(status_code=404, reason="Not found")
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _missing)
+
+    raw = await _classify_djen_status(
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        tribunal="TJSP",
+        d=date(2024, 1, 2),
+        djen_limiter=_limiter(),
+    )
+    assert raw == "404"
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_400_for_holiday(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _holiday(*_args: object, **_kwargs: object) -> str:
+        raise DJENNotFoundError(status_code=400, reason="Holiday")
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _holiday)
+
+    raw = await _classify_djen_status(
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        tribunal="TJSP",
+        d=date(2024, 1, 2),
+        djen_limiter=_limiter(),
+    )
+    assert raw == "400"
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_403_for_cloudfront_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _waf(*_args: object, **_kwargs: object) -> str:
+        raise DJENRateLimitedError("CloudFront block")  # noqa: EM101, TRY003
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _waf)
+
+    raw = await _classify_djen_status(
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        tribunal="TJSP",
+        d=date(2024, 1, 2),
+        djen_limiter=_limiter(),
+    )
+    assert raw == "403"
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_error_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    async def _boom(*_args: object, **_kwargs: object) -> str:
+        raise httpx.HTTPError("Server error: 502")  # noqa: EM101, TRY003
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _boom)
+
+    raw = await _classify_djen_status(
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        tribunal="TJSP",
+        d=date(2024, 1, 2),
+        djen_limiter=_limiter(),
+    )
+    assert raw == "error"

--- a/tests/djen_backup/test_stage_download.py
+++ b/tests/djen_backup/test_stage_download.py
@@ -1,0 +1,151 @@
+"""Unit tests for ``_stage_download``.
+
+Covers happy path (download → move), DJENNotFoundError exhaustion after 3
+retries, and the fact that non-retryable transport errors propagate without
+being looped on.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from aiolimiter import AsyncLimiter
+
+from djen_backup import engine as engine_module
+from djen_backup.djen import DJENNotFoundError
+from djen_backup.engine import _stage_download
+from djen_backup.manifest import ManifestEntry
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _entry(d: date = date(2024, 1, 2)) -> ManifestEntry:
+    return ManifestEntry(tribunal="TJSP", date=d)
+
+
+def _limiter() -> AsyncLimiter:
+    return AsyncLimiter(max_rate=100, time_period=1)
+
+
+@pytest.mark.asyncio
+async def test_stage_download_moves_to_per_item_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    raw_zip = tmp_path / "raw.zip"
+    raw_zip.write_bytes(b"PK\x03\x04")
+
+    async def _url(*_args: object, **_kwargs: object) -> str:
+        return "https://example/zip"
+
+    async def _dl(*_args: object, **_kwargs: object) -> Path:
+        return raw_zip
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _url)
+    monkeypatch.setattr(engine_module, "download_zip", _dl)
+
+    staging = tmp_path / "staging"
+
+    staged = await _stage_download(
+        _entry(),
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        djen_limiter=_limiter(),
+        staging_dir=staging,
+    )
+
+    assert staged.item_id == "djen-tjsp-2024"
+    assert staged.tribunal == "TJSP"
+    assert staged.path == staging / "djen-tjsp-2024" / "djen-2024-01-02-TJSP.zip"
+    assert staged.path.exists()
+    assert not raw_zip.exists()  # moved, not copied
+
+
+@pytest.mark.asyncio
+async def test_stage_download_retries_djen_not_found_then_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+
+    async def _url_flaky(*_args: object, **_kwargs: object) -> str:
+        calls.append(1)
+        if len(calls) < 2:
+            raise DJENNotFoundError(status_code=404, reason="transient")
+        return "https://example/zip"
+
+    raw_zip = tmp_path / "raw.zip"
+    raw_zip.write_bytes(b"PK\x03\x04")
+
+    async def _dl(*_args: object, **_kwargs: object) -> Path:
+        return raw_zip
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _url_flaky)
+    monkeypatch.setattr(engine_module, "download_zip", _dl)
+
+    staged = await _stage_download(
+        _entry(),
+        client=object(),  # type: ignore[arg-type]
+        proxy_url="https://djen.example",
+        djen_limiter=_limiter(),
+        staging_dir=tmp_path / "staging",
+    )
+
+    assert len(calls) == 2  # one retry
+    assert staged.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_stage_download_propagates_after_retry_exhaustion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _url_404(*_args: object, **_kwargs: object) -> str:
+        raise DJENNotFoundError(status_code=404, reason="permanent")
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _url_404)
+    monkeypatch.setattr(engine_module, "download_zip", _async_unreachable_download_zip)
+
+    with pytest.raises(DJENNotFoundError):
+        await _stage_download(
+            _entry(),
+            client=object(),  # type: ignore[arg-type]
+            proxy_url="https://djen.example",
+            djen_limiter=_limiter(),
+            staging_dir=tmp_path / "staging",
+        )
+
+
+@pytest.mark.asyncio
+async def test_stage_download_does_not_retry_transport_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+
+    async def _url_boom(*_args: object, **_kwargs: object) -> str:
+        calls.append(1)
+        raise httpx.HTTPError("502")  # noqa: EM101
+
+    monkeypatch.setattr(engine_module, "get_caderno_url", _url_boom)
+    monkeypatch.setattr(engine_module, "download_zip", _async_unreachable_download_zip)
+
+    with pytest.raises(httpx.HTTPError):
+        await _stage_download(
+            _entry(),
+            client=object(),  # type: ignore[arg-type]
+            proxy_url="https://djen.example",
+            djen_limiter=_limiter(),
+            staging_dir=tmp_path / "staging",
+        )
+
+    assert len(calls) == 1  # tenacity only retries DJENNotFoundError
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+async def _async_unreachable_download_zip(*_args: object, **_kwargs: object) -> object:
+    msg = "download_zip should not be reached"
+    raise AssertionError(msg)


### PR DESCRIPTION
## Summary

Stacked on #672 — finishes the engine worker test gap from the original analysis.

Lifts two more pieces out of `run_pipeline` closures so they can be unit-tested without driving the full pipeline:

### `_classify_djen_status`
The DJEN-call → `raw_status` mapping. One call to `get_caderno_url`, mapped to:
- `"200"` — caderno available
- `"404"` / `"400"` — genuine absence (not found / holiday)
- `"403"` — CloudFront/WAF block (transient, no breaker hit)
- `"error"` — any other HTTP/timeout failure

`checker_worker` now calls this helper instead of inlining the try/except cascade.

### `_stage_download`
URL resolve → download → move into the per-item staging dir, with the same tenacity retry (`DJENNotFoundError` only, 3 attempts). `download_worker` now calls this and just handles queue/summary bookkeeping.

## Tests

- `tests/djen_backup/test_classify_djen.py` (5 cases) — covers each `raw_status` outcome via monkey-patched `get_caderno_url` (200, 404, 400, 403, transport error).
- `tests/djen_backup/test_stage_download.py` (4 cases) — happy path (move into per-item dir), retry-then-succeed, retry-exhaustion (`DJENNotFoundError` after 3 attempts), and transport errors propagating without retry.

## Test plan

- [x] `uv run pytest -q` — **99 passed, 1 skipped** (was 90)
- [x] `uv run ruff check tests/djen_backup/test_classify_djen.py tests/djen_backup/test_stage_download.py` — clean
- [x] `uv run ruff format --check`
- [x] No behaviour change in the pipeline; both refactors are pure code motion.

## Note

Stacked on #672 (which is stacked on #671). Merge order: #671 → #672 → this.

https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq)_