### PR TITLE
Extract bindDrawerBackdropClicks and prevent duplicate nav-drawer listeners

### DIFF
--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -204,6 +204,17 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
 )}
 
 <script>
+  function bindDrawerBackdropClicks() {
+    document.querySelectorAll<HTMLDialogElement>('dialog.nav-drawer').forEach(dialog => {
+      if (dialog.dataset.backdropBound === 'true') return;
+
+      dialog.dataset.backdropBound = 'true';
+      dialog.addEventListener('click', (e) => {
+        if (e.target === dialog) dialog.close();
+      });
+    });
+  }
+
   function setupNavHandlers() {
     // Close details[role="list"] dropdowns on outside click
     document.addEventListener('click', (e) => {
@@ -221,14 +232,9 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
       open.open = false;
       open.querySelector<HTMLElement>('summary')?.focus();
     });
-
-    // Close nav-drawer dialog on backdrop click
-    document.querySelectorAll<HTMLDialogElement>('dialog.nav-drawer').forEach(dialog => {
-      dialog.addEventListener('click', (e) => {
-        if (e.target === dialog) dialog.close();
-      });
-    });
   }
+
+  bindDrawerBackdropClicks();
 
   if (!(window as any).__navHandlersBound) {
     (window as any).__navHandlersBound = true;
@@ -237,10 +243,6 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
 
   // Re-bind dialog backdrop clicks after Astro view transitions
   document.addEventListener('astro:page-load', () => {
-    document.querySelectorAll<HTMLDialogElement>('dialog.nav-drawer').forEach(dialog => {
-      dialog.addEventListener('click', (e) => {
-        if (e.target === dialog) dialog.close();
-      });
-    });
+    bindDrawerBackdropClicks();
   });
 </script>


### PR DESCRIPTION
### Motivation
- Prevent duplicate backdrop `click` listeners from being attached to mobile nav drawers when Astro view transitions re-render elements.
- Ensure newly rendered `dialog.nav-drawer` elements receive a single backdrop handler that closes the dialog on outside clicks.

### Description
- Extracted backdrop binding into `bindDrawerBackdropClicks()` which iterates `dialog.nav-drawer` elements and skips ones already marked with a sentinel attribute. 
- Uses a `data-backdrop-bound="true"` sentinel set on a dialog before attaching the `click` listener that closes the dialog when the event target equals the dialog. 
- Calls `bindDrawerBackdropClicks()` during initial setup and on `astro:page-load` so replaced drawers are re-bound without duplicating listeners. 
- Kept global `click` and `keydown` document listeners inside `setupNavHandlers()` and still protected by `window.__navHandlersBound`; modified file: `web/src/components/Header.astro`.

### Testing
- Ran `git diff --check` which reported no issues. 
- Ran `npm run lint -- src/components/Header.astro`, which completed but reported the file is ignored by the current ESLint config. 
- Ran `npm run typecheck`, which could not complete in this environment because Astro requires Node.js `>=22.12.0` and the runtime uses an older Node.js version, so type checking is blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2ce341408325bfac9424a94644e4)