### PR TITLE
refactor(engine): extract _discover_ia_items helper

### DIFF
--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -276,6 +276,43 @@ async def _stage_download(
     return StagedItem(item_id, entry.date, entry.tribunal, final_path)
 
 
+async def _discover_ia_items(manifest: SyncManifest) -> set[tuple[str, int]]:
+    """Phase 0: enumerate existing ``djen-*-{year}`` items on Internet Archive.
+
+    Hits IA's advanced-search endpoint for ``identifier:djen-*-*`` and
+    returns the set of ``(tribunal, year)`` pairs found. On any HTTP or
+    parse failure, falls back to the manifest's not-yet-uploaded set so
+    the pipeline can still proceed offline-ish.
+    """
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), follow_redirects=True) as client:
+        try:
+            resp = await client.get(
+                "https://archive.org/advancedsearch.php",
+                params={
+                    "q": "identifier:djen-*-*",
+                    "fl[]": "identifier",
+                    "rows": "2000",
+                    "output": "json",
+                },
+            )
+            existing: set[tuple[str, int]] = set()
+            for d in resp.json()["response"]["docs"]:
+                ident = d["identifier"]
+                parts = ident.rsplit("-", 1)
+                if len(parts) == 2 and parts[1].isdigit():
+                    existing.add((parts[0][len("djen-") :].upper(), int(parts[1])))
+            log.info("ia_items_discovered", count=len(existing))
+        except (httpx.HTTPError, ValueError, KeyError, TypeError, AttributeError) as exc:
+            log.warning("ia_search_failed_fallback", error=str(exc))
+            return {
+                (e.tribunal, e.date.year)
+                for e in manifest._entries.values()
+                if e.ia_status != "uploaded"
+            }
+        else:
+            return existing
+
+
 # ── Unified check + download + upload pipeline ──────────────────────
 
 
@@ -292,30 +329,7 @@ async def run_pipeline(
     existing_items: set[tuple[str, int]] = set()
     if not config.upload_only:
         log.info("ia_discovery_starting")
-        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), follow_redirects=True) as client:
-            try:
-                resp = await client.get(
-                    "https://archive.org/advancedsearch.php",
-                    params={
-                        "q": "identifier:djen-*-*",
-                        "fl[]": "identifier",
-                        "rows": "2000",
-                        "output": "json",
-                    },
-                )
-                for d in resp.json()["response"]["docs"]:
-                    ident = d["identifier"]
-                    parts = ident.rsplit("-", 1)
-                    if len(parts) == 2 and parts[1].isdigit():
-                        existing_items.add((parts[0][5:].upper(), int(parts[1])))
-                log.info("ia_items_discovered", count=len(existing_items))
-            except (httpx.HTTPError, ValueError, KeyError, TypeError, AttributeError) as exc:
-                log.warning("ia_search_failed_fallback", error=str(exc))
-                existing_items = {
-                    (e.tribunal, e.date.year)
-                    for e in manifest._entries.values()
-                    if e.ia_status != "uploaded"
-                }
+        existing_items = await _discover_ia_items(manifest)
 
     # Build check priority
     from collections import defaultdict

--- a/tests/djen_backup/test_discover_ia.py
+++ b/tests/djen_backup/test_discover_ia.py
@@ -1,0 +1,112 @@
+"""Unit tests for ``_discover_ia_items``.
+
+Covers happy path (well-formed IA advanced-search response), schema
+variants that previously crashed startup, and the manifest-fallback
+path on HTTP failure.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import pytest
+import respx
+
+from djen_backup.engine import _discover_ia_items
+from djen_backup.manifest import SyncManifest
+
+
+_IA_SEARCH_URL = "https://archive.org/advancedsearch.php"
+
+
+@pytest.mark.asyncio
+async def test_discover_parses_well_formed_response() -> None:
+    payload = {
+        "response": {
+            "docs": [
+                {"identifier": "djen-tjsp-2024"},
+                {"identifier": "djen-tre-ac-2023"},
+                {"identifier": "djen-tjba-2024"},
+            ]
+        }
+    }
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith=_IA_SEARCH_URL).respond(200, json=payload)
+        existing = await _discover_ia_items(SyncManifest())
+
+    assert existing == {("TJSP", 2024), ("TRE-AC", 2023), ("TJBA", 2024)}
+
+
+@pytest.mark.asyncio
+async def test_discover_skips_identifiers_without_year_suffix() -> None:
+    payload = {
+        "response": {
+            "docs": [
+                {"identifier": "djen-tjsp-2024"},
+                {"identifier": "djen-no-year"},  # no trailing digits
+                {"identifier": "djen-malformed"},
+            ]
+        }
+    }
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith=_IA_SEARCH_URL).respond(200, json=payload)
+        existing = await _discover_ia_items(SyncManifest())
+
+    assert existing == {("TJSP", 2024)}
+
+
+@pytest.mark.asyncio
+async def test_discover_falls_back_to_manifest_on_http_error() -> None:
+    m = SyncManifest()
+    m.build(["TJSP", "TJBA"], date(2024, 1, 1), date(2024, 1, 5))
+    await m.mark_uploaded("TJSP", date(2024, 1, 2))  # not in fallback
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith=_IA_SEARCH_URL).mock(
+            side_effect=httpx.ConnectError("boom")
+        )
+        existing = await _discover_ia_items(m)
+
+    # Fallback returns (tribunal, year) for entries still pending upload —
+    # not the already-uploaded TJSP/2024-01-02 (it's filtered out, but
+    # other TJSP/2024 entries remain).
+    assert ("TJSP", 2024) in existing
+    assert ("TJBA", 2024) in existing
+
+
+@pytest.mark.asyncio
+async def test_discover_handles_schema_variant_docs_null() -> None:
+    """Regression: response with ``docs: null`` previously raised TypeError."""
+    payload = {"response": {"docs": None}}
+    m = SyncManifest()
+    m.build(["TJSP"], date(2024, 1, 1), date(2024, 1, 2))
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith=_IA_SEARCH_URL).respond(200, json=payload)
+        existing = await _discover_ia_items(m)
+
+    # Falls back to manifest (TJSP/2024 entries pending).
+    assert existing == {("TJSP", 2024)}
+
+
+@pytest.mark.asyncio
+async def test_discover_handles_schema_variant_non_dict_entries() -> None:
+    """Regression: docs entries that aren't dicts previously raised AttributeError."""
+    payload = {
+        "response": {
+            "docs": [
+                {"identifier": "djen-tjsp-2024"},
+                "not-a-dict",  # would have raised AttributeError on .rsplit
+            ]
+        }
+    }
+    m = SyncManifest()
+    m.build(["TJBA"], date(2024, 1, 1), date(2024, 1, 2))
+
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url__startswith=_IA_SEARCH_URL).respond(200, json=payload)
+        existing = await _discover_ia_items(m)
+
+    # Falls back to manifest because of TypeError/AttributeError.
+    assert existing == {("TJBA", 2024)}


### PR DESCRIPTION
## Summary

Lifts the Phase 0 IA advanced-search call out of the `run_pipeline` closure into a top-level async function. Same fallback semantics — if IA returns a malformed payload or HTTP error, fall back to manifest entries that aren't yet uploaded.

This finishes the testability refactor for `run_pipeline`'s phases (paired with `_classify_djen_status`, `_stage_download`, `_process_upload_item` from earlier PRs).

### Tests

`tests/djen_backup/test_discover_ia.py` (5 cases) covers:

- happy path with well-formed response
- identifiers without trailing year suffix are skipped
- HTTP error → manifest fallback
- **schema variant**: `docs` is `null` (regression for the `TypeError` fix in #671)
- **schema variant**: `docs` entries are non-dicts (regression for `AttributeError`)

## Test plan

- [x] `uv run pytest -q` — 105 passed, 1 skipped (was 100)
- [x] `uv run ruff check tests/djen_backup/test_discover_ia.py` — clean
- [x] `uv run ruff format --check`
- [x] No behaviour change in the pipeline.

https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5gps9WNGXg39WGRSy7vaq)_