### PR TITLE
Add per-attempt timeout to fetchWithRetry

### DIFF
--- a/web/src/lib/fetchData.test.ts
+++ b/web/src/lib/fetchData.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithRetry } from './fetchData';
+
+describe('fetchWithRetry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('starts a new browser retry after a request times out', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+        }, { once: true });
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = fetchWithRetry('https://example.test/data.json', {}, 2, 100);
+    request.catch(() => {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(request).rejects.toMatchObject({ name: 'TimeoutError' });
+  });
+});

--- a/web/src/lib/fetchData.ts
+++ b/web/src/lib/fetchData.ts
@@ -77,6 +77,7 @@ export async function fetchWithRetry(
   url: string,
   options: RequestInit = {},
   maxRetries: number = 5,
+  timeoutMs: number = 15000,
 ): Promise<Response | FallbackResponse> {
   let lastError: unknown;
   const isBrowser = typeof window !== 'undefined';
@@ -102,8 +103,46 @@ export async function fetchWithRetry(
   }
 
   for (let i = 0; i < maxRetries; i++) {
+    const attemptController = new AbortController();
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let cleanupCombinedSignal = (): void => {};
+    let fetchOptions = options;
+    let retryDelay: number | undefined;
+
     try {
-      const response = await fetch(url, options);
+      timeoutTimer = setTimeout(() => {
+        attemptController.abort(new DOMException(`Fetch timed out after ${timeoutMs}ms`, 'TimeoutError'));
+      }, timeoutMs);
+
+      if (options.signal) {
+        const combinedController = new AbortController();
+        const abortCombined = (signal: AbortSignal): void => {
+          if (!combinedController.signal.aborted) {
+            combinedController.abort(signal.reason);
+          }
+        };
+        const abortFromOptions = (): void => abortCombined(options.signal as AbortSignal);
+        const abortFromTimeout = (): void => abortCombined(attemptController.signal);
+
+        options.signal.addEventListener('abort', abortFromOptions, { once: true });
+        attemptController.signal.addEventListener('abort', abortFromTimeout, { once: true });
+        cleanupCombinedSignal = (): void => {
+          options.signal?.removeEventListener('abort', abortFromOptions);
+          attemptController.signal.removeEventListener('abort', abortFromTimeout);
+        };
+
+        if (options.signal.aborted) {
+          abortCombined(options.signal);
+        } else if (attemptController.signal.aborted) {
+          abortCombined(attemptController.signal);
+        }
+
+        fetchOptions = { ...options, signal: combinedController.signal };
+      } else {
+        fetchOptions = { ...options, signal: attemptController.signal };
+      }
+
+      const response = await fetch(url, fetchOptions);
       if (!response.ok && response.status >= 500) {
         throw new Error(`HTTP Error: ${response.status}`);
       }
@@ -115,14 +154,20 @@ export async function fetchWithRetry(
     } catch (error) {
       lastError = error;
       if (i < maxRetries - 1) {
-        const delay = Math.min(1000 * Math.pow(3, i), 30000);
+        retryDelay = Math.min(1000 * Math.pow(3, i), 30000);
         if (isBrowser) {
           window.dispatchEvent(new CustomEvent('cg-network-retry', {
-            detail: { attempt: i + 1, maxRetries, delay }
+            detail: { attempt: i + 1, maxRetries, delay: retryDelay }
           }));
         }
-        await new Promise(r => setTimeout(r, delay));
       }
+    } finally {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      cleanupCombinedSignal();
+    }
+
+    if (retryDelay !== undefined) {
+      await new Promise(r => setTimeout(r, retryDelay));
     }
   }
 


### PR DESCRIPTION
### Motivation
- Browser `fetchWithRetry` could hang indefinitely when a request never resolves, blocking retries. 
- Introduce a per-attempt timeout so stalled fetches abort and the helper can continue its existing retry behavior. 

### Description
- Added a `timeoutMs` parameter to `fetchWithRetry` (default `15000`) in `web/src/lib/fetchData.ts`. 
- For each browser attempt the code now creates an `AbortController`, combines it with a caller-provided `options.signal` when present, passes the combined `signal` to `fetch`, and forwards abort reasons. 
- Timers and event listeners are cleaned up in a `finally` block to avoid leaks, and existing events `cg-network-slow`, `cg-network-retry`, `cg-network-success`, and `cg-network-error` are preserved. 
- Added a Vitest unit test `web/src/lib/fetchData.test.ts` that simulates a never-resolving request and verifies a new attempt is started after the per-attempt timeout. 

### Testing
- Ran the unit test with `npm test -- fetchData.test.ts`, and the test file passed (1 test passed). 
- Ran lint with `npm run lint -- src/lib/fetchData.ts src/lib/fetchData.test.ts`, which completed successfully. 
- Ran `npm run typecheck`, which was blocked/failed in this environment due to Node.js `v20.20.2` while Astro requires `>=22.12.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2ce6c9f4832591fd4758d7a1877f)