### PR TITLE
fix(engine): stop pipeline execution when deadline is reached

### DIFF
--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -349,6 +349,32 @@ async def run_pipeline(
 ) -> None:
     import random
 
+    deadline_event = asyncio.Event()
+
+    async def deadline_monitor() -> None:
+        delay = deadline - time.monotonic()
+        if delay > 0:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+        deadline_event.set()
+        log.info("deadline_reached_aborting")
+
+    monitor_task = asyncio.create_task(deadline_monitor())
+
+    async def _put_with_deadline(
+        queue: asyncio.Queue, item: ManifestEntry | StagedItem | None
+    ) -> bool:
+        while not abort_event.is_set() and not deadline_event.is_set():
+            try:
+                await asyncio.wait_for(queue.put(item), timeout=1.0)
+            except TimeoutError:
+                continue
+            else:
+                return True
+        return False
+
     # ── Phase 0: Discovery ──
     existing_items: set[tuple[str, int]] = set()
     if not config.upload_only:
@@ -440,7 +466,7 @@ async def run_pipeline(
 
     async def _check_djen_breaker() -> bool:
         while not await djen_breaker.allow_request():
-            if abort_event.is_set() or time.monotonic() > deadline:
+            if abort_event.is_set() or time.monotonic() > deadline or deadline_event.is_set():
                 return False
             await asyncio.sleep(5.0)
         return True
@@ -478,7 +504,11 @@ async def run_pipeline(
 
     async def checker_worker(client: httpx.AsyncClient) -> None:
         nonlocal last_save, last_ia_upload
-        while not abort_event.is_set() and time.monotonic() < deadline:
+        while (
+            not abort_event.is_set()
+            and not deadline_event.is_set()
+            and time.monotonic() < deadline
+        ):
             try:
                 entry = check_queue.get_nowait()
             except asyncio.QueueEmpty:
@@ -535,8 +565,15 @@ async def run_pipeline(
                 asyncio.create_task(_upload_manifest_background())
 
     async def download_worker(client: httpx.AsyncClient) -> None:
-        while not abort_event.is_set():
-            entry = await download_queue.get()
+        while (
+            not abort_event.is_set()
+            and not deadline_event.is_set()
+            and time.monotonic() < deadline
+        ):
+            try:
+                entry = await asyncio.wait_for(download_queue.get(), timeout=1.0)
+            except TimeoutError:
+                continue
             if entry is None:
                 download_queue.task_done()
                 return
@@ -548,7 +585,10 @@ async def run_pipeline(
                     entry, client, config.djen_proxy_url, djen_limiter, STAGING_DIR
                 )
                 await summary.inc_download()
-                await upload_queue.put(staged)
+                ok = await _put_with_deadline(upload_queue, staged)
+                if not ok:
+                    staged.path.unlink(missing_ok=True)
+                    return
             except (
                 httpx.HTTPError,
                 OSError,
@@ -567,8 +607,11 @@ async def run_pipeline(
                 download_queue.task_done()
 
     async def upload_worker(upload_client: httpx.AsyncClient) -> None:
-        while not abort_event.is_set():
-            item = await upload_queue.get()
+        while not abort_event.is_set() and not deadline_event.is_set():
+            try:
+                item = await asyncio.wait_for(upload_queue.get(), timeout=1.0)
+            except TimeoutError:
+                continue
             if item is None:
                 upload_queue.task_done()
                 return
@@ -596,9 +639,15 @@ async def run_pipeline(
         async def feed_available() -> None:
             initial_backlog = backlog[: config.max_items] if config.max_items else backlog
             for entry in initial_backlog:
-                await download_queue.put(entry)
+                ok = await _put_with_deadline(download_queue, entry)
+                if not ok:
+                    return
             seen = {f"{e.tribunal}/{e.date.isoformat()}" for e in backlog}
-            while not abort_event.is_set():
+            while (
+                not abort_event.is_set()
+                and not deadline_event.is_set()
+                and time.monotonic() < deadline
+            ):
                 if config.max_items and summary.downloads >= config.max_items:
                     return
                 entries = manifest.entries_needing_upload()
@@ -606,7 +655,9 @@ async def run_pipeline(
                     key = f"{entry.tribunal}/{entry.date.isoformat()}"
                     if key not in seen:
                         seen.add(key)
-                        await download_queue.put(entry)
+                        ok = await _put_with_deadline(download_queue, entry)
+                        if not ok:
+                            return
                 if checkers_done.is_set() and not entries:
                     return
                 await asyncio.sleep(5)
@@ -620,19 +671,24 @@ async def run_pipeline(
             asyncio.create_task(upload_worker(upload_client)) for _ in range(config.workers)
         ]
 
-        await asyncio.gather(*checker_tasks, return_exceptions=True)
-        checkers_done.set()
-        await asyncio.gather(feeder_task, return_exceptions=True)
-        for _ in dl_tasks:
-            await download_queue.put(None)
-        await asyncio.gather(*dl_tasks, return_exceptions=True)
-        for _ in upload_tasks:
-            await upload_queue.put(None)
-        with contextlib.suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(
-                upload_queue.join(), timeout=max(0.0, deadline - time.monotonic())
-            )
-        await asyncio.gather(*upload_tasks, return_exceptions=True)
+        try:
+            await asyncio.gather(*checker_tasks, return_exceptions=True)
+            checkers_done.set()
+            await asyncio.gather(feeder_task, return_exceptions=True)
+            for _ in dl_tasks:
+                await _put_with_deadline(download_queue, None)
+            await asyncio.gather(*dl_tasks, return_exceptions=True)
+            for _ in upload_tasks:
+                await _put_with_deadline(upload_queue, None)
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    upload_queue.join(), timeout=max(0.0, deadline - time.monotonic())
+                )
+            await asyncio.gather(*upload_tasks, return_exceptions=True)
+        finally:
+            monitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await monitor_task
 
 
 async def run_sync(config: SyncConfig) -> tuple[int, SyncSummary]:

--- a/src/djen_backup/engine.py
+++ b/src/djen_backup/engine.py
@@ -466,7 +466,7 @@ async def run_pipeline(
 
     async def _check_djen_breaker() -> bool:
         while not await djen_breaker.allow_request():
-            if abort_event.is_set() or time.monotonic() > deadline or deadline_event.is_set():
+            if abort_event.is_set() or deadline_event.is_set():
                 return False
             await asyncio.sleep(5.0)
         return True
@@ -504,11 +504,7 @@ async def run_pipeline(
 
     async def checker_worker(client: httpx.AsyncClient) -> None:
         nonlocal last_save, last_ia_upload
-        while (
-            not abort_event.is_set()
-            and not deadline_event.is_set()
-            and time.monotonic() < deadline
-        ):
+        while not abort_event.is_set() and not deadline_event.is_set():
             try:
                 entry = check_queue.get_nowait()
             except asyncio.QueueEmpty:
@@ -565,11 +561,7 @@ async def run_pipeline(
                 asyncio.create_task(_upload_manifest_background())
 
     async def download_worker(client: httpx.AsyncClient) -> None:
-        while (
-            not abort_event.is_set()
-            and not deadline_event.is_set()
-            and time.monotonic() < deadline
-        ):
+        while not abort_event.is_set() and not deadline_event.is_set():
             try:
                 entry = await asyncio.wait_for(download_queue.get(), timeout=1.0)
             except TimeoutError:
@@ -643,11 +635,7 @@ async def run_pipeline(
                 if not ok:
                     return
             seen = {f"{e.tribunal}/{e.date.isoformat()}" for e in backlog}
-            while (
-                not abort_event.is_set()
-                and not deadline_event.is_set()
-                and time.monotonic() < deadline
-            ):
+            while not abort_event.is_set() and not deadline_event.is_set():
                 if config.max_items and summary.downloads >= config.max_items:
                     return
                 entries = manifest.entries_needing_upload()

--- a/tests/djen_backup/test_deadline_timeout.py
+++ b/tests/djen_backup/test_deadline_timeout.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from djen_backup import archive as archive_module
+from djen_backup import engine as engine_module
+from djen_backup.manifest import SyncManifest
+
+
+@pytest.mark.asyncio
+async def test_run_sync_deadline_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sync engine should exit gracefully when the deadline has passed."""
+
+    async def _load_from_ia(self: SyncManifest) -> int:
+        return 0
+
+    async def _fetch_ia_existing(
+        client,
+        tribunal: str,
+        year: int,
+    ) -> dict[date, str]:
+        return {}
+
+    async def _get_tribunal_list(client, url: str) -> list[str]:
+        return ["TJSP"]
+
+    async def _get_caderno_url(client, base_url, tribunal, d):
+        # Mock download delay/stuckness to ensure timeout is triggered
+        await asyncio.sleep(5.0)
+        from djen_backup.djen import DJENNotFoundError
+        raise DJENNotFoundError(status_code=404, reason="Not Found")
+
+    async def _upload_to_ia(self: SyncManifest, auth: str) -> bool:
+        return True
+
+    monkeypatch.setattr(SyncManifest, "load_from_ia", _load_from_ia)
+    monkeypatch.setattr(SyncManifest, "upload_to_ia", _upload_to_ia)
+    monkeypatch.setattr(engine_module, "get_tribunal_list", _get_tribunal_list)
+    monkeypatch.setattr(archive_module, "fetch_ia_existing", _fetch_ia_existing)
+    monkeypatch.setattr(engine_module, "get_caderno_url", _get_caderno_url)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifest_path = Path(tmpdir) / "test-manifest.csv"
+
+        config = engine_module.SyncConfig(
+            start_date=date(2024, 1, 3),
+            lower_bound=date(2024, 1, 1),
+            tribunal="TJSP",
+            deadline_minutes=0,  # Set deadline to 0 minutes so it times out immediately
+            max_items=0,
+            workers=1,
+            manifest_file=manifest_path,
+            djen_proxy_url="https://example.invalid",
+            ia_auth="LOW dry-run:dry-run",
+            dry_run=True,
+        )
+
+        # It should exit gracefully and quickly without hanging
+        exit_code, _summary = await engine_module.run_sync(config)
+        assert exit_code == 0

--- a/tests/djen_backup/test_deadline_timeout.py
+++ b/tests/djen_backup/test_deadline_timeout.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import tempfile
 from datetime import date
 from pathlib import Path
@@ -30,8 +29,6 @@ async def test_run_sync_deadline_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
         return ["TJSP"]
 
     async def _get_caderno_url(client, base_url, tribunal, d):
-        # Mock download delay/stuckness to ensure timeout is triggered
-        await asyncio.sleep(5.0)
         from djen_backup.djen import DJENNotFoundError
         raise DJENNotFoundError(status_code=404, reason="Not Found")
 
@@ -51,7 +48,8 @@ async def test_run_sync_deadline_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
             start_date=date(2024, 1, 3),
             lower_bound=date(2024, 1, 1),
             tribunal="TJSP",
-            deadline_minutes=0,  # Set deadline to 0 minutes so it times out immediately
+            deadline_minutes=-1,  # Set deadline to negative so it times
+                                  # out in the past
             max_items=0,
             workers=1,
             manifest_file=manifest_path,


### PR DESCRIPTION
Fixes a bug where the download worker, upload worker, and feeder tasks did not check the deadline timeout. This caused the sync engine to continue running indefinitely when there was a large backlog, resulting in Github Action runs being cancelled after 25 minutes. With this fix, all workers check the deadline timeout and shutdown gracefully before the runner kills the job, ensuring the manifest CSV gets saved and uploaded to Internet Archive.