### PR TITLE
fix(web): a11y and tap-target polish

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -2,10 +2,10 @@
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
-<footer class="site-footer">
+<footer class="site-footer" aria-labelledby="footer-brand">
   <div class="footer-inner">
-    <p class="footer-brand">CausaGanha</p>
-    <nav class="footer-links">
+    <p id="footer-brand" class="footer-brand">CausaGanha</p>
+    <nav class="footer-links" aria-label="Links do rodapé">
       <a href={BASE + 'publicacoes'} class="footer-link">Publicações</a>
       <a href={BASE + 'sobre'} class="footer-link">Metodologia</a>
       <a href="https://github.com/franklinbaldo/causaganha" class="footer-link" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -549,6 +549,14 @@ const recursosLinks = [
     text-decoration: none;
   }
 
+  @media (pointer: coarse) {
+    .btn-back,
+    .btn-menu {
+      min-width: 44px;
+      min-height: 44px;
+    }
+  }
+
   .btn-back:hover {
     background: var(--color-base-200);
   }

--- a/web/src/components/SearchFilters.svelte
+++ b/web/src/components/SearchFilters.svelte
@@ -324,4 +324,10 @@
   .presets-row .ghost.danger:focus-visible {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-error) 25%, transparent);
   }
+
+  @media (pointer: coarse) {
+    .presets-row button {
+      min-height: 44px;
+    }
+  }
 </style>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -89,4 +89,16 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     background: var(--color-secondary);
     color: var(--color-secondary-content);
   }
+
+  .btn-secondary:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 480px) {
+    .action-buttons {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -134,7 +134,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       </form>
 
       <!-- Search hint chips — clickable examples that pre-fill the search input. -->
-      <p class="search-hints" aria-label="Exemplos de busca">
+      <div class="search-hints" role="group" aria-label="Exemplos de busca">
         <span class="search-hints-label">Exemplos:</span>
         {['OAB SP 12345', 'TJSP mandado de segurança', 'TRF3 2026', 'STJ 2025'].map(hint => (
           <button
@@ -144,7 +144,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
             aria-label={`Buscar por ${hint}`}
           >{hint}</button>
         ))}
-      </p>
+      </div>
 
       <!-- Task-first entry points: three blunt actions someone can take right now. -->
       <ul class="quick-access" aria-label="Ações rápidas">


### PR DESCRIPTION
## Summary

A small batch of easy UI/UX wins across the web frontend. All changes are CSS additions or single-attribute swaps — no logic changes.

- **Header**: 44px minimum tap target for `.btn-back` and `.btn-menu` under `@media (pointer: coarse)`. The global tap-target rule in `index.css` only enforces 44px on `.btn*` / menu links — these two were below the WCAG 2.5.5 minimum on touch devices.
- **SearchFilters**: 44px minimum tap target for the period preset buttons (`Hoje`, `7 dias`, etc.) on touch. They render at `0.35rem × 0.75rem` padding which is ~28px tall on phones.
- **index.astro (hero)**: `search-hints` was a `<p>` with `aria-label`, containing buttons. `aria-label` on `<p>` is ignored by screen readers because `<p>` isn't a landmark. Switched to `<div role="group" aria-label="…">`.
- **Footer**: Added `aria-label="Links do rodapé"` on the footer `<nav>` and `aria-labelledby="footer-brand"` on the `<footer>` so AT users can distinguish it from the primary nav.
- **404**: Added `:focus-visible` ring on `.btn-secondary` (it was the only `.btn*` variant without the accent ring override) and stacked the two CTAs vertically on screens <480px.

## Test plan

- [ ] Verify hero search hint chips still work (click pre-fills input, keyboard focus moves through them)
- [ ] Verify focus ring is visible on both 404 buttons via keyboard tab
- [ ] On a touch device or with DevTools `pointer: coarse` emulation, confirm tap targets are ≥44px on `.btn-back`, `.btn-menu`, and the period preset buttons
- [ ] Screen reader announces "Links do rodapé, navegação" landmark distinctly from the main nav

https://claude.ai/code/session_017hGVW7MC4f3wRpcXnxaTkP

---
_Generated by [Claude Code](https://claude.ai/code/session_017hGVW7MC4f3wRpcXnxaTkP)_