### PR TITLE
fix(web): easy UX wins — pt-BR strings, dropdown a11y, dead code

### DIFF
--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -47,6 +47,8 @@ const recursosLinks = [
   { href: BASE + 'dicionario', label: 'Entender esquema' },
   { href: BASE + 'changelog', label: 'Changelog' },
 ];
+
+const ferramentasActive = [...ferramentasLinks, ...recursosLinks].some(l => isActive(l.href));
 ---
 
 {variant === 'home' ? (
@@ -64,8 +66,8 @@ const recursosLinks = [
           </li>
         ))}
         <li>
-          <details>
-            <summary aria-haspopup="true">Ferramentas</summary>
+          <details class="nav-dropdown">
+            <summary aria-haspopup="true" class={ferramentasActive ? 'active' : ''}>Ferramentas</summary>
             <ul class="dropdown-menu">
               {ferramentasLinks.map(link => (
                 <li>
@@ -176,8 +178,8 @@ const recursosLinks = [
             </li>
           ))}
           <li>
-            <details>
-              <summary aria-haspopup="true">Ferramentas</summary>
+            <details class="nav-dropdown">
+              <summary aria-haspopup="true" class={ferramentasActive ? 'active' : ''}>Ferramentas</summary>
               <ul class="dropdown-menu">
                 {ferramentasLinks.map(link => (
                   <li>
@@ -255,6 +257,28 @@ const recursosLinks = [
     </div>
   </header>
 )}
+
+<script>
+  // Close any open <details class="nav-dropdown"> on outside click or Escape.
+  // Listeners are attached to document once and survive astro:after-swap.
+  if (!(window as any).__navDropdownBound) {
+    (window as any).__navDropdownBound = true;
+    document.addEventListener('click', (e) => {
+      const target = e.target as Element | null;
+      const inside = target?.closest('details.nav-dropdown');
+      document.querySelectorAll<HTMLDetailsElement>('details.nav-dropdown[open]').forEach(d => {
+        if (d !== inside) d.open = false;
+      });
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+      const open = document.querySelector<HTMLDetailsElement>('details.nav-dropdown[open]');
+      if (!open) return;
+      open.open = false;
+      open.querySelector<HTMLElement>('summary')?.focus();
+    });
+  }
+</script>
 
 <style>
   /* Navbar */

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -391,7 +391,8 @@ const ferramentasActive = [...ferramentasLinks, ...recursosLinks].some(l => isAc
     background: var(--color-base-200);
   }
 
-  .menu a.active {
+  .menu a.active,
+  .menu summary.active {
     background: var(--color-base-200);
     font-weight: 600;
   }

--- a/web/src/components/SystemStatus.svelte
+++ b/web/src/components/SystemStatus.svelte
@@ -83,21 +83,21 @@
         <div class="status-text">
           <div class="status-title">
             {#if stats}
-              {isSuccess ? 'Pipeline Operational' : 'Pipeline Issue'}
+              {isSuccess ? 'Pipeline operacional' : 'Falha no pipeline'}
             {:else}
-              Loading...
+              Carregando...
             {/if}
           </div>
           {#if stats?.timestamp}
             <small class="status-timestamp">
-              Last run: {new Date(stats.timestamp).toLocaleString('pt-BR')}
+              Última execução: {new Date(stats.timestamp).toLocaleString('pt-BR')}
             </small>
           {/if}
           <span class="status-subtitle">
             {#if stats}
-              {isSuccess ? 'System operational' : 'System fault detected'}
+              {isSuccess ? 'Sistema operacional' : 'Falha detectada no sistema'}
             {:else}
-              Loading system status
+              Carregando status do sistema
             {/if}
           </span>
         </div>
@@ -121,10 +121,10 @@
         {/if}
         {#if filesToday != null}
           <div class="stat-pill">
-            <span>{isDataStale ? dataDate : 'Today'}:</span>
+            <span>{isDataStale ? dataDate : 'Hoje'}:</span>
             <span class={isDataStale ? 'text-warning' : ''}>{filesToday}/91</span>
             {#if isDataStale}
-              <span class="text-warning" title="Data collection appears stalled — no new data since this date">stale</span>
+              <span class="text-warning" title="Coleta parece parada — sem novos dados desde esta data">desatualizado</span>
             {/if}
           </div>
         {/if}
@@ -143,7 +143,7 @@
     <div class="status-right">
       {#if stats?.timestamp}
         <div class="countdown-block">
-          <small class="countdown-label">Next run</small>
+          <small class="countdown-label">Próxima execução</small>
           <div class="countdown-value">{countdown}</div>
         </div>
       {/if}
@@ -153,7 +153,7 @@
           class="toggle-btn"
           onclick={() => showDetails = !showDetails}
           aria-expanded={showDetails}
-          aria-label="Toggle run details">
+          aria-label="Alternar detalhes da execução">
           {#if showDetails}
             <svg class="toggle-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m18 15-6-6-6 6"/>
@@ -172,7 +172,7 @@
   {#if stats?.steps && showDetails}
     <div class="details-section">
       <div class="details-inner">
-        <h3 class="details-heading">Pipeline Steps</h3>
+        <h3 class="details-heading">Etapas do pipeline</h3>
         <div class="steps-list">
           {#each Object.entries(stats.steps) as [stepName, stepData]}
             {@const isOk = (stepData.success !== 0 && stepData.failed === 0) || stepData.success === true}
@@ -191,7 +191,7 @@
                       <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
                     </svg>
                   {/if}
-                  <span>{isOk ? 'OK' : 'Issue'}</span>
+                  <span>{isOk ? 'OK' : 'Falha'}</span>
                 </span>
               </div>
               <div class="step-details">

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -20,7 +20,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         </p>
         <div class="action-buttons">
           <a href={BASE + 'publicacoes'} class="btn btn-primary">Buscar publicações</a>
-          <a href={BASE} class="btn btn-secondary">Início</a>
+          <a href={BASE} class="btn btn-outline-secondary">Início</a>
         </div>
       </div>
     </div>
@@ -67,26 +67,6 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     display: flex;
     gap: 1rem;
     justify-content: center;
-  }
-
-  .btn-secondary {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-    border-radius: var(--radius-btn);
-    cursor: pointer;
-    transition: all var(--transition-base);
-    background: transparent;
-    border: 1px solid var(--color-secondary);
-    color: var(--color-secondary);
-    text-decoration: none;
-  }
-
-  .btn-secondary:hover {
-    background: var(--color-secondary);
-    color: var(--color-secondary-content);
+    flex-wrap: wrap;
   }
 </style>

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -2,7 +2,6 @@
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
-import DatabaseIcon from '../components/icons/DatabaseIcon.astro';
 import DuckDBExplorer from '../components/DuckDBExplorer.svelte';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');


### PR DESCRIPTION
## Summary

Quick UX polish pass on the web frontend. Four small, independent fixes — no architectural changes, no new dependencies.

- **`SystemStatus.svelte`**: translate the remaining hardcoded English labels (`Pipeline Operational`, `Loading...`, `Last run`, `Next run`, `Today`, `stale`, `Pipeline Steps`, `OK`/`Issue`, `Toggle run details`) to pt-BR — this card was the most visible English-language leak on the site.
- **`Header.astro`**: the native `<details>` nav dropdown didn't close on outside click or Escape, which is unexpected for menu UX. Added a one-time-bound document listener for both, and tagged the "Ferramentas" `<summary>` with `active` when one of its children matches the current path (the parent label used to stay unstyled while inner pages were active).
- **`404.astro`**: dropped the local `.btn-secondary` override that duplicated the global `.btn-outline-secondary` class — the markup now uses the canonical class. Added `flex-wrap` so the two CTAs stack cleanly on narrow screens.
- **`explorador.astro`**: removed the unused `DatabaseIcon` import (the only TypeScript hint in `astro check`).

## Test plan

- [x] `npx astro check` → 0 errors, 0 warnings, 0 hints (was 1 hint before)
- [x] `npx vitest run` → 101/101 passing
- [x] `npm run lint` → clean
- [ ] Manual: confirm nav dropdown closes on click outside and on Escape
- [ ] Manual: visit `/advogados` or `/comparador` and confirm the "Ferramentas" parent label is highlighted
- [ ] Manual: visit `/404` and confirm the secondary "Início" button matches the rest of the site's outline-secondary styling

https://claude.ai/code/session_01NXkQJVA8DkDPzB1xeyFwxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXkQJVA8DkDPzB1xeyFwxt)_