### PR TITLE
fix(web): replace hardcoded colors with design tokens

### DIFF
--- a/web/src/components/DataAccessPanel.svelte
+++ b/web/src/components/DataAccessPanel.svelte
@@ -113,7 +113,7 @@ SELECT * FROM cg.comunicacoes WHERE tribunal = '${tribunalCode}' LIMIT 100;`);
 
     <!-- Parquet files -->
     {#if loading}
-      <p aria-busy="true">Carregando arquivos...</p>
+      <p role="status" aria-live="polite" aria-busy="true">Carregando arquivos...</p>
     {/if}
 
     {#if parquetFiles.length > 0}

--- a/web/src/components/IncidentBanner.astro
+++ b/web/src/components/IncidentBanner.astro
@@ -72,7 +72,7 @@ const { incident } = Astro.props;
 <style>
   .incident-banner {
     border-left: 4px solid var(--color-error);
-    background: rgba(220, 38, 38, 0.08);
+    background: color-mix(in srgb, var(--color-error) 8%, transparent);
     border-radius: var(--radius-box);
     padding: var(--space-sm) var(--space-md);
     margin-bottom: var(--space-sm);
@@ -130,7 +130,7 @@ const { incident } = Astro.props;
 
   .pr-link {
     color: var(--color-accent);
-    background: rgba(180, 83, 9, 0.1);
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
     padding: 0.125rem 0.5rem;
     border-radius: var(--radius-sm);
     font-weight: 500;
@@ -142,7 +142,7 @@ const { incident } = Astro.props;
   }
 
   .blocked-badge {
-    background: rgba(217, 119, 6, 0.12);
+    background: color-mix(in srgb, var(--color-warning) 12%, transparent);
     color: var(--color-warning);
     padding: 0.125rem 0.5rem;
     border-radius: var(--radius-sm);

--- a/web/src/components/NetworkStatusBanner.astro
+++ b/web/src/components/NetworkStatusBanner.astro
@@ -23,6 +23,7 @@
     </div>
     <button
       id="ns-retry-btn"
+      type="button"
       class="retry-button"
       aria-label="Tentar reconectar rede agora">
       Tentar Novamente
@@ -159,7 +160,7 @@
 <style>
   aside {
     padding: var(--space-sm);
-    background: rgba(217, 119, 6, 0.1);
+    background: color-mix(in srgb, var(--color-warning) 10%, transparent);
     border-left: 4px solid var(--color-warning);
     border-radius: var(--radius-box);
     font-size: var(--font-size-sm);

--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -842,23 +842,23 @@
   }
 
   .meta-chip.accent {
-    border-color: rgba(180, 83, 9, 0.3);
-    background: rgba(180, 83, 9, 0.08);
+    border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 8%, transparent);
   }
 
   .meta-chip.success {
-    border-color: rgba(5, 150, 105, 0.25);
-    background: rgba(5, 150, 105, 0.08);
+    border-color: color-mix(in srgb, var(--color-success) 25%, transparent);
+    background: color-mix(in srgb, var(--color-success) 8%, transparent);
   }
 
   .meta-chip.warning {
-    border-color: rgba(217, 119, 6, 0.25);
-    background: rgba(217, 119, 6, 0.08);
+    border-color: color-mix(in srgb, var(--color-warning) 25%, transparent);
+    background: color-mix(in srgb, var(--color-warning) 8%, transparent);
   }
 
   .meta-chip.danger {
-    border-color: rgba(220, 38, 38, 0.25);
-    background: rgba(220, 38, 38, 0.08);
+    border-color: color-mix(in srgb, var(--color-error) 25%, transparent);
+    background: color-mix(in srgb, var(--color-error) 8%, transparent);
   }
 
   .orgao-name,

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -458,13 +458,13 @@
   }
 
   .toggle-btn:hover {
-    border-color: var(--color-primary, #3b82f6);
-    color: var(--color-primary, #3b82f6);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
   }
 
   .submit-btn {
-    background: var(--color-primary, #3b82f6);
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-primary-content);
     border-color: transparent;
     display: inline-flex;
     align-items: center;
@@ -537,18 +537,18 @@
   }
 
   .banner.info {
-    border-color: #3b82f6;
-    color: #1e40af;
+    border-color: var(--color-info);
+    color: var(--color-info);
   }
 
   .banner.warning {
-    border-color: #d97706;
-    color: #92400e;
+    border-color: var(--color-warning);
+    color: var(--color-warning);
   }
 
   .banner.danger {
-    border-color: #dc2626;
-    color: #991b1b;
+    border-color: var(--color-error);
+    color: var(--color-error);
   }
 
   .banner.muted {

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -543,7 +543,9 @@
 
   .banner.warning {
     border-color: var(--color-warning);
-    color: var(--color-warning);
+    /* --color-warning is a light gold (~2.5:1 on the light theme background);
+       mix toward base-content for WCAG AA contrast while keeping the warning hue. */
+    color: color-mix(in srgb, var(--color-warning) 50%, var(--color-base-content));
   }
 
   .banner.danger {

--- a/web/src/components/RateLimitBadge.svelte
+++ b/web/src/components/RateLimitBadge.svelte
@@ -54,18 +54,18 @@
   }
 
   .rate-limit-badge.ok {
-    border-color: #16a34a;
-    color: #16a34a;
+    border-color: var(--color-success);
+    color: var(--color-success);
   }
 
   .rate-limit-badge.warning {
-    border-color: #d97706;
-    color: #d97706;
+    border-color: var(--color-warning);
+    color: var(--color-warning);
   }
 
   .rate-limit-badge.danger {
-    border-color: #dc2626;
-    color: #dc2626;
+    border-color: var(--color-error);
+    color: var(--color-error);
   }
 
   .fallback-tag {

--- a/web/src/components/RateLimitBadge.svelte
+++ b/web/src/components/RateLimitBadge.svelte
@@ -60,7 +60,9 @@
 
   .rate-limit-badge.warning {
     border-color: var(--color-warning);
-    color: var(--color-warning);
+    /* --color-warning is a light gold; mix toward base-content so the small
+       badge text clears WCAG AA contrast on the light theme background. */
+    color: color-mix(in srgb, var(--color-warning) 50%, var(--color-base-content));
   }
 
   .rate-limit-badge.danger {

--- a/web/src/components/SearchFilters.svelte
+++ b/web/src/components/SearchFilters.svelte
@@ -254,8 +254,8 @@
   .field input:focus,
   .field select:focus {
     outline: none;
-    border-color: var(--color-primary, #3b82f6);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 15%, transparent);
   }
 
   .radio-row {
@@ -301,13 +301,13 @@
 
   .presets-row button:hover,
   .presets-row button:focus-visible {
-    border-color: var(--color-primary, #3b82f6);
-    color: var(--color-primary, #3b82f6);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
     outline: none;
   }
 
   .presets-row button:focus-visible {
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 25%, transparent);
   }
 
   .presets-row .ghost {
@@ -317,11 +317,11 @@
 
   .presets-row .ghost.danger:hover,
   .presets-row .ghost.danger:focus-visible {
-    color: #dc2626;
-    border-color: #dc2626;
+    color: var(--color-error);
+    border-color: var(--color-error);
   }
 
   .presets-row .ghost.danger:focus-visible {
-    box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.25);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-error) 25%, transparent);
   }
 </style>

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -81,8 +81,8 @@
   }
 
   .input-wrapper:focus-within {
-    border-color: var(--color-primary, #3b82f6);
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
   }
 
   .search-icon {


### PR DESCRIPTION
## Summary

Easy UX wins — several components shipped with hardcoded Tailwind hex values (`#3b82f6`, `#dc2626`, `#d97706`, etc.) that bypassed the theme system.

Most visibly, focus rings on `SearchFilters` and `SmartSearchInput` rendered **blue** even though `--color-primary` is green (`#1A6B3C`) — a jarring mismatch on the publicações search page. The hardcoded colors also failed to adapt in dark mode (theme tokens shift, hex values don't).

Swaps every offending hex/rgba over to the matching semantic token (`--color-primary`, `--color-error`, `--color-success`, `--color-warning`, `--color-info`, `--color-accent`) and uses `color-mix(in srgb, var(--color-X) N%, transparent)` for tinted backgrounds — the established pattern already in `SystemStatus`, `IASearchBar`, `DuckDBExplorer`, `BackfillDetailedStatus`, `AlertBanner`.

Plus two small a11y/correctness fixes bundled in the same pass:

- `NetworkStatusBanner` retry button — added `type="button"` (defensive).
- `DataAccessPanel` loading message — added `role="status"` + `aria-live="polite"` so screen readers actually announce "Carregando arquivos…" instead of just setting `aria-busy` on a bare `<p>`.

### Files

| File | What changed |
|---|---|
| `SearchFilters.svelte` | input focus ring (was blue), preset button hover/focus, danger preset button |
| `SmartSearchInput.svelte` | input wrapper focus ring (was blue) |
| `PublicationSearch.svelte` | info/warning/danger banner colors, submit button + toggle hover |
| `RateLimitBadge.svelte` | ok/warning/danger badge colors |
| `PublicationCard.svelte` | meta-chip accent/success/warning/danger tints |
| `IncidentBanner.astro` | alert bg, PR link bg, blocked badge bg |
| `NetworkStatusBanner.astro` | warning bg + `type="button"` on retry button |
| `DataAccessPanel.svelte` | loading state gains `role="status"` + `aria-live="polite"` |

8 files, +40 / −39.

## Test plan

- [x] `npm run lint` clean
- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx vitest run` — 101/101 pass
- [ ] Visual check: focus a `SearchFilters` input and confirm the focus ring is **green** (was blue)
- [ ] Visual check: switch to dark theme and confirm error/warning/success badges/banners adapt
- [ ] Visual check: PublicationSearch info/danger banners render with green-tinted / red-tinted borders consistent with the rest of the dashboard

https://claude.ai/code/session_013qMaxskqJ9mJFEd3vgZbPM

---
_Generated by [Claude Code](https://claude.ai/code/session_013qMaxskqJ9mJFEd3vgZbPM)_