### PR TITLE
Reset publication search pagination on criteria changes

### DIFF
--- a/web/features/publicacoes-search.feature
+++ b/web/features/publicacoes-search.feature
@@ -35,3 +35,8 @@ Feature: Live DJEN publication search
   Scenario: Input is auto-focused on load
     When the publication search loads with no URL params
     Then the search input should be focused
+
+  Scenario: Search criteria changes reset pagination
+    Given the DJEN API returns 30 publications out of 60 for each request
+    When I search for "contrato", go to page 2, and replace the search with "mandado de segurança"
+    Then the last DJEN query should request page 1 for "mandado de segurança"

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -48,6 +48,18 @@
 
   const smart = $derived(smartParseInput(rawInput));
   const effectiveQuery = $derived<DjenComunicacaoQuery>({ ...filters, ...smart.patch });
+  const criteriaFilters = $derived({
+    siglaTribunal: filters.siglaTribunal,
+    numeroOab: filters.numeroOab,
+    ufOab: filters.ufOab,
+    nomeAdvogado: filters.nomeAdvogado,
+    nomeParte: filters.nomeParte,
+    numeroProcesso: filters.numeroProcesso,
+    dataDisponibilizacaoInicio: filters.dataDisponibilizacaoInicio,
+    dataDisponibilizacaoFim: filters.dataDisponibilizacaoFim,
+    meio: filters.meio,
+    itensPorPagina: filters.itensPorPagina,
+  });
 
   const identityKeys = [
     'siglaTribunal',
@@ -167,9 +179,19 @@
     return () => stopCooldownTick();
   });
 
-  function submitSearch() {
+  function submitSearch({
+    page,
+    resetPage = false,
+  }: { page?: number; resetPage?: boolean } = {}) {
     if (cooldownRemaining > 0 || !hasIdentity) return;
-    submittedQuery = { ...effectiveQuery };
+    const nextPage = page ?? (resetPage ? 1 : (effectiveQuery.pagina ?? 1));
+    const nextQuery = { ...effectiveQuery, pagina: nextPage };
+
+    if (resetPage && filters.pagina !== nextPage) {
+      filters = { ...filters, pagina: nextPage };
+    }
+
+    submittedQuery = nextQuery;
     expandedSeq = null;
   }
 
@@ -178,22 +200,22 @@
       clearTimeout(debounceId);
       debounceId = null;
     }
-    submitSearch();
+    submitSearch({ resetPage: true });
   }
 
   function handlePageChange(delta: number) {
     const current = filters.pagina ?? 1;
     const next = Math.max(1, current + delta);
     filters = { ...filters, pagina: next };
-    submittedQuery = { ...effectiveQuery, pagina: next };
+    submitSearch({ page: next });
   }
 
-  // Debounced reactive trigger
+  // Debounced reactive trigger for criteria changes. Pagination changes are handled separately.
   $effect(() => {
     const _input = rawInput;
-    const _filters = filters;
+    const _criteriaFilters = criteriaFilters;
     void _input;
-    void _filters;
+    void _criteriaFilters;
 
     if (debounceId) clearTimeout(debounceId);
     debounceId = setTimeout(() => {
@@ -205,7 +227,7 @@
           pagina: undefined,
         });
         if (trimmed.length >= 3 || hasFilterValues) {
-          submitSearch();
+          submitSearch({ resetPage: true });
         }
       });
     }, 400);

--- a/web/src/components/__steps__/publicacoes-search.steps.ts
+++ b/web/src/components/__steps__/publicacoes-search.steps.ts
@@ -37,6 +37,17 @@ function mockFetchOnce(body: unknown, init: { status?: number; headers?: Record<
   return fetchMock;
 }
 
+function fetchCallUrl(call: unknown[]): URL {
+  const [input] = call;
+  if (input instanceof Request) return new URL(input.url);
+  return new URL(String(input));
+}
+
+function latestFetchUrl(fetchMock: ReturnType<typeof vi.fn>): URL {
+  const calls = fetchMock.mock.calls;
+  return fetchCallUrl(calls[calls.length - 1] as unknown[]);
+}
+
 async function typeAndSubmit(input: HTMLInputElement, value: string) {
   await fireEvent.input(input, { target: { value } });
   await fireEvent.keyDown(input, { key: 'Enter' });
@@ -146,6 +157,47 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
     Then('I should see a rate-limit banner with a countdown', async () => {
       await waitFor(() => {
         expect(screen.getByText(/Limite de requisições atingido/i)).toBeTruthy();
+      });
+    });
+  });
+
+  Scenario('Search criteria changes reset pagination', ({ Given, When, Then }) => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    Given('the DJEN API returns 30 publications out of 60 for each request', () => {
+      fetchMock = mockFetchOnce(
+        { items: Array.from({ length: 30 }, (_, i) => samplePublication(i + 1)), count: 60 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+    });
+
+    When(
+      'I search for "contrato", go to page 2, and replace the search with "mandado de segurança"',
+      async () => {
+        render(PublicationSearch);
+        const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
+
+        await typeAndSubmit(input, 'contrato');
+        await waitFor(() => {
+          expect(fetchMock).toHaveBeenCalled();
+          expect(screen.getByText(/Página 1 de 2/)).toBeTruthy();
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Próxima/ }));
+        await waitFor(() => {
+          expect(latestFetchUrl(fetchMock).searchParams.get('pagina')).toBe('2');
+          expect(screen.getByText(/Página 2 de 2/)).toBeTruthy();
+        });
+
+        await typeAndSubmit(input, 'mandado de segurança');
+      },
+    );
+
+    Then('the last DJEN query should request page 1 for "mandado de segurança"', async () => {
+      await waitFor(() => {
+        const lastUrl = latestFetchUrl(fetchMock);
+        expect(lastUrl.searchParams.get('texto')).toBe('mandado de segurança');
+        expect(lastUrl.searchParams.get('pagina')).toBe('1');
       });
     });
   });


### PR DESCRIPTION
### Motivation
- Avoid submitting new search criteria with a stale `pagina` when the user changes the query or identity filters while on a later page. 
- Ensure page navigation (`handlePageChange(delta)`) continues to move between pages without being treated as a criteria change. 
- Preserve `itensPorPagina` when resetting pagination so per-page selection is not lost. 

### Description
- UI: split criteria dependencies from pagination by adding a `criteriaFilters` derived value in `web/src/components/PublicationSearch.svelte`. 
- Submission API: change `submitSearch` to accept `{ page?: number; resetPage?: boolean }` so callers can request a specific page or force a reset to page `1`. 
- Behavior: `handleSubmit` and debounced criteria changes now call `submitSearch({ resetPage: true })` to force `pagina: 1`, while `handlePageChange(delta)` still navigates pages via `submitSearch({ page: next })`. 
- Tests: add a BDD scenario and helper functions in `web/src/components/__steps__/publicacoes-search.steps.ts` and update the feature file to assert that changing the search term after going to page 2 issues a DJEN request with `pagina=1`. 

### Testing
- Ran the focused test file with `npm test -- --run src/components/__steps__/publicacoes-search.steps.ts`, which completed successfully (`Test Files 1 passed`, `Tests 23 passed`). 
- Ran `npm run lint` which completed without errors. 
- Attempted `npm run typecheck`, but it could not complete in the environment because Astro requires Node.js `>=22.12.0` while the container uses Node.js `v20.20.2` (typecheck not blocking this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2cee38d88325b5eb60362fc068d2)