### PR TITLE
fix(web): UX easy wins — 404 description, title consistency, reduced-motion

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -622,6 +622,20 @@ small { font-size: var(--font-size-sm); }
 }
 
 /* ═══════════════════════════════════════════
+   Reduced Motion (WCAG 2.3.3)
+   Honor the user's OS-level preference to minimize motion.
+   ═══════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ═══════════════════════════════════════════
    Touch Target Minimums (WCAG 2.5.5)
    ═══════════════════════════════════════════ */
 

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -4,7 +4,10 @@ import Header from '../components/Header.astro';
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
-<Layout title="Página não encontrada — CausaGanha">
+<Layout
+  title="Página não encontrada — CausaGanha"
+  description="O endereço não existe ou foi movido. Use a busca ou volte ao início para encontrar publicações judiciais arquivadas."
+>
   <Header variant="page" title="Página não encontrada" backHref={BASE} backLabel="Início" tile="404" />
 
   <div class="hero">

--- a/web/src/pages/admin/backfill.astro
+++ b/web/src/pages/admin/backfill.astro
@@ -4,7 +4,7 @@ import Header from '../../components/Header.astro';
 import ManifestStatus from '../../components/ManifestStatus.svelte';
 ---
 
-<Layout title="Admin - Backfill" description="Progresso de backfill e cobertura histórica do pipeline.">
+<Layout title="Backfill — Admin — CausaGanha" description="Progresso de backfill e cobertura histórica do pipeline.">
   <Header variant="page" title="Manifest Status" subtitle="Cobertura do backup por tribunal e ano" />
 
   <div class="page-container">

--- a/web/src/pages/admin/index.astro
+++ b/web/src/pages/admin/index.astro
@@ -20,7 +20,7 @@ const adminPages = [
 ];
 ---
 
-<Layout title="Admin Dashboard" description="Painel de administração e monitoramento do CausaGanha.">
+<Layout title="Admin — CausaGanha" description="Painel de administração e monitoramento do CausaGanha.">
   <Header variant="page" title="Admin Dashboard" subtitle="Monitoramento interno e ferramentas do sistema" />
 
   <div class="container mx-auto px-4">

--- a/web/src/pages/admin/perf.astro
+++ b/web/src/pages/admin/perf.astro
@@ -32,7 +32,7 @@ const qualityScores = readJson<Record<string, QualityScore>>('tribunal_quality_s
 ---
 
 <Layout
-  title="CausaGanha — Painel de Performance"
+  title="Performance — Admin — CausaGanha"
   description="Saúde do sistema e métricas de performance do pipeline de backfill da CausaGanha."
 >
   <Header

--- a/web/src/pages/admin/pr-gate.astro
+++ b/web/src/pages/admin/pr-gate.astro
@@ -5,7 +5,7 @@ import PRGateExplainer from '../../components/PRGateExplainer.svelte';
 ---
 
 <Layout
-  title="CausaGanha — Diagnóstico de prontidão do PR"
+  title="Diagnóstico de PR — Admin — CausaGanha"
   description="Diagnostica se um PR está ou não pronto para merge no CausaGanha."
 >
   <Header

--- a/web/src/pages/admin/quality.astro
+++ b/web/src/pages/admin/quality.astro
@@ -12,7 +12,7 @@ const entries = Object.entries(qualityScores)
 const avg = entries.length ? entries.reduce((sum, item) => sum + item.score, 0) / entries.length : 0;
 ---
 
-<Layout title="Admin - Data Quality" description="Painel de qualidade por tribunal.">
+<Layout title="Data Quality — Admin — CausaGanha" description="Painel de qualidade por tribunal.">
   <Header variant="page" title="Data Quality" subtitle="Score de qualidade por tribunal" />
 
   <div class="page-container">

--- a/web/src/pages/advogados.astro
+++ b/web/src/pages/advogados.astro
@@ -23,7 +23,7 @@ const avgCoverage = tribunalStats.length
   : 0;
 ---
 
-<Layout title="Advogados - CausaGanha" description="Cobertura por tribunal para exploração de dados de advogados/OAB no acervo público.">
+<Layout title="Advogados — CausaGanha" description="Cobertura por tribunal para exploração de dados de advogados/OAB no acervo público.">
   <Header variant="page" title="Advogados / OAB" subtitle="Cobertura por tribunal para consultas de advogados" backHref={BASE} backLabel="Início" tile="advogados" />
 
   <div class="container">

--- a/web/src/pages/advogados/[oab].astro
+++ b/web/src/pages/advogados/[oab].astro
@@ -36,7 +36,7 @@ const tribunal = tribunalStats.find((item: any) => item.tribunal === key);
 const query = `SELECT numero_oab, uf_oab, COUNT(*) AS aparicoes\nFROM advogados\nWHERE tribunal = '${key}'\nGROUP BY numero_oab, uf_oab\nORDER BY aparicoes DESC\nLIMIT 25;`;
 ---
 
-<Layout title={`${key} - Advogados - CausaGanha`} description={`Guia de consulta de advogados/OAB para ${key}.`}>
+<Layout title={`${key} — Advogados — CausaGanha`} description={`Guia de consulta de advogados/OAB para ${key}.`}>
   <Header variant="page" backHref={BASE + 'advogados'} backLabel="Advogados" tile="advogados" title={`Guia por Tribunal: ${key}`} subtitle="Use no Explorador para consultar OABs com dados já coletados" />
 
   <div class="container">

--- a/web/src/pages/changelog.astro
+++ b/web/src/pages/changelog.astro
@@ -19,7 +19,7 @@ const entries = [
 ];
 ---
 
-<Layout title="Changelog - CausaGanha" description="Atualizações de produto e status do projeto CausaGanha.">
+<Layout title="Changelog — CausaGanha" description="Atualizações de produto e status do projeto CausaGanha.">
   <Header variant="page" title="Changelog" subtitle="Evolução do dashboard e do pipeline" backHref={BASE} backLabel="Início" tile="changelog" />
 
   <div class="page-container">

--- a/web/src/pages/comparador.astro
+++ b/web/src/pages/comparador.astro
@@ -36,7 +36,7 @@ const tribunais = Array.from(grouped.values()).sort((a, b) => {
 }).slice(0, 12);
 ---
 
-<Layout title="Comparador de Tribunais - CausaGanha" description="Compare cobertura e volume de publicações entre tribunais.">
+<Layout title="Comparador de Tribunais — CausaGanha" description="Compare cobertura e volume de publicações entre tribunais.">
   <Header variant="page" title="Comparador de Tribunais" subtitle="Tribunais com maior cobertura histórica — do mais antigo ao mais recente" backHref={BASE + 'publicacoes'} backLabel="Publicações" tile="comparador" />
 
   <div class="container">

--- a/web/src/pages/consultas.astro
+++ b/web/src/pages/consultas.astro
@@ -25,7 +25,7 @@ const queries = [
 ];
 ---
 
-<Layout title="Consultas SQL - CausaGanha" description="Consultas prontas para acelerar o uso do Explorador DuckDB.">
+<Layout title="Consultas SQL — CausaGanha" description="Consultas prontas para acelerar o uso do Explorador DuckDB.">
   <Header variant="page" title="Consultas Prontas" subtitle="Exemplos SQL para usar no explorador" backHref={BASE + 'explorador'} backLabel="Explorador" tile="consultas" />
 
   <div class="page-container">

--- a/web/src/pages/dados.astro
+++ b/web/src/pages/dados.astro
@@ -18,7 +18,7 @@ const snapVolumeLabel = snapGB === 0
 ---
 
 <Layout
-  title="Dados Abertos - CausaGanha"
+  title="Dados Abertos — CausaGanha"
   description="Acesse, baixe e consulte dados judiciais brasileiros de 96 tribunais. Parquet, DuckDB e API pública."
 >
   <Header variant="page" title="Dados Abertos" backHref={BASE} backLabel="Início" tile="dados">

--- a/web/src/pages/dicionario.astro
+++ b/web/src/pages/dicionario.astro
@@ -15,7 +15,7 @@ const dictionary = [
 ];
 ---
 
-<Layout title="Dicionário de Dados - CausaGanha" description="Glossário dos campos e tabelas do dataset jurídico aberto.">
+<Layout title="Dicionário de Dados — CausaGanha" description="Glossário dos campos e tabelas do dataset jurídico aberto.">
   <Header variant="page" title="Dicionário de Dados" subtitle="Campos principais do catálogo Parquet" backHref={BASE + 'dados'} backLabel="Dados" tile="dicionario" />
 
   <div class="page-container">

--- a/web/src/pages/publicacoes/[tribunal].astro
+++ b/web/src/pages/publicacoes/[tribunal].astro
@@ -69,7 +69,7 @@ const ogImage = new URL(`${BASE}og/${tribunalCode.toLowerCase()}.svg`, Astro.sit
 ---
 
 <Layout
-  title={`${tribunalCode} - Publicações - CausaGanha`}
+  title={`${tribunalCode} — Publicações — CausaGanha`}
   description={ogDesc}
   ogImage={ogImage}
 >

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -22,7 +22,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <Layout
-  title="CausaGanha — Publicações"
+  title="Publicações — CausaGanha"
   description="Publicações judiciais brasileiras arquivadas no Internet Archive."
 >
   <Header variant="page" title="CausaGanha" tile="publicacoes">


### PR DESCRIPTION
## Summary

A handful of low-risk UX/SEO/a11y improvements across the web frontend:

- **404 page description** — `web/src/pages/404.astro` was missing a `description` prop, so its OG/Twitter cards and `<meta name="description">` fell back to the generic site-wide string. Added a focused description for not-found pages.
- **`<title>` consistency** — page titles used a mix of `Page - CausaGanha`, `Page — CausaGanha`, and `CausaGanha — Page`. Normalized to `Page Name — CausaGanha` (em-dash, brand suffix) across 12 pages. Admin pages now include the brand: `Backfill — Admin — CausaGanha`, etc. Home page keeps its existing `CausaGanha — Dados do Judiciário Brasileiro` since the brand is the headline there.
- **`prefers-reduced-motion`** — the stylesheet has animations and transitions but no opt-out for users with the OS-level reduced-motion preference (WCAG 2.3.3). Added a global `@media (prefers-reduced-motion: reduce)` rule that collapses animation/transition durations and disables smooth scroll.

## Files changed

- `web/src/index.css` — added reduced-motion media query
- `web/src/pages/404.astro` — added description prop
- 14 page files in `web/src/pages/` — title normalization

No JS/TS/runtime changes; all edits are to text strings or CSS.

## Test plan

- [ ] `cd web && npm run build` succeeds
- [ ] View source of `/`, `/sobre`, `/admin`, `/404` and verify titles / `<meta name="description">` look right
- [ ] Toggle "Reduce motion" in OS settings and confirm animations no longer play

https://claude.ai/code/session_012diNyrZJF4xqai2WjXoEXq

---
_Generated by [Claude Code](https://claude.ai/code/session_012diNyrZJF4xqai2WjXoEXq)_