### PR TITLE
fix(notebooks): make marimo-exported .ipynb runnable in Colab

### DIFF
--- a/notebooks/train_decision_segmenter.ipynb
+++ b/notebooks/train_decision_segmenter.ipynb
@@ -3,16 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Hbol",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import marimo as mo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "MJUe",
    "metadata": {},
    "outputs": [],

--- a/notebooks/train_ml_document_classifier.ipynb
+++ b/notebooks/train_ml_document_classifier.ipynb
@@ -3,16 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Hbol",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import marimo as mo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "MJUe",
    "metadata": {},
    "outputs": [],

--- a/scripts/check_notebooks_synced.py
+++ b/scripts/check_notebooks_synced.py
@@ -2,9 +2,9 @@
 """CI check: every marimo notebook has an up-to-date exported .ipynb.
 
 Notebooks in ``notebooks/`` are authored as marimo notebooks (``*.py``), and
-the committed ``*.ipynb`` is the artifact produced by::
-
-    marimo export ipynb <notebook>.py --sort top-down -o <notebook>.ipynb
+the committed ``*.ipynb`` is produced by ``marimo export ipynb`` followed by a
+small post-processing step (see ``export_ipynb``) that drops the standalone
+``import marimo as mo`` cell so the notebook runs in Colab.
 
 This check re-runs that export for every marimo notebook and fails if the
 committed ``.ipynb`` is missing or differs from a fresh export — i.e. the
@@ -23,6 +23,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import nbformat
+
 
 NOTEBOOK_DIR = Path(__file__).resolve().parent.parent / "notebooks"
 # Match how the committed .ipynb files are produced. Keep in sync with the
@@ -37,22 +39,45 @@ def is_marimo_notebook(path: Path) -> bool:
 
 
 def export_ipynb(notebook: Path, out: Path) -> None:
-    """Run ``marimo export ipynb`` for ``notebook`` into ``out``."""
-    subprocess.run(  # noqa: S603
-        [
-            "marimo",
-            "export",
-            "ipynb",
-            str(notebook),
-            "--sort",
-            EXPORT_SORT,
-            "-o",
-            str(out),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    """Export ``notebook`` to a Colab-runnable Jupyter notebook at ``out``.
+
+    Runs ``marimo export ipynb`` and then strips the standalone
+    ``import marimo as mo`` cell that marimo emits: ``mo.md(...)`` cells are
+    already exported as real markdown cells, so that import is dead code in
+    the .ipynb and would raise ``ModuleNotFoundError`` in Colab (where marimo
+    isn't installed). Both the check and the --fix paths go through here, so
+    the committed .ipynb stays byte-identical to this output.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
+        raw = Path(tmp.name)
+    try:
+        subprocess.run(  # noqa: S603
+            [
+                "marimo",
+                "export",
+                "ipynb",
+                str(notebook),
+                "--sort",
+                EXPORT_SORT,
+                "-o",
+                str(raw),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        nb = nbformat.read(raw, as_version=nbformat.NO_CONVERT)
+        nb.cells = [
+            c
+            for c in nb.cells
+            if not (
+                c.get("cell_type") == "code"
+                and c.get("source", "").strip() == "import marimo as mo"
+            )
+        ]
+        nbformat.write(nb, str(out))
+    finally:
+        raw.unlink(missing_ok=True)
 
 
 def main() -> int:


### PR DESCRIPTION
## Problem

Running the exported training notebooks in Google Colab fails immediately:

```
ModuleNotFoundError: No module named 'marimo'
```

The notebooks are authored in marimo (`notebooks/*.py`) and exported to `.ipynb`. marimo correctly exports `mo.md(...)` cells as **real markdown cells**, but it also leaves a standalone `import marimo as mo` **code cell** in the exported `.ipynb`. Colab doesn't have marimo installed, so that cell raises `ModuleNotFoundError` — even though nothing else in the exported notebook uses `mo`.

## Fix

`scripts/check_notebooks_synced.py`'s `export_ipynb` now runs `marimo export ipynb` and then **strips the lone `import marimo as mo` cell** before writing the `.ipynb`. Both the check and the `--fix` paths go through this function, so the committed `.ipynb` stays byte-identical to the generated output (the sync-check invariant holds).

All committed notebooks were regenerated. Verified that **no executable `import marimo` / `mo.` remains in any code cell** of the three `.ipynb` (only a harmless `# packages added via marimo's package management` comment in the setup cell remains).

## Files
- `scripts/check_notebooks_synced.py` — strip the marimo import cell on export (uses `nbformat`).
- `notebooks/train_decision_segmenter.ipynb`, `notebooks/train_ml_document_classifier.ipynb` — regenerated (cost_estimate was already clean).

## Verification
- `uv run python scripts/check_notebooks_synced.py` → all 3 in sync
- `ruff check`/`ruff format --check` on the script → clean
- No code cell contains `import marimo` in any of the three notebooks

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_