### PR TITLE
fix(web): UX easy wins — pt-BR locale, type=button, reduced-motion, focus

### DIFF
--- a/web/src/components/PerfDashboard.svelte
+++ b/web/src/components/PerfDashboard.svelte
@@ -161,7 +161,7 @@
             {#each slowestTribunals as t, idx}
               <li>
                 <span>{idx + 1}. {t.tribunal}</span>
-                <span>{t.velocity_14d.toFixed(1)} velocidade (14d)</span>
+                <span>velocidade {t.velocity_14d.toFixed(1)} (14d)</span>
               </li>
             {/each}
             {#if slowestTribunals.length === 0}

--- a/web/src/components/PipelineRunHistory.svelte
+++ b/web/src/components/PipelineRunHistory.svelte
@@ -77,11 +77,11 @@
                 </td>
                 <td>
                   {#if run.status !== 'completed'}
-                    <span title="Em andamento">⏳</span>
+                    <span title="Em andamento" aria-label="Em andamento">⏳</span>
                   {:else if run.conclusion === 'success'}
-                    <span title="Sucesso">✅</span>
+                    <span title="Sucesso" aria-label="Sucesso">✅</span>
                   {:else}
-                    <a href={run.html_url} target="_blank" rel="noopener noreferrer" title="Ver logs da falha">❌</a>
+                    <a href={run.html_url} target="_blank" rel="noopener noreferrer" title="Ver logs da falha" aria-label="Ver logs da falha">❌</a>
                   {/if}
                 </td>
               </tr>

--- a/web/src/components/SystemStatus.svelte
+++ b/web/src/components/SystemStatus.svelte
@@ -124,7 +124,7 @@
             <span>{isDataStale ? dataDate : 'Hoje'}:</span>
             <span class={isDataStale ? 'text-warning' : ''}>{filesToday}/91</span>
             {#if isDataStale}
-              <span class="text-warning" title="Coleta parece parada — sem novos dados desde esta data">desatualizado</span>
+              <span class="text-warning" title="A coleta parece estar parada — sem novos dados desde esta data">desatualizado</span>
             {/if}
           </div>
         {/if}
@@ -150,6 +150,7 @@
 
       {#if stats?.steps}
         <button
+          type="button"
           class="toggle-btn"
           onclick={() => showDetails = !showDetails}
           aria-expanded={showDetails}
@@ -191,7 +192,7 @@
                       <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
                     </svg>
                   {/if}
-                  <span>{isOk ? 'OK' : 'Falha'}</span>
+                  <span>{isOk ? 'OK' : 'Erro'}</span>
                 </span>
               </div>
               <div class="step-details">


### PR DESCRIPTION
## Summary

A fresh batch of low-risk UI/UX fixes across the web frontend, picked up after the most recent easy-wins commits already covered the obvious stuff.

### Localization
- `pt-BR` locale on `.toLocaleString()` / `.toLocaleTimeString()` in `publicacoes/index.astro`, `publicacoes/[tribunal].astro` (OG image SVG), and `LiveStatusWidget.svelte` — so 5-digit numbers and clock times render with Brazilian separators.
- Translate stray English UI strings in the admin surfaces (`SystemStatus.svelte`, `PerfDashboard.svelte`, `PipelineRunHistory.svelte`): `Loading…`, `Pipeline Operational`, `Grade Distribution`, `Today`, `Next run`, etc.

### a11y
- Add `type="button"` to 9 non-submit buttons in `MonthPicker.svelte`, `Heatmap.svelte`, `DuckDBExplorer.svelte`, and `JulesSessionStatus.svelte`. Defensive against future `<form>` wrapping.
- Add `scope="col"` to `PipelineRunHistory` table headers.
- Add `aria-label` to the icon-only Jules refresh button and to the pipeline-status emoji links/spans (`⏳ ✅ ❌`).
- Restore visible focus on `IASearchBar` by adding `:focus-within` to the wrapper — the inner input had `outline: none` with no replacement.

### Motion / theming
- `@media (prefers-reduced-motion: reduce)` guards on the `IASearchBar` skeleton pulse and `DateDetail` spinner.
- Replace the last hardcoded `rgba(148, 163, 184, 0.2)` in `RateLimitBadge` with `color-mix(in srgb, var(--color-base-300) 40%, transparent)`.

### Tests
- Updated one Cucumber step (`admin-perf.steps.ts`) to match the renamed "Distribuição por nota" heading.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx astro check` — 0 errors, 0 warnings, 1 pre-existing hint
- [x] `npx vitest run` — 101/101 passing
- [x] `npm run build` — 113 pages built successfully

https://claude.ai/code/session_01EVsuh665CyJzA24e97km3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVsuh665CyJzA24e97km3A)_