### PR TITLE
fix(web): UX easy wins — search a11y + semantic changelog dates

### DIFF
--- a/web/src/components/IASearchBar.svelte
+++ b/web/src/components/IASearchBar.svelte
@@ -136,6 +136,7 @@
         oninput={(e) => query = (e.target as HTMLInputElement).value}
         onkeydown={handleKeyDown}
         placeholder="Buscar no Internet Archive (ex: TJSP, 2026, 2026-03)"
+        aria-label="Buscar no Internet Archive por tribunal ou ano"
       />
       {#if shortcutEnabled}
         <kbd class="kbd-tag">Ctrl</kbd>
@@ -164,7 +165,8 @@
         id="search-submit-btn"
         class="search-btn"
         onclick={handleSearch}
-        disabled={loading || !query.trim()}>
+        disabled={loading || !query.trim()}
+        aria-busy={loading}>
         {#if loading}Buscando...{:else}Buscar{/if}
       </button>
     </div>

--- a/web/src/components/PRGateExplainer.svelte
+++ b/web/src/components/PRGateExplainer.svelte
@@ -137,7 +137,7 @@
       value={prNumber}
       oninput={(e: Event & { currentTarget: HTMLInputElement }) => prNumber = e.currentTarget.value}
     />
-    <button type="submit" disabled={loading || !prNumber}>
+    <button type="submit" disabled={loading || !prNumber} aria-busy={loading}>
       {loading ? 'Verificando...' : 'Verificar PR'}
     </button>
   </form>

--- a/web/src/components/TribunalCoverageHeatmap.svelte
+++ b/web/src/components/TribunalCoverageHeatmap.svelte
@@ -54,7 +54,7 @@
     <MonthPicker bind:selectedYear bind:selectedMonth {monthSummaries} />
 
     {#if loading}
-      <div class="loading-msg">Carregando dados de cobertura...</div>
+      <div class="loading-msg" role="status" aria-live="polite" aria-busy="true">Carregando dados de cobertura...</div>
     {:else if error}
       <div class="text-error">Erro: {error}</div>
     {:else}

--- a/web/src/pages/changelog.astro
+++ b/web/src/pages/changelog.astro
@@ -17,6 +17,13 @@ const entries = [
     items: ['Painel admin de performance estabilizado.', 'Melhorias de cache para dados de backfill.'],
   },
 ];
+
+const dateFormatter = new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
 ---
 
 <Layout title="Changelog — CausaGanha" description="Atualizações de produto e status do projeto CausaGanha.">
@@ -29,7 +36,11 @@ const entries = [
       {entries.map((entry) => (
         <article class="card">
           <div class="card-body">
-            <small class="entry-date">{entry.date}</small>
+            <small class="entry-date">
+              <time datetime={entry.date}>
+                {dateFormatter.format(new Date(entry.date + 'T00:00:00Z'))}
+              </time>
+            </small>
             <h2 class="card-heading">{entry.title}</h2>
             <ul class="entry-list">
               {entry.items.map((item) => <li>{item}</li>)}


### PR DESCRIPTION
## Summary

Small, low-risk UX wins found by scanning the frontend. Each change is independent and targeted.

### a11y on the IA search bar (user-facing, /publicacoes)
- `IASearchBar`: the search input had no `aria-label` (the `<label>` is just a wrapper with an icon and `<kbd>` hints, no text). Screen readers were announcing it as a blank search field. Added a descriptive `aria-label`.
- `IASearchBar`: added `aria-busy={loading}` to the submit button so SR users hear the busy state while results load.

### a11y on admin loading states
- `PRGateExplainer`: added `aria-busy={loading}` to the "Verificar PR" submit button.
- `TribunalCoverageHeatmap`: the "Carregando dados de cobertura..." message was a plain `<div>` — added `role="status"` + `aria-live="polite"` so it's announced.

### Semantic changelog dates (user-facing, /changelog)
- Dates were raw ISO strings ("2026-04-06"). Now wrapped in `<time datetime="…">` and rendered in pt-BR ("06 de abril de 2026"), matching the project's pt-BR locale used everywhere else.

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npx eslint .` — clean
- [x] `npx vitest run` — 101/101 pass
- [x] `npx astro build` — 113 pages built
- [x] Verified built `/changelog` HTML renders `<time datetime="2026-04-06">06 de abril de 2026</time>`

https://claude.ai/code/session_01RTemcPg6TS96jUAdGhGLBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTemcPg6TS96jUAdGhGLBe)_