### PR TITLE
fix(web): a11y focus-visible, button types, and pt-BR PR-gate

### DIFF
--- a/web/features/admin-pr-gate.feature
+++ b/web/features/admin-pr-gate.feature
@@ -21,4 +21,4 @@ Feature: PR Readiness Gate
     Given the PR gate page is loaded
     And PR 42 is already merged
     When I submit PR number "42"
-    Then I should see "Merged" status
+    Then I should see "Mesclado" status

--- a/web/src/components/DateDetail.svelte
+++ b/web/src/components/DateDetail.svelte
@@ -249,6 +249,7 @@
 
 {#snippet DateShareButton()}
   <button
+    type="button"
     onclick={handleShareClick}
     class="btn btn-outline-secondary"
   >
@@ -273,6 +274,7 @@
         usedFallback={featuredPub.usedFallback}
       />
       <button
+        type="button"
         class="btn"
         onclick={handleDismissFeatured}
       >
@@ -346,7 +348,7 @@
 
   {#if currentPage < totalPages && !loading}
     <div class="load-more-row">
-      <button onclick={handleLoadMore} disabled={loadingMore} class="btn btn-secondary" aria-busy={loadingMore}>
+      <button type="button" onclick={handleLoadMore} disabled={loadingMore} class="btn btn-secondary" aria-busy={loadingMore}>
         {loadingMore ? 'Carregando...' : `Página ${currentPage + 1} de ${totalPages}`}
       </button>
     </div>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -380,13 +380,14 @@ FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
     transition: background var(--transition-base), border-color var(--transition-base);
   }
 
-  .retry-btn:hover,
-  .retry-btn:focus-visible {
+  .retry-btn:hover {
     background: var(--color-base-200);
     border-color: var(--color-base-content);
   }
 
   .retry-btn:focus-visible {
+    background: var(--color-base-200);
+    border-color: var(--color-base-content);
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -380,9 +380,15 @@ FROM read_parquet('${IA_BASE}/${ITEM}/comunicacoes.parquet')`,
     transition: background var(--transition-base), border-color var(--transition-base);
   }
 
-  .retry-btn:hover {
+  .retry-btn:hover,
+  .retry-btn:focus-visible {
     background: var(--color-base-200);
     border-color: var(--color-base-content);
+  }
+
+  .retry-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   /* Starter cards */

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -526,12 +526,12 @@ const recursosLinks = [
     color: var(--color-base-content);
   }
 
-  .btn-menu:hover,
-  .btn-menu:focus-visible {
+  .btn-menu:hover {
     background: var(--color-base-200);
   }
 
   .btn-menu:focus-visible {
+    background: var(--color-base-200);
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
@@ -549,12 +549,12 @@ const recursosLinks = [
     text-decoration: none;
   }
 
-  .btn-back:hover,
-  .btn-back:focus-visible {
+  .btn-back:hover {
     background: var(--color-base-200);
   }
 
   .btn-back:focus-visible {
+    background: var(--color-base-200);
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -526,8 +526,14 @@ const recursosLinks = [
     color: var(--color-base-content);
   }
 
-  .btn-menu:hover {
+  .btn-menu:hover,
+  .btn-menu:focus-visible {
     background: var(--color-base-200);
+  }
+
+  .btn-menu:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .btn-back {
@@ -543,8 +549,14 @@ const recursosLinks = [
     text-decoration: none;
   }
 
-  .btn-back:hover {
+  .btn-back:hover,
+  .btn-back:focus-visible {
     background: var(--color-base-200);
+  }
+
+  .btn-back:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   /* Page header variant */

--- a/web/src/components/PRGateExplainer.svelte
+++ b/web/src/components/PRGateExplainer.svelte
@@ -75,7 +75,7 @@
         fetchWithRetry(`https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews`)
       ]);
 
-      if (!prRes.ok) throw new Error("Failed to fetch PR details. Make sure PR number is correct.");
+      if (!prRes.ok) throw new Error("Falha ao obter detalhes do PR. Verifique se o número está correto.");
 
       const prInfo: PRInfo = await prRes.json();
       const reviews: Review[] = await reviewsRes.json();
@@ -96,30 +96,30 @@
     const isMerged = prInfo.merged;
     const isClosed = prInfo.state === 'closed';
 
-    if (isMerged) return { status: 'Merged', description: 'This PR is already merged.', color: 'status-success' };
-    if (isClosed) return { status: 'Closed', description: 'This PR is closed without merging.', color: 'status-error' };
+    if (isMerged) return { status: 'Mesclado', description: 'Este PR já foi mesclado.', color: 'status-success' };
+    if (isClosed) return { status: 'Fechado', description: 'Este PR foi fechado sem ser mesclado.', color: 'status-error' };
 
     const pendingChecks = checkRuns.filter(c => c.status !== 'completed');
     const failedChecks = checkRuns.filter(c => c.status === 'completed' && c.conclusion !== 'success' && c.conclusion !== 'neutral' && c.conclusion !== 'skipped');
 
     const blockedByKilo = failedChecks.find(c => c.name.toLowerCase().includes('kilo') || (c.output && c.output.title && c.output.title.toLowerCase().includes('kilo')));
 
-    let status = 'Mergeable';
-    let description = 'All checks passed and PR is ready to merge.';
+    let status = 'Pronto para merge';
+    let description = 'Todas as verificações passaram. O PR está pronto para ser mesclado.';
     let color = 'status-success';
 
     if (failedChecks.length > 0) {
-      status = 'Blocked';
+      status = 'Bloqueado';
       color = 'status-error';
       if (blockedByKilo) {
-        description = `CI ${failedChecks.length > 1 ? 'and Kilo failed' : 'green, Kilo ACTION_REQUIRED'} → merge blocked by external review gate.`;
+        description = `${failedChecks.length > 1 ? 'CI e Kilo falharam' : 'CI verde, Kilo ACTION_REQUIRED'} → merge bloqueado por revisão externa.`;
       } else {
-        description = `${failedChecks.length} check(s) failed.`;
+        description = `${failedChecks.length} verificação(ões) falharam.`;
       }
     } else if (pendingChecks.length > 0) {
-      status = 'Pending';
+      status = 'Pendente';
       color = 'status-accent';
-      description = `${pendingChecks.length} check(s) still in progress.`;
+      description = `${pendingChecks.length} verificação(ões) em andamento.`;
     }
 
     return { status, description, color, blockedByKilo: blockedByKilo || failedChecks[0] };
@@ -127,16 +127,18 @@
 </script>
 
 <div class="card" id="pr-gate-explainer"><div class="card-body">
-  <h2>PR Readiness Gate Explainer</h2>
+  <h2>Diagnóstico de prontidão do PR</h2>
   <form onsubmit={fetchPRStatus}>
     <input
       class="input-field"
-      type="number" placeholder="Enter PR Number (e.g., 425)"
+      type="number"
+      placeholder="Número do PR (ex.: 425)"
+      aria-label="Número do PR"
       value={prNumber}
       oninput={(e: Event & { currentTarget: HTMLInputElement }) => prNumber = e.currentTarget.value}
     />
     <button type="submit" disabled={loading || !prNumber}>
-      {loading ? 'Checking...' : 'Check PR'}
+      {loading ? 'Verificando...' : 'Verificar PR'}
     </button>
   </form>
 
@@ -158,7 +160,7 @@
 
           {#if summary.blockedByKilo}
             <div>
-              <strong>Blocker: </strong>
+              <strong>Bloqueio: </strong>
               <a href={summary.blockedByKilo.html_url || '#'} target="_blank" rel="noopener noreferrer" class="link-accent">
                 {summary.blockedByKilo.name}
               </a>
@@ -169,7 +171,7 @@
 
       <div class="checks-grid">
         <div>
-          <h4>Completed Checks</h4>
+          <h4>Verificações concluídas</h4>
           <ul>
             {#each completedChecks as c (c.id)}
               <li>
@@ -180,22 +182,22 @@
               </li>
             {/each}
             {#if completedChecks.length === 0}
-              <li>No completed checks.</li>
+              <li>Nenhuma verificação concluída.</li>
             {/if}
           </ul>
         </div>
 
         <div>
-          <h4>Pending Checks</h4>
+          <h4>Verificações pendentes</h4>
           <ul>
             {#each pendingChecks as c (c.id)}
               <li>
                 <span title={c.name}>{c.name}</span>
-                <span class="status-accent">In Progress...</span>
+                <span class="status-accent">Em andamento...</span>
               </li>
             {/each}
             {#if pendingChecks.length === 0}
-              <li>No pending checks.</li>
+              <li>Nenhuma verificação pendente.</li>
             {/if}
           </ul>
         </div>

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -129,8 +129,15 @@
     opacity: 0.55;
   }
 
-  .clear-btn:hover {
+  .clear-btn:hover,
+  .clear-btn:focus-visible {
     opacity: 1;
+  }
+
+  .clear-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm, 0.25rem);
   }
 
   .hint {

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -129,12 +129,12 @@
     opacity: 0.55;
   }
 
-  .clear-btn:hover,
-  .clear-btn:focus-visible {
+  .clear-btn:hover {
     opacity: 1;
   }
 
   .clear-btn:focus-visible {
+    opacity: 1;
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
     border-radius: var(--radius-sm, 0.25rem);

--- a/web/src/components/__steps__/admin-pr-gate.steps.ts
+++ b/web/src/components/__steps__/admin-pr-gate.steps.ts
@@ -45,7 +45,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And('I should see a submit button', () => {
-      expect(screen.getByText('Check PR')).toBeTruthy();
+      expect(screen.getByText('Verificar PR')).toBeTruthy();
     });
   });
 
@@ -62,7 +62,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     Then('I should see a loading indicator', () => {
-      expect(screen.getByText('Checking...')).toBeTruthy();
+      expect(screen.getByText('Verificando...')).toBeTruthy();
     });
   });
 
@@ -88,7 +88,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     Then('I should see an error message', () => {
-      expect(screen.getByText(/Failed to fetch PR details/)).toBeTruthy();
+      expect(screen.getByText(/Falha ao obter detalhes do PR/)).toBeTruthy();
     });
   });
 
@@ -124,11 +124,11 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       const input = document.querySelector('input[type="number"]') as HTMLInputElement;
       fireEvent.input(input, { target: { value: '42' } });
       fireEvent.submit(input.closest('form')!);
-      await waitFor(() => screen.getByText('Merged'));
+      await waitFor(() => screen.getByText('Mesclado'));
     });
 
-    Then('I should see "Merged" status', () => {
-      expect(screen.getByText('Merged')).toBeTruthy();
+    Then('I should see "Mesclado" status', () => {
+      expect(screen.getByText('Mesclado')).toBeTruthy();
     });
   });
 });

--- a/web/src/components/__steps__/publicacoes.steps.ts
+++ b/web/src/components/__steps__/publicacoes.steps.ts
@@ -47,7 +47,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And('I should see the ZIP count in the banner', () => {
-      expect(screen.getAllByText(/15,000/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/15\.000/).length).toBeGreaterThan(0);
     });
 
     And('I should see "85" as tribunals with data', () => {

--- a/web/src/pages/admin/pr-gate.astro
+++ b/web/src/pages/admin/pr-gate.astro
@@ -5,13 +5,13 @@ import PRGateExplainer from '../../components/PRGateExplainer.svelte';
 ---
 
 <Layout
-  title="CausaGanha - PR Readiness Gate"
-  description="Compact PR readiness gate explainer for CausaGanha."
+  title="CausaGanha — Diagnóstico de prontidão do PR"
+  description="Diagnostica se um PR está ou não pronto para merge no CausaGanha."
 >
   <Header
     variant="page"
-    title="PR Readiness Gate"
-    subtitle="Explain why a PR is or is not ready to merge"
+    title="Diagnóstico de prontidão do PR"
+    subtitle="Entenda por que um PR está ou não pronto para ser mesclado"
   />
 
   <div class="page-container">


### PR DESCRIPTION
## Summary

A small batch of UI/UX easy wins identified by an audit pass over the web frontend.

- **a11y — focus-visible parity with hover**: `Header.btn-menu`, `Header.btn-back`, `SmartSearchInput.clear-btn`, and `DuckDBExplorer.retry-btn` previously only highlighted on `:hover`, leaving keyboard users without a visible focus indicator. Each now also responds to `:focus-visible` with a 2px outline.
- **Form safety — explicit `type="button"`**: `DateDetail`'s share link, "Ver todas as publicações" dismiss, and load-more buttons now declare `type="button"` so they cannot accidentally submit an enclosing form.
- **pt-BR translation — admin PR-gate**: `/admin/pr-gate` and `PRGateExplainer` were the last surface still rendering English (heading, placeholder, "Check PR", "Checking…", "Merged/Closed/Mergeable/Blocked/Pending", "Completed/Pending Checks", error message, etc.). Now translated to match the rest of the app. Cucumber feature file and step definitions updated in lockstep.
- **Test fix — locale**: `publicacoes.steps.ts` asserted `/15,000/` (en-US) but `TribunalView` switched to `toLocaleString('pt-BR')` → `15.000`. Updated the regex; this was a pre-existing failure on `main`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run` — 101/101 passing (was 100/101 on `main` due to the locale mismatch fixed here)
- [x] `npx astro check` — no new errors introduced (7 pre-existing unrelated errors in `stats.astro` / `explorador.astro` from missing `public/data/*.json`)
- [ ] Manual a11y check: tab through homepage header, search clear button, and `/explorador` retry button to confirm visible focus rings
- [ ] Manual: visit `/admin/pr-gate` and verify all UI is in pt-BR

https://claude.ai/code/session_01Nbp3XZTPmPirN3mqFQp2y9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nbp3XZTPmPirN3mqFQp2y9)_