### PR TITLE
web: QueryCard copy-to-clipboard + ThemeToggle icon FOUC fix

### DIFF
--- a/web/src/components/QueryCard.astro
+++ b/web/src/components/QueryCard.astro
@@ -8,15 +8,75 @@ interface Props {
 const { title, description, sql } = Astro.props;
 ---
 
-<div class="card">
+<div class="card query-card">
   <div class="card-body">
-    <h3 class="card-title">{title}</h3>
+    <div class="card-header">
+      <h3 class="card-title">{title}</h3>
+      <button
+        type="button"
+        class="copy-btn"
+        data-sql={sql}
+        aria-label={`Copiar SQL: ${title}`}
+      >
+        <svg class="copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+        </svg>
+        <svg class="check-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+        <span class="copy-label">Copiar</span>
+      </button>
+    </div>
     <p class="description">{description}</p>
     <pre class="code-block"><code>{sql}</code></pre>
   </div>
 </div>
 
+<script>
+  function setupQueryCardCopy() {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.query-card .copy-btn');
+    buttons.forEach((btn) => {
+      if (btn.dataset.bound === '1') return;
+      btn.dataset.bound = '1';
+      btn.addEventListener('click', async () => {
+        const sql = btn.dataset.sql ?? '';
+        const label = btn.querySelector<HTMLElement>('.copy-label');
+        try {
+          await navigator.clipboard.writeText(sql);
+        } catch {
+          // Fallback: select the sibling code block so the user can copy manually.
+          const code = btn.closest('.card-body')?.querySelector('code');
+          if (code) {
+            const range = document.createRange();
+            range.selectNodeContents(code);
+            const sel = window.getSelection();
+            sel?.removeAllRanges();
+            sel?.addRange(range);
+          }
+          return;
+        }
+        btn.classList.add('copied');
+        if (label) label.textContent = 'Copiado!';
+        window.setTimeout(() => {
+          btn.classList.remove('copied');
+          if (label) label.textContent = 'Copiar';
+        }, 1800);
+      });
+    });
+  }
+
+  setupQueryCardCopy();
+  document.addEventListener('astro:after-swap', setupQueryCardCopy);
+</script>
+
 <style>
+  .query-card .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
 
   .card-title {
     font-weight: 600;
@@ -29,6 +89,48 @@ const { title, description, sql } = Astro.props;
     margin: 0;
   }
 
+  .copy-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.65rem;
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--color-content-secondary);
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-btn);
+    cursor: pointer;
+    transition: color var(--transition-base), background var(--transition-base), border-color var(--transition-base);
+    flex-shrink: 0;
+  }
+
+  .copy-btn:hover,
+  .copy-btn:focus-visible {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: var(--color-surface);
+    outline: none;
+  }
+
+  .copy-btn .check-icon {
+    display: none;
+  }
+
+  .copy-btn.copied {
+    color: var(--color-success, var(--color-primary));
+    border-color: var(--color-success, var(--color-primary));
+  }
+
+  .copy-btn.copied .copy-icon {
+    display: none;
+  }
+
+  .copy-btn.copied .check-icon {
+    display: inline;
+  }
+
   .code-block {
     background: var(--color-base-200);
     border-radius: var(--radius-box);
@@ -39,6 +141,6 @@ const { title, description, sql } = Astro.props;
   }
 
   .code-block code {
-    font-family: monospace;
+    font-family: var(--font-mono);
   }
 </style>

--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -6,11 +6,12 @@
   class="theme-toggle-btn"
   type="button"
   aria-label="Alternar tema"
+  title="Alternar tema (claro/escuro)"
 >
-  <svg id="theme-toggle-sun" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;">
+  <svg class="icon-sun" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
   </svg>
-  <svg id="theme-toggle-moon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;">
+  <svg class="icon-moon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
   </svg>
 </button>
@@ -18,33 +19,26 @@
 <script>
   function setupThemeToggle() {
     const btn = document.getElementById('theme-toggle');
-    const sun = document.getElementById('theme-toggle-sun');
-    const moon = document.getElementById('theme-toggle-moon');
-    if (!btn || !sun || !moon) return;
+    if (!btn) return;
+    if (btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
 
-    const saved = localStorage.getItem('causaganha-theme');
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    let isDark = saved ? saved === 'dark' : prefersDark;
-
-    function applyTheme() {
-      document.documentElement.setAttribute('data-theme', isDark ? 'causaganhadark' : 'causaganha');
-      sun!.style.display = isDark ? 'block' : 'none';
-      moon!.style.display = isDark ? 'none' : 'block';
+    function syncLabel() {
+      const isDark = document.documentElement.getAttribute('data-theme') === 'causaganhadark';
       btn!.setAttribute('aria-label', isDark ? 'Mudar para modo claro' : 'Mudar para modo escuro');
     }
 
-    applyTheme();
+    syncLabel();
 
     btn.addEventListener('click', () => {
-      isDark = !isDark;
-      const theme = isDark ? 'dark' : 'light';
-      document.documentElement.setAttribute('data-theme', isDark ? 'causaganhadark' : 'causaganha');
-      localStorage.setItem('causaganha-theme', theme);
-      applyTheme();
+      const isDark = document.documentElement.getAttribute('data-theme') === 'causaganhadark';
+      const nextDark = !isDark;
+      document.documentElement.setAttribute('data-theme', nextDark ? 'causaganhadark' : 'causaganha');
+      localStorage.setItem('causaganha-theme', nextDark ? 'dark' : 'light');
+      syncLabel();
     });
   }
 
-  // Setup on initial load and view transitions
   setupThemeToggle();
   document.addEventListener('astro:after-swap', setupThemeToggle);
 </script>
@@ -69,5 +63,29 @@
 
   .theme-toggle-btn:hover {
     background: var(--color-base-200);
+  }
+
+  .theme-toggle-btn:focus-visible {
+    background: var(--color-base-200);
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* Icon visibility is driven by [data-theme] (set by the inline head script
+     before paint), so the correct icon shows on first render — no FOUC. */
+  .theme-toggle-btn .icon-sun {
+    display: none;
+  }
+
+  .theme-toggle-btn .icon-moon {
+    display: inline;
+  }
+
+  :root[data-theme='causaganhadark'] .theme-toggle-btn .icon-sun {
+    display: inline;
+  }
+
+  :root[data-theme='causaganhadark'] .theme-toggle-btn .icon-moon {
+    display: none;
   }
 </style>


### PR DESCRIPTION
## Summary

Two small UX wins in the web frontend.

### 1. `QueryCard` — copy SQL to clipboard
`/consultas` literally tells users _"Copie e adapte os blocos abaixo"_, but the cards had no copy button — users had to manually select the SQL. Same component is reused in the homepage "proof" block.

- Adds an accessible **Copiar / Copiado!** button (clipboard icon → checkmark) inside the card header.
- Uses `navigator.clipboard.writeText`; falls back to selecting the code block if the Clipboard API is unavailable / denied.
- Reattaches handlers on `astro:after-swap` so it survives view transitions.
- Also switches the code block from `font-family: monospace` to `var(--font-mono)` for consistency with the rest of the app.

### 2. `ThemeToggle` — fix icon FOUC
Both SVGs previously started with inline `style="display:none"` and only got one revealed once JS ran. Until then, the toggle was a button with no visible glyph.

- Icon visibility is now CSS-driven via `[data-theme]` attribute selectors. The inline head script in `Layout.astro` already sets `data-theme` before paint, so the correct icon shows on first render with no flash.
- Script is reduced to just toggling the attribute, persisting the choice, and updating `aria-label` (also added a `:focus-visible` outline and a `title` for the tooltip).

## Test plan
- [ ] Visit `/consultas` and `/` — Copy buttons appear in each query card; clicking copies the SQL and shows "Copiado!" briefly.
- [ ] Toggle theme: icon switches sun/moon as expected, and persists across reload.
- [ ] Reload the page in dark mode — moon→sun icon shows on first paint, no flicker.
- [ ] Keyboard: Tab to copy button; Enter copies. Tab to theme toggle; Enter toggles theme. Both have visible focus rings.

https://claude.ai/code/session_01LL8FMSMYTHADKa542M2Y2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL8FMSMYTHADKa542M2Y2f)_