### PR TITLE
fix(analysis): pass rotating Gemini key to litellm instead of mutating os.environ

### DIFF
--- a/src/causaganha/analysis/llm_analyzer.py
+++ b/src/causaganha/analysis/llm_analyzer.py
@@ -376,7 +376,12 @@ class LLMAnalyzer:
                 parsed = _parse_response(content)
                 analysis = _build_analysis(parsed, intimation_id or 0)
             except (ValueError, KeyError, json.JSONDecodeError) as exc:
-                logger.warning("llm_parse_error", model=model, error=str(exc), raw_content=content[:1000] if 'content' in locals() else None)
+                logger.warning(
+                    "llm_parse_error",
+                    model=model,
+                    error=str(exc),
+                    raw_content=content[:1000] if "content" in locals() else None,
+                )
                 last_exc = exc
                 continue
             except Exception as exc:
@@ -455,14 +460,14 @@ class LLMAnalyzer:
         if raw_keys:
             gemini_keys = [k.strip() for k in raw_keys.split(",") if k.strip()]
         if not gemini_keys:
-            gemini_keys = [None] # fallback to litellm default / system env
+            gemini_keys = [None]  # fallback to litellm default / system env
 
         last_exc: Exception | None = None
         for model in self.models:
             is_gemini = model.startswith("gemini/")
             # Rotate keys for Gemini models
             api_keys_to_try = gemini_keys if is_gemini else [None]
-            
+
             for api_key in api_keys_to_try:
                 try:
                     logger.debug(
@@ -471,17 +476,18 @@ class LLMAnalyzer:
                         batch_size=len(items),
                         using_key=f"{api_key[:8]}..." if api_key else "default",
                     )
-                    
-                    # Set temporary API key if rotating
-                    if api_key:
-                        os.environ["GEMINI_API_KEY"] = api_key
-                        os.environ["GOOGLE_API_KEY"] = api_key
-                        
+
+                    # Pass the rotating key directly instead of mutating the
+                    # process-wide environment: os.environ is shared across all
+                    # concurrent tasks, so writing it here races between batches
+                    # (and permanently leaks the last key). litellm resolves the
+                    # key from its env defaults when api_key is None.
                     response = await litellm.acompletion(
                         model=model,
                         messages=messages,
                         temperature=0.1,
                         max_tokens=max_output_tokens,
+                        api_key=api_key,
                     )
                     content = response.choices[0].message.content or ""
                     batch_parsed = _parse_response(content)
@@ -491,7 +497,11 @@ class LLMAnalyzer:
                     # Don't try other keys for formatting errors, go to next model/next step
                     break
                 except Exception as exc:
-                    if _is_retryable(exc) or "quota" in str(exc).lower() or "limit" in str(exc).lower():
+                    if (
+                        _is_retryable(exc)
+                        or "quota" in str(exc).lower()
+                        or "limit" in str(exc).lower()
+                    ):
                         logger.warning(
                             "llm_batch_model_unavailable_or_quota",
                             model=model,
@@ -548,14 +558,18 @@ class LLMAnalyzer:
         available: list[str] = []
         if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
             # gemini-2.0-flash retired March/2026; use 2.5 series
-            available.extend([
-                "gemini/gemini-2.5-flash-lite",  # 1 000 RPD free — most generous
-                "gemini/gemini-2.5-flash",        # 250 RPD free
-            ])
+            available.extend(
+                [
+                    "gemini/gemini-2.5-flash-lite",  # 1 000 RPD free — most generous
+                    "gemini/gemini-2.5-flash",  # 250 RPD free
+                ]
+            )
         if os.environ.get("OPENROUTER_API_KEY"):
-            available.extend([
-                "openrouter/moonshotai/kimi-k2.6:free",
-                "openrouter/google/gemma-4-31b-it:free",
-                "openrouter/meta-llama/llama-3.3-70b-instruct:free",
-            ])
+            available.extend(
+                [
+                    "openrouter/moonshotai/kimi-k2.6:free",
+                    "openrouter/google/gemma-4-31b-it:free",
+                    "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+                ]
+            )
         return available or DEFAULT_MODELS

--- a/tests/test_llm_analyzer_key_rotation.py
+++ b/tests/test_llm_analyzer_key_rotation.py
@@ -1,0 +1,70 @@
+"""Regression test for Gemini key rotation in LLMAnalyzer (Bug B).
+
+Key rotation must pass the rotating key directly to ``litellm.acompletion``
+rather than mutating ``os.environ`` — the environment is process-wide and
+shared across concurrent tasks, so writing it races between batches and
+permanently leaks the last key.
+
+litellm lives in the optional ``classify`` dependency group and isn't installed
+in the default test environment, so we inject a fake module into ``sys.modules``
+to satisfy the analyzer's lazy ``import litellm``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from causaganha.analysis.llm_analyzer import LLMAnalyzer
+
+
+def _fake_response(content: str) -> MagicMock:
+    resp = MagicMock()
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    resp.choices = [choice]
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_rotating_key_is_passed_to_litellm_not_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "SECRET_ROTATING_KEY")
+    monkeypatch.delenv("GEMINI_API_KEYS", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_response("{}"))
+
+    analyzer = LLMAnalyzer(models=["gemini/gemini-2.5-flash"])
+    with patch.dict(sys.modules, {"litellm": fake_litellm}):
+        await analyzer.analyze_batch([(1, "Julgo procedente o pedido.")])
+
+    # The key was handed to litellm directly...
+    fake_litellm.acompletion.assert_awaited_once()
+    assert fake_litellm.acompletion.await_args.kwargs["api_key"] == "SECRET_ROTATING_KEY"
+
+    # ...and NOT smuggled through the shared process environment.
+    assert "GOOGLE_API_KEY" not in os.environ
+    assert os.environ.get("GEMINI_API_KEY") == "SECRET_ROTATING_KEY"  # unchanged by rotation
+
+
+@pytest.mark.asyncio
+async def test_non_gemini_model_passes_none_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEYS", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_response("{}"))
+
+    analyzer = LLMAnalyzer(models=["openrouter/some-model"])
+    with patch.dict(sys.modules, {"litellm": fake_litellm}):
+        await analyzer.analyze_batch([(1, "Julgo improcedente.")])
+
+    fake_litellm.acompletion.assert_awaited_once()
+    # litellm resolves the key from its own env defaults when api_key is None.
+    assert fake_litellm.acompletion.await_args.kwargs["api_key"] is None


### PR DESCRIPTION
## Problem (Bug B from the #720 audit)

`LLMAnalyzer.analyze_batch` rotates Gemini API keys by mutating the process
environment before each call:

```python
if api_key:
    os.environ["GEMINI_API_KEY"] = api_key
    os.environ["GOOGLE_API_KEY"] = api_key
response = await litellm.acompletion(model=model, messages=messages, ...)
```

`os.environ` is **process-wide**. Under concurrent batches (`asyncio.gather`)
these writes race — one batch can issue its request with a key set by another —
and the last key written **leaks permanently** into the process environment
after the analyzer is done.

## Fix

Pass the rotating key directly to litellm and stop touching `os.environ`:

```python
response = await litellm.acompletion(
    model=model,
    messages=messages,
    temperature=0.1,
    max_tokens=max_output_tokens,
    api_key=api_key,
)
```

litellm resolves the key from its own env defaults when `api_key` is `None`
(non-Gemini models / no rotation), so behavior is preserved.

## Tests

`tests/test_llm_analyzer_key_rotation.py` — litellm is in the optional
`classify` dependency group (not installed in the default test env), so the
test injects a fake `litellm` module via `sys.modules`:
- rotating Gemini key reaches litellm through the `api_key` kwarg, and
  `os.environ` is **not** mutated (`GOOGLE_API_KEY` never appears)
- non-Gemini model passes `api_key=None`

Verified: `pytest tests/test_llm_analyzer_key_rotation.py` → 2 passed; `ruff check --select S,BLE001,B904,TRY300` + `ruff format --check` clean.

> Note: stacked conceptually alongside #724 (the other #720-audit bug, RAG outcome normalization), but this branch is cut from `main` and only touches `llm_analyzer.py` — independent and mergeable on its own.

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_