### PR TITLE
Harden data source indicator rendering

### DIFF
--- a/web/features/data-source-indicator.feature
+++ b/web/features/data-source-indicator.feature
@@ -1,0 +1,8 @@
+Feature: Data source indicator
+  The data source indicator renders live archive status safely.
+
+  Scenario: Escape HTML characters from generated_at payload
+    Given the Internet Archive metadata has generated_at with HTML characters
+    When the data source indicator probes the metadata
+    Then the generated_at HTML should be displayed as text
+    And the live pulse should be rendered as a span

--- a/web/src/components/DataSourceIndicator.astro
+++ b/web/src/components/DataSourceIndicator.astro
@@ -16,12 +16,20 @@
         const res = await fetch(IA_URL);
         if (res.ok) {
           const data = await res.json();
-          indicator!.innerHTML = `<span class="cg-pulse"></span> Live via Internet Archive (${data.generated_at?.slice(0, 16)})`;
+          const generatedAt = String(data.generated_at ?? '').slice(0, 16);
+          const pulse = document.createElement('span');
+          pulse.className = 'cg-pulse';
+
+          indicator.replaceChildren(
+            pulse,
+            document.createTextNode(` Live via Internet Archive (${generatedAt})`),
+          );
         } else {
-          indicator!.innerHTML = `Static fallback (IA HTTP ${res.status})`;
+          indicator.textContent = `Static fallback (IA HTTP ${res.status})`;
         }
-      } catch (err: any) {
-        indicator!.innerHTML = `Offline: ${err.message || String(err)}`;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        indicator.textContent = `Offline: ${message}`;
       }
     }
 

--- a/web/src/components/__steps__/data-source-indicator.steps.ts
+++ b/web/src/components/__steps__/data-source-indicator.steps.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+
+const feature = await loadFeature('features/data-source-indicator.feature');
+
+describeFeature(feature, ({ Scenario }) => {
+  let generatedAt = '';
+  let indicator: HTMLElement;
+
+  async function flushPromises() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function renderIndicator() {
+    document.body.innerHTML = '<small id="datasource-indicator" class="datasource" role="status">Connecting...</small>';
+    indicator = document.getElementById('datasource-indicator')!;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ generated_at: generatedAt }),
+      }),
+    );
+
+    const component = readFileSync('src/components/DataSourceIndicator.astro', 'utf8');
+    const script = component.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+    if (!script) {
+      throw new Error('DataSourceIndicator script not found');
+    }
+
+    const executableScript = script.replace(/indicator!/g, 'indicator');
+    Function(executableScript)();
+    await flushPromises();
+  }
+
+  Scenario('Escape HTML characters from generated_at payload', ({ Given, When, Then, And }) => {
+    Given('the Internet Archive metadata has generated_at with HTML characters', () => {
+      generatedAt = '<em>2026-05-30Z</em>';
+    });
+
+    When('the data source indicator probes the metadata', async () => {
+      await renderIndicator();
+    });
+
+    Then('the generated_at HTML should be displayed as text', () => {
+      expect(indicator.textContent).toContain('Live via Internet Archive (<em>2026-05-30Z<)');
+      expect(indicator.querySelector('em')).toBeNull();
+    });
+
+    And('the live pulse should be rendered as a span', () => {
+      const pulse = indicator.querySelector('span.cg-pulse');
+      expect(pulse).toBeInstanceOf(HTMLSpanElement);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The data source indicator used `innerHTML` to interpolate remote values (e.g., `generated_at`), which risks parsing HTML-like payloads from a remote source and may allow unsafe rendering.
- The display should treat remote metadata as plain text while preserving the visual `.cg-pulse` element.

### Description
- Replaced `innerHTML` success case with a safe DOM build: `const pulse = document.createElement('span'); pulse.className = 'cg-pulse'; indicator.replaceChildren(pulse, document.createTextNode(...))` and converted `data.generated_at` via `String(data.generated_at ?? '').slice(0, 16)` before display in `web/src/components/DataSourceIndicator.astro`.
- Replaced fallback/offline `innerHTML` uses with `indicator.textContent = ...` to ensure plain-text rendering.
- Narrowed error handling by extracting a safe message via `err instanceof Error ? err.message : String(err)` before showing it in the UI.
- Added BDD coverage: `web/features/data-source-indicator.feature` and `web/src/components/__steps__/data-source-indicator.steps.ts` to verify that `generated_at` containing HTML characters is rendered as text and that the live pulse is a real `span`.

### Testing
- Ran the targeted spec with `npm test -- data-source-indicator.steps.ts`, which passed (4 tests, 0 failures).
- Linted the new step file with `npx eslint src/components/__steps__/data-source-indicator.steps.ts`, which passed.
- Ran the full test suite with `npm test`; unrelated existing tests failed (`admin-pr-gate.steps.ts` and `publicacoes.steps.ts`) and are outside the scope of this change.
- `npm run typecheck` could not complete in CI here because the environment uses Node.js `v20.20.2` while `astro` requires `>=22.12.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2cd9f4e08325ac1657e27758bdb6)