### PR TITLE
chore: update .gitignore to exclude local log and script files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ data_*.json
 ia_data.json
 run_stats.json
 logs/
+job_log.txt
+log.txt
+scripts/save_tjro_parquets.py


### PR DESCRIPTION
Updates .gitignore to exclude local job_log.txt, log.txt, and scripts/save_tjro_parquets.py.