### PR TITLE
fix(web): UX easy wins — button types, pt-BR strings, locale-aware numbers

### DIFF
--- a/web/src/components/AnnualCoverageMonitor.svelte
+++ b/web/src/components/AnnualCoverageMonitor.svelte
@@ -94,7 +94,7 @@ function sortIcon(field: string): string {
         disabled={loading}
         aria-busy={loading}
         title="Atualizar dados">
-        {loading ? 'Atualizando…' : 'Refresh'}
+        {loading ? 'Atualizando…' : 'Atualizar'}
       </button>
     </div>
   </div>

--- a/web/src/components/DataAccessPanel.svelte
+++ b/web/src/components/DataAccessPanel.svelte
@@ -79,6 +79,7 @@ SELECT * FROM cg.comunicacoes WHERE tribunal = '${tribunalCode}' LIMIT 100;`);
 
 {#if !expanded}
   <button
+    type="button"
     class="btn btn-expand"
     onclick={() => (expanded = true)}>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="btn-icon">
@@ -92,6 +93,7 @@ SELECT * FROM cg.comunicacoes WHERE tribunal = '${tribunalCode}' LIMIT 100;`);
     <header>
       <h4>Acesso aos Dados</h4>
       <button
+        type="button"
         class="btn btn-outline"
         onclick={() => (expanded = false)}>
         Fechar
@@ -103,6 +105,7 @@ SELECT * FROM cg.comunicacoes WHERE tribunal = '${tribunalCode}' LIMIT 100;`);
       <div>
         <span>Consulta via Catálogo (DuckDB)</span>
         <button
+          type="button"
           class="btn btn-outline"
           onclick={() => copyToClipboard(catalogQuery, 'catalog')}>
           {copied === 'catalog' ? 'Copiado!' : 'Copiar'}
@@ -138,6 +141,7 @@ SELECT * FROM cg.comunicacoes WHERE tribunal = '${tribunalCode}' LIMIT 100;`);
                   {duckdbQuery(f.name).substring(0, 80)}...
                 </code>
                 <button
+                  type="button"
                   class="btn btn-outline"
                   onclick={() => copyToClipboard(duckdbQuery(f.name), f.name)}>
                   {copied === f.name ? 'Copiado!' : 'SQL'}

--- a/web/src/components/PerfDashboard.svelte
+++ b/web/src/components/PerfDashboard.svelte
@@ -100,7 +100,7 @@
 </script>
 
 {#if !perfMetrics || !qualityScores}
-  <div>Loading performance data...</div>
+  <div>Carregando dados de desempenho...</div>
 {:else}
   <div>
     <div>
@@ -110,7 +110,7 @@
     <div class="stats-grid">
       <div class="card">
         <div class="card-body">
-          <small>Upload Success Rate</small>
+          <small>Taxa de sucesso de upload</small>
           <div class={successRate >= 90 ? 'value-success' : 'value-error'}>
             {successRate.toFixed(1)}%
           </div>
@@ -119,7 +119,7 @@
 
       <div class="card">
         <div class="card-body">
-          <small>Pending Backlog Days</small>
+          <small>Dias de backlog pendente</small>
           <div class="value-accent">
             {backlogDays}
           </div>
@@ -128,7 +128,7 @@
 
       <div class="card">
         <div class="card-body">
-          <small>Active Tribunals</small>
+          <small>Tribunais ativos</small>
           <div>
             {activeTribunals}
           </div>
@@ -138,10 +138,10 @@
 
     <div class="card">
       <div class="card-body">
-        <h3>Collection Latency Trend (7 days)</h3>
+        <h3>Tendência de latência de coleta (7 dias)</h3>
         <div bind:this={chartEl}></div>
         {#if latencies.length === 0}
-          <div>No latency data available.</div>
+          <div>Sem dados de latência disponíveis.</div>
         {/if}
       </div>
     </div>
@@ -149,23 +149,23 @@
     <div class="stats-grid">
       <div class="card">
         <div class="card-body">
-          <h3>Grade Distribution</h3>
+          <h3>Distribuição por nota</h3>
           <div bind:this={pieEl}></div>
         </div>
       </div>
 
       <div class="card">
         <div class="card-body">
-          <h3>Top 5 Slowest Tribunals</h3>
+          <h3>5 tribunais mais lentos</h3>
           <ul class="slowest-list">
             {#each slowestTribunals as t, idx}
               <li>
                 <span>{idx + 1}. {t.tribunal}</span>
-                <span>{t.velocity_14d.toFixed(1)} velocity (14d)</span>
+                <span>{t.velocity_14d.toFixed(1)} velocidade (14d)</span>
               </li>
             {/each}
             {#if slowestTribunals.length === 0}
-              <li>All tribunals are up to date!</li>
+              <li>Todos os tribunais estão atualizados!</li>
             {/if}
           </ul>
         </div>

--- a/web/src/components/PipelineRunHistory.svelte
+++ b/web/src/components/PipelineRunHistory.svelte
@@ -46,10 +46,10 @@
 
 <div class="card">
   <div class="card-body">
-    <h3>Pipeline Run History (Collect ZIPs)</h3>
+    <h3>Histórico de Execuções do Pipeline (Collect ZIPs)</h3>
 
     {#if loading}
-      <div>Loading run history...</div>
+      <div>Carregando histórico de execuções...</div>
     {:else if error}
       <AlertBanner level="error" title="Erro ao carregar histórico" message={error} />
     {:else if runs.length === 0}
@@ -59,9 +59,9 @@
         <table class="data-table">
           <thead>
             <tr>
-              <th>Run Date</th>
-              <th>Duration (min)</th>
-              <th>Status</th>
+              <th scope="col">Data da execução</th>
+              <th scope="col">Duração (min)</th>
+              <th scope="col">Status</th>
             </tr>
           </thead>
           <tbody>
@@ -77,9 +77,9 @@
                 </td>
                 <td>
                   {#if run.status !== 'completed'}
-                    <span title="In Progress">⏳</span>
+                    <span title="Em andamento">⏳</span>
                   {:else if run.conclusion === 'success'}
-                    <span title="Success">✅</span>
+                    <span title="Sucesso">✅</span>
                   {:else}
                     <a href={run.html_url} target="_blank" rel="noopener noreferrer" title="Ver logs da falha">❌</a>
                   {/if}

--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -365,6 +365,7 @@
             </a>
           {/if}
           <button
+            type="button"
             class="btn btn-outline-secondary"
             onclick={(e: MouseEvent) => handleShare(e, "compact")}
             title="Copiar link"
@@ -431,6 +432,7 @@
         </div>
         <div class="header-actions" aria-label="Ações de navegação e leitura">
           <button
+            type="button"
             class="btn btn-outline-secondary"
             onclick={() => (isReaderMode = false)}
             title="Sair do Modo Leitura"
@@ -444,6 +446,7 @@
             </a>
           {/if}
           <button
+            type="button"
             class="btn btn-outline-secondary"
             onclick={(e: MouseEvent) => handleShare(e, "reader")}
             title="Copiar link"
@@ -543,6 +546,7 @@
         <div class="header-actions" aria-label="Ações de navegação e leitura">
           {#if onCollapse}
             <button
+              type="button"
               class="btn btn-outline-secondary"
               onclick={onCollapse}
               title="Fechar detalhes"
@@ -551,6 +555,7 @@
             </button>
           {/if}
           <button
+            type="button"
             class="btn btn-outline-primary"
             onclick={() => (isReaderMode = true)}
             title="Abrir Modo Leitura"
@@ -566,6 +571,7 @@
           <div class="nav-actions" aria-label="Ações de navegação">
             {#if onNavigate}
               <button
+                type="button"
                 class="btn btn-outline-secondary"
                 onclick={() => onNavigate(seq - 1)}
                 disabled={seq <= 1}
@@ -573,6 +579,7 @@
                 Anterior
               </button>
               <button
+                type="button"
                 class="btn btn-outline-secondary"
                 onclick={() => onNavigate(seq + 1)}
                 disabled={totalSeq != null && seq >= totalSeq}
@@ -581,6 +588,7 @@
               </button>
             {/if}
             <button
+              type="button"
               class="btn btn-outline-secondary"
               onclick={(e: MouseEvent) => handleShare(e, "main")}
               title="Copiar link"

--- a/web/src/components/SearchFilters.svelte
+++ b/web/src/components/SearchFilters.svelte
@@ -102,6 +102,7 @@
       <span>Nome do advogado</span>
       <input
         type="text"
+        autocomplete="off"
         placeholder="Ex.: João da Silva"
         value={filters.nomeAdvogado ?? ''}
         oninput={(e) => (filters = { ...filters, nomeAdvogado: e.currentTarget.value || undefined })}
@@ -112,6 +113,7 @@
       <span>Nome da parte</span>
       <input
         type="text"
+        autocomplete="off"
         placeholder="Ex.: Empresa XYZ LTDA"
         value={filters.nomeParte ?? ''}
         oninput={(e) => (filters = { ...filters, nomeParte: e.currentTarget.value || undefined })}

--- a/web/src/components/__steps__/admin-perf.steps.ts
+++ b/web/src/components/__steps__/admin-perf.steps.ts
@@ -103,7 +103,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     Then('I should see grade labels for non-zero grades', () => {
-      expect(screen.getByText('Grade Distribution')).toBeTruthy();
+      expect(screen.getByText('Distribuição por nota')).toBeTruthy();
     });
   });
 

--- a/web/src/pages/publicacoes/[tribunal].astro
+++ b/web/src/pages/publicacoes/[tribunal].astro
@@ -56,7 +56,7 @@ if (import.meta.env.PROD && zipCount > 0) {
   <text x="80" y="120" font-family="system-ui,sans-serif" font-size="24" fill="#94a3b8">CausaGanha</text>
   <text x="80" y="200" font-family="system-ui,sans-serif" font-size="72" font-weight="bold" fill="#3b82f6">${tribunalCode}</text>
   <text x="80" y="260" font-family="system-ui,sans-serif" font-size="28" fill="#cbd5e1">${fullName}</text>
-  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">${zipCount.toLocaleString()} publicações</text>
+  <text x="80" y="360" font-family="monospace" font-size="48" font-weight="bold" fill="#f8fafc">${zipCount.toLocaleString('pt-BR')} publicações</text>
   <text x="80" y="420" font-family="system-ui,sans-serif" font-size="24" fill="#64748b">${earliestDate ? earliestDate + ' a ' + latestDate : 'Internet Archive'}</text>
   <text x="80" y="520" font-family="system-ui,sans-serif" font-size="20" fill="#475569">Dados públicos do Diário de Justiça Eletrônico Nacional</text>
   <text x="80" y="555" font-family="system-ui,sans-serif" font-size="18" fill="#334155">franklinbaldo.github.io/causaganha</text>

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -28,7 +28,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   <Header variant="page" title="CausaGanha" tile="publicacoes">
     <DatabaseIcon slot="icon" />
     <p slot="subtitle" class="header-subtitle">
-      {snap ? `${(snap.total_zips ?? 0).toLocaleString()} ZIPs · ${snap.tribunals_with_data ?? 0} tribunais · última coleta: ${latestDate}` : 'Carregando...'}
+      {snap ? `${(snap.total_zips ?? 0).toLocaleString('pt-BR')} ZIPs · ${snap.tribunals_with_data ?? 0} tribunais · última coleta: ${latestDate}` : 'Carregando...'}
     </p>
   </Header>
 


### PR DESCRIPTION
## Summary

Small UX cleanups found while scanning the frontend — all under a line or two each, no behavior changes beyond what the labels say.

### Defensive `type="button"`
- `PublicationCard.svelte`: 8 buttons (share/compact, reader-mode toggles, navigate prev/next, share/main, share/reader, close)
- `DataAccessPanel.svelte`: 4 buttons (expand, close, copy catalog, copy parquet SQL)

These weren't currently inside `<form>` elements, but the implicit `type="submit"` is a footgun if the component is ever nested in one.

### Hardcoded English → pt-BR
- `PerfDashboard.svelte`: "Loading performance data...", "Upload Success Rate", "Pending Backlog Days", "Active Tribunals", "Collection Latency Trend", "Grade Distribution", "Top 5 Slowest Tribunals", "All tribunals are up to date!", "No latency data available."
- `PipelineRunHistory.svelte`: title, loading, table headers "Run Date / Duration / Status", status tooltips
- `AnnualCoverageMonitor.svelte`: "Refresh" → "Atualizar" (matches the existing "Atualizando…" loading state)
- Test step in `admin-perf.steps.ts` updated to match new "Distribuição por nota" header.

### Misc
- `PipelineRunHistory`: added `scope="col"` to `<th>` headers.
- `SearchFilters.svelte`: added `autocomplete="off"` to "Nome do advogado" / "Nome da parte" inputs (the OAB inputs already had it).
- `publicacoes/index.astro` + `publicacoes/[tribunal].astro`: pass `'pt-BR'` to `toLocaleString` so build-time SVG OG images and the page subtitle format `12345` as `12.345`, not `12,345`. The OG image renders in Node at build time where the default locale is `en-US`.

## Test plan
- [x] `npx vitest run` → 101 passed (updated one expectation to match new pt-BR string)
- [x] `npx astro check` → 0 errors, 0 warnings
- [x] `npm run lint` → clean

https://claude.ai/code/session_01H9Q4cASaALtdxmWqdPfQrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9Q4cASaALtdxmWqdPfQrj)_