### PR TITLE
docs(scripts): Purpose/Problem/Strategy/Status headers — manifest batch

### DIFF
--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Append new ZIP uploads to the append-only manifest.jsonl and upload to IA."""
+"""Append new ZIP uploads to the append-only manifest.jsonl and upload to IA.
+
+Purpose:  Record freshly uploaded DJEN ZIPs as entries in the append-only
+          manifest.jsonl artifact on Internet Archive.
+Problem:  Uploads happen incrementally and from multiple runs; we need a durable
+          log of what landed without rewriting (and risking clobbering) the whole
+          manifest on every upload.
+Strategy: Append new rows as JSONL lines and push to IA. Append-only keeps writes
+          cheap and concurrency-safe (no read-modify-write of the full file).
+Status:   production — invoked by the collect/backfill workflows.
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows

--- a/scripts/backfill_probe.py
+++ b/scripts/backfill_probe.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Backfill probe — diagnose inconsistencies between sync-manifest and DJEN proxy.
 
-Pulls the canonical manifest from IA, samples entries by category
-(absent / unknown / available / 403 / timeout), re-probes the DJEN proxy live,
-and prints a side-by-side comparison so we can spot rows where the manifest
-disagrees with reality.
-
-Designed to run inside the ``backfill-probe`` GitHub Actions workflow. The job
-intentionally exits non-zero at the end so the run is flagged as failed and
-the operator gets the report attached to a visible failure.
+Purpose:  Spot rows where the manifest's recorded status disagrees with what the
+          DJEN proxy returns right now.
+Problem:  Manifest categories (absent/unknown/403/timeout) can be stale or wrong
+          (e.g. 403 rate-limits mislabeled as absent); we need a live audit.
+Strategy: Pull the canonical manifest from IA, sample entries per category, re-probe
+          the DJEN proxy live, and print a side-by-side comparison. Sampling keeps
+          the probe cheap while still surfacing systemic drift.
+Status:   production diagnostic — runs in the backfill-probe workflow, which
+          intentionally exits non-zero so the report is attached to a visible
+          failed run for the operator.
 """
 
 from __future__ import annotations

--- a/scripts/drain_unknowns.py
+++ b/scripts/drain_unknowns.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
-"""One-shot backfill — drain djen_raw="" rows by hitting the DJEN proxy live.
+"""Drain djen_raw="" (unknown) rows by hitting the DJEN proxy live.
 
-Bypasses ``collect-zips``' Phase 0 IA discovery and engine plumbing (which is
-currently breaching GHA's timeout, see PR #677) to push the unknown bucket
-forward. Pulls the canonical manifest from IA, classifies every unknown row
-in parallel against the DJEN proxy, then merges and uploads the result back
-to IA in one shot.
-
-Designed to be safe to re-run: it only writes ``djen_raw`` for rows where
-``djen_raw`` is currently empty, and ``upload_to_ia`` re-downloads-and-merges
-to avoid clobbering concurrent updates.
+Purpose:  Push the "unknown" bucket of the manifest forward by classifying rows
+          that have no recorded DJEN raw code yet.
+Problem:  The full collect-zips path (Phase 0 IA discovery + engine plumbing) was
+          breaching the GitHub Actions timeout (see PR #677), so unknowns piled up
+          and never got a real status.
+Strategy: Pull the canonical manifest from IA, classify every unknown row in
+          parallel directly against the DJEN proxy, then merge and upload once.
+          Safe to re-run: only writes djen_raw where it is currently empty, and
+          upload re-downloads-and-merges to avoid clobbering concurrent updates.
+Status:   ops workaround — runs via the drain-unknowns workflow while the engine
+          timeout is unresolved. RFC: fold back into the engine once #677 is fixed,
+          or keep as a deliberate lightweight side-channel? Comments welcome.
 """
 
 from __future__ import annotations

--- a/scripts/generate_cache_from_manifest.py
+++ b/scripts/generate_cache_from_manifest.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """Generate webapp cache JSONs from the sync-manifest.
 
-Reads `manifest-summary.json` from IA (produced by djen-backup engine)
-and generates the legacy cache files that the webapp still expects:
-- cache/backfill.json
-- cache/today.json
-- cache/meta.json
-- cache/calendar.json
-- cache/runs.json (empty, replaced by GitHub API calls at runtime)
-- ia-snapshot.json
+Purpose:  Produce the cache/*.json files the dashboard still reads from a single
+          manifest summary.
+Problem:  The webapp predates the .qmd query-contract pipeline and still expects a
+          fixed set of pre-baked cache JSONs (backfill/today/meta/calendar/...).
+Strategy: Read manifest-summary.json from IA (written by the djen-backup engine)
+          and emit those files (cache/backfill.json, today.json, meta.json,
+          calendar.json, runs.json [empty — runtime GitHub API], ia-snapshot.json),
+          optionally uploading with --upload.
+Status:   legacy / transitional — kept during the migration to the .qmd query
+          contracts (scripts/render_queries.py). RFC: which of these JSONs are
+          still consumed by the live frontend, and can this be retired once the
+          dashboard reads only rendered query outputs? Comments welcome before we
+          DRY/remove it.
 
 Usage:
     uv run python scripts/generate_cache_from_manifest.py

--- a/scripts/reconcile_manifest.py
+++ b/scripts/reconcile_manifest.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
-"""One-shot manifest reconciliation.
+"""One-shot manifest reconciliation against ground truth.
 
-Three corrections applied to the canonical sync-manifest.csv:
-
-1. **IA truth**: query metadata for every djen-{tribunal}-{year} item,
-   mark those dates as ia_status='uploaded'.
-2. **Reset legacy absents**: entries with djen_status='absent' but
-   djen_raw='' (absent marked before we tracked raw codes). Re-check
-   next run will re-classify them with a real raw code.
-3. **Upload reconciled manifest** back to IA.
+Purpose:  Correct drift in the canonical sync-manifest.csv against what actually
+          exists on Internet Archive, then re-upload it.
+Problem:  The manifest can diverge from reality: items uploaded out-of-band aren't
+          marked, and legacy rows were flagged absent before we recorded the raw
+          DJEN code, so "absent" can no longer be trusted for them.
+Strategy: Three corrections — (1) query IA metadata for every djen-{tribunal}-{year}
+          item and mark those dates ia_status='uploaded'; (2) reset legacy absents
+          (djen_status='absent' with empty djen_raw) so the next run re-classifies
+          them with a real code; (3) upload the reconciled manifest back to IA.
+          Trusting IA + raw codes over stale categories matches the "never trust
+          absent from old runs" rule.
+Status:   one-shot ops utility (manual run; requires IAS3_ACCESS_KEY/SECRET).
 
 Usage::
 
     uv run --env-file ~/workspace/.env python scripts/reconcile_manifest.py
-
-Requires IAS3_ACCESS_KEY + IAS3_SECRET_KEY for upload.
 """
 
 from __future__ import annotations

--- a/scripts/render_manifest_parquet.py
+++ b/scripts/render_manifest_parquet.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 """Render sync-manifest.csv → sync-manifest.parquet and upload to IA.
 
-The Parquet artifact is a read-optimized companion to the canonical CSV.
-Engine writes still go through the CSV (cheap appends); workflows and
-dashboards that only need to QUERY the manifest can fetch this Parquet
-via DuckDB httpfs and pull only the row groups they care about.
-
-Delta CSVs written by the upload-backlog drain (upload-deltas/*.csv on IA)
-are merged in before rendering so the parquet reflects confirmed uploads
-even before the full sync-manifest.csv is updated.
-
-Typical size reduction: 8MB CSV → ~1MB Parquet (columnar + dictionary
-encoding on the high-cardinality `tribunal` column).
+Purpose:  Produce a read-optimized Parquet companion to the canonical manifest CSV.
+Problem:  The CSV is great for cheap engine appends but expensive to query remotely
+          (8MB, full download). Workflows/dashboards only need to read subsets.
+Strategy: Merge the upload-backlog delta CSVs (upload-deltas/*.csv on IA) so the
+          snapshot reflects confirmed uploads even before the full CSV updates,
+          then render to Parquet (columnar + dictionary encoding on the
+          high-cardinality `tribunal` column → ~8MB CSV becomes ~1MB) so readers
+          can fetch only the row groups they need via DuckDB httpfs. Writes still
+          flow through the CSV — this is a derived read replica.
+Status:   production — runs every 30 min via render-manifest-parquet.yml.
 """
 
 from __future__ import annotations

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Validate the newly generated manifest.jsonl before uploading."""
+"""Validate the newly generated manifest.jsonl before uploading.
+
+Purpose:  Sanity-check a freshly generated manifest.jsonl before it is pushed to IA.
+Problem:  A malformed or truncated manifest uploaded to IA would corrupt the single
+          source of truth that the dashboard and downstream jobs read.
+Strategy: Parse every line as JSON and assert the expected schema/row invariants,
+          failing loudly (non-zero exit) before any upload happens — cheap guard
+          rail in the publish path.
+Status:   production — gate step in the manifest publish workflow.
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows


### PR DESCRIPTION
First batch of the scripts-clarification effort (per the approved `Purpose / Problem / Strategy / Status` template, delivered per-category).

Documents the **manifest** category — why each script exists, the problem it solves, why its strategy supposedly makes sense, and its status. Docstring-only, no behavior change.

| Script | Status |
|---|---|
| `append_manifest.py` | production |
| `validate_manifest.py` | production (publish gate) |
| `reconcile_manifest.py` | one-shot ops utility |
| `render_manifest_parquet.py` | production (every 30 min) |
| `drain_unknowns.py` | **WIP/RFC** — ops workaround for the engine GHA timeout (#677) |
| `generate_cache_from_manifest.py` | **legacy/RFC** — transitional cache during the `.qmd` query-contract migration |
| `backfill_probe.py` | production diagnostic |

The two RFC-flagged scripts ask explicit questions in their headers (fold `drain_unknowns` back into the engine once #677 is fixed? which `generate_cache` JSONs are still consumed by the live frontend?).

Verified: `py_compile` OK, `ruff check --select S,BLE001,B904,TRY300` clean.

Next batches (separate PRs): embedding/ML, validation/health, catalog/web, monitoring, one-off.

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_