### PR TITLE
fix(drain): respect deadline when queue.join() blocks on in-flight items

### DIFF
--- a/src/djen_backup/drain.py
+++ b/src/djen_backup/drain.py
@@ -206,9 +206,11 @@ async def drain(
                 for entry in fresh:
                     seen.add(entry)
                     await queue.put(entry)
-                # Wait for this batch to be processed before fetching the next.
-                # Bounded by deadline check via worker shutdown.
-                await queue.join()
+                remaining = max(0.0, deadline - time.monotonic())
+                try:
+                    await asyncio.wait_for(queue.join(), timeout=remaining)
+                except TimeoutError:
+                    break
         finally:
             for _ in range(workers):
                 await queue.put(None)

--- a/tests/djen_backup/test_drain.py
+++ b/tests/djen_backup/test_drain.py
@@ -1,12 +1,14 @@
 """Tests for the batched-drain mode (``djen_backup.drain``).
 
-Covers ``DeltaWriter`` (append-only CSV) and ``_drain_one`` (single-pair
+Covers ``DeltaWriter`` (append-only CSV), ``_drain_one`` (single-pair
 flow: already-on-IA short-circuit, happy path, DJEN 404 skip, transport
-error skip, ``ItemBusyError`` retry loop).
+error skip, ``ItemBusyError`` retry loop), and ``drain`` deadline behaviour.
 """
 
 from __future__ import annotations
 
+import asyncio
+import time
 from datetime import date
 from typing import TYPE_CHECKING
 
@@ -16,7 +18,7 @@ import pytest
 from djen_backup import drain as drain_module
 from djen_backup.archive import CircuitBreaker, ItemBusyError
 from djen_backup.djen import DJENNotFoundError
-from djen_backup.drain import DeltaWriter, _drain_one
+from djen_backup.drain import DeltaWriter, _drain_one, drain
 
 
 if TYPE_CHECKING:
@@ -52,12 +54,8 @@ async def test_drain_one_skips_when_already_on_ia(
     monkeypatch.setattr(
         drain_module, "get_caderno_url", _async_raise(AssertionError("must not call"))
     )
-    monkeypatch.setattr(
-        drain_module, "download_zip", _async_raise(AssertionError("must not call"))
-    )
-    monkeypatch.setattr(
-        drain_module, "upload_zip", _async_raise(AssertionError("must not call"))
-    )
+    monkeypatch.setattr(drain_module, "download_zip", _async_raise(AssertionError("must not call")))
+    monkeypatch.setattr(drain_module, "upload_zip", _async_raise(AssertionError("must not call")))
 
     writer = DeltaWriter(tmp_path / "delta.csv")
     await _drain_one(
@@ -74,9 +72,7 @@ async def test_drain_one_skips_when_already_on_ia(
 
 
 @pytest.mark.asyncio
-async def test_drain_one_happy_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_drain_one_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     raw_zip = tmp_path / "raw.zip"
     raw_zip.write_bytes(b"PK\x03\x04")
 
@@ -185,6 +181,54 @@ async def test_drain_one_retries_busy_then_succeeds(
     assert writer.count == 1
 
 
+# ── drain deadline ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drain_respects_deadline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """drain() must finish within ~deadline_seconds even when workers are slow."""
+
+    async def _slow_download(*_a: object, **_kw: object) -> object:
+        await asyncio.sleep(60)  # simulates a hung download
+        return None  # unreachable in practice
+
+    monkeypatch.setattr(drain_module, "check_ia_file_exists", _ia_miss)
+    monkeypatch.setattr(drain_module, "get_caderno_url", _async_return("https://x/z"))
+    monkeypatch.setattr(drain_module, "download_zip", _slow_download)
+    monkeypatch.setattr(drain_module, "upload_zip", _ia_hit)
+    monkeypatch.setattr(drain_module, "upload_delta", _async_return_false)
+
+    # Patch fetch_pending_batch to return two fake entries
+    def _fake_batch(*_a: object, **_kw: object) -> list[tuple[str, date]]:
+        return [("TJSP", date(2024, 1, 1)), ("TJBA", date(2024, 1, 2))]
+
+    monkeypatch.setattr(drain_module, "fetch_pending_batch", _fake_batch)
+
+    # Patch duckdb.connect so we don't need real DuckDB httpfs
+    import duckdb
+
+    class _FakeDuck:
+        def execute(self, *_a: object) -> _FakeDuck:
+            return self
+
+    monkeypatch.setattr(duckdb, "connect", _FakeDuck)
+
+    deadline_seconds = 0.5
+    t0 = time.monotonic()
+    await drain(
+        workers=2,
+        batch_size=10,
+        deadline_seconds=deadline_seconds,
+        djen_proxy_url="https://djen.example",
+        ia_auth="key:secret",
+    )
+    elapsed = time.monotonic() - t0
+
+    # Should finish well before a hypothetical 18-minute GHA timeout;
+    # give 5x margin to account for CI jitter, but definitely not 60 s.
+    assert elapsed < deadline_seconds * 5 + 2, f"drain took {elapsed:.1f}s — deadline not respected"
+
+
 # ── helpers ──────────────────────────────────────────────────────────
 
 
@@ -197,6 +241,10 @@ async def _ia_hit(*_args: object, **_kwargs: object) -> bool:
 
 
 async def _ia_miss(*_args: object, **_kwargs: object) -> bool:
+    return False
+
+
+async def _async_return_false(*_args: object, **_kwargs: object) -> bool:
     return False
 
 


### PR DESCRIPTION
## Problema

O comando `djen-backup drain --deadline-minutes 14` não parava dentro do prazo, fazendo as runs do `upload-backlog` baterem consistentemente no timeout de 18 minutos do GitHub Actions (status `cancelled`).

**Root cause:** `drain.py:211` — `await queue.join()` sem timeout.

O produtor enfileira um batch e chama `queue.join()`, que bloqueia até **todos os workers finalizarem o item atual**. Os workers só checam o deadline *entre* itens — não durante uma operação em andamento. Se um worker estava no meio de um upload/download lento (timeout HTTP de até 120 s), ele continuava até terminar, mesmo com o deadline já passado. O produtor ficava preso esperando, empurrando o processo de 14 para 16–18 minutos.

## Fix

```python
# Antes (drain.py:211):
await queue.join()

# Depois:
remaining = max(0.0, deadline - time.monotonic())
try:
    await asyncio.wait_for(queue.join(), timeout=remaining)
except TimeoutError:
    break
```

Quando o deadline passa durante um `queue.join()`, o `TimeoutError` é capturado, o produtor sai do loop, o `finally` manda sentinels `None` para os workers. Eles terminam o item em voo atual e param. O overrun passa a ser apenas o tempo do item já em processamento quando o deadline bateu — segundos, não minutos.

## Teste

Adicionado `test_drain_respects_deadline`: injeta um download fake de 60 segundos e garante que o `drain()` retorna dentro de `5 * deadline_seconds + 2 s`, mesmo com workers bloqueados.

## Impacto esperado

Runs do `upload-backlog` (a cada 15 min) devem completar em ~14 min ao invés de serem canceladas no timeout de 18 min, aumentando a quantidade de uploads por hora e acelerando o backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)