### PR TITLE
Guard theme localStorage access

### DIFF
--- a/web/src/components/ThemeToggle.astro
+++ b/web/src/components/ThemeToggle.astro
@@ -35,7 +35,11 @@
       btn.addEventListener('click', () => {
         const next = !isDark();
         document.documentElement.setAttribute('data-theme', next ? 'dark' : 'light');
-        localStorage.setItem('causaganha-theme', next ? 'dark' : 'light');
+        try {
+          localStorage.setItem('causaganha-theme', next ? 'dark' : 'light');
+        } catch {
+          // Ignore storage errors so the theme toggle still works in restricted contexts.
+        }
         // Sync labels on all instances after any toggle
         document.querySelectorAll<HTMLButtonElement>('.theme-toggle-btn').forEach(b => {
           b.setAttribute('aria-label', next ? 'Mudar para modo claro' : 'Mudar para modo escuro');

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -59,7 +59,14 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       // our custom --color-base-* tokens live in [data-theme="dark"], not in
       // a @media block, so they would not activate under data-theme="auto".
       (function () {
-        const saved = localStorage.getItem('causaganha-theme');
+        let saved = null;
+
+        try {
+          saved = localStorage.getItem('causaganha-theme');
+        } catch {
+          saved = null;
+        }
+
         const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
         const isDark = saved ? saved === 'dark' : prefersDark;
         document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');


### PR DESCRIPTION
### Motivation
- Prevent runtime errors in environments that block or throw on `localStorage` access so the initial theme application does not fail.
- Keep the existing system-preference fallback via `matchMedia` so users without a saved preference still get the correct theme.

### Description
- Wrap the inline read of `localStorage.getItem('causaganha-theme')` in a `try/catch` and use `null` as the fallback in `web/src/layouts/Layout.astro`.
- Preserve the `window.matchMedia('(prefers-color-scheme: dark)')` fallback behavior when no saved theme is available.
- Wrap the write `localStorage.setItem('causaganha-theme', ...)` in a `try/catch` in `web/src/components/ThemeToggle.astro` so toggling still updates the UI when persistence fails.

### Testing
- Ran `npm run lint` in `web` and it passed.
- Ran `git diff --check` and no whitespace or diff-check issues were reported.
- Attempted `npm run typecheck` but it could not complete in the current environment because Node.js `v20.20.2` is installed while Astro requires Node.js `>=22.12.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2cdef9388325a0afcc32c3e9da52)