### PR TITLE
docs(scripts): Purpose/Problem/Strategy/Status headers — embedding/ML batch

### DIFF
--- a/scripts/analyze_with_rag.py
+++ b/scripts/analyze_with_rag.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Analyze decisions using RAG k-NN classification (83.3% accuracy, $0.09/5794)."""
+"""Analyze decisions using RAG k-NN classification (83.3% accuracy, $0.09/5794).
+
+Purpose:  Classify decision outcomes by retrieving nearest labelled neighbours
+          (RAG / k-NN) from an embedding index.
+Problem:  Pure-LLM classification is costly; nearest-neighbour over a labelled index
+          reaches competitive accuracy at a fraction of the cost.
+Strategy: Chunk + embed each decision, query the LanceDB ground-truth index (built
+          by index_ground_truth), and vote over retrieved neighbours.
+Status:   experiment/analysis — the headline-best approach in the R&D track, but not
+          wired into production. RFC: promote this to the canonical classifier?
+"""
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib

--- a/scripts/batch_embed_decisions.py
+++ b/scripts/batch_embed_decisions.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Process decisions using Google Batch API for embeddings (50% cost reduction)."""
+"""Process decisions using Google Batch API for embeddings (50% cost reduction).
+
+Purpose:  Embed many decisions cheaply via Google's asynchronous Batch API.
+Problem:  Synchronous embedding calls are expensive at corpus scale; we want the
+          ~50% batch discount for bulk backfills.
+Strategy: Chunk decision text with an instruction prefix, submit as a Batch job,
+          and persist the vectors (consumed by classify_from_batch_embeddings).
+Status:   research / experiment — part of the embeddings R&D track (experiments/),
+          not wired into a production workflow. RFC: is the Batch path still the
+          chosen embedding strategy vs the JINA continuous pipeline? Promote out of
+          scripts/ if yes; archive if no.
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows

--- a/scripts/build_gold_benchmark.py
+++ b/scripts/build_gold_benchmark.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Build gold-standard ground truth benchmark using LLM validation."""
+"""Build gold-standard ground truth benchmark using LLM validation.
+
+Purpose:  Construct the gold benchmark dataset used to evaluate all classifiers.
+Problem:  Without trusted labels we can't measure classifier quality, and manual
+          labelling at scale is infeasible.
+Strategy: Sample decisions, take keyword-heuristic priors, then validate/label with
+          the LLM in batches (~20x throughput vs single calls), with a deterministic
+          mock fallback for offline runs.
+Status:   research/data-build — produces the benchmark consumed by
+          evaluate_heuristics and daily_benchmark_update.
+"""
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib

--- a/scripts/classify_documents.py
+++ b/scripts/classify_documents.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Run DocumentClassifier on the consolidated parquet texts and display statistics."""
+"""Run DocumentClassifier on the consolidated parquet texts and display statistics.
+
+Purpose:  Apply the heuristic DocumentClassifier over the corpus and report the
+          distribution of document types / procedural stages.
+Problem:  We need to know how well rule-based classification covers the corpus and
+          to emit labels that feed the ML training step.
+Strategy: Read textos/comunicacoes parquet, classify each, print stats, and write
+          classificacoes_documentos.parquet (consumed by train_ml_document_classifier).
+Status:   research/analysis step in the classification R&D track. RFC: keep as a
+          manual analysis tool, or fold into a reproducible pipeline?
+"""
 
 import argparse
 import sys

--- a/scripts/classify_from_batch_embeddings.py
+++ b/scripts/classify_from_batch_embeddings.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+"""Classify decisions using pre-computed batch embeddings + k-NN (zero added cost).
+
+Purpose:  Predict outcomes by k-NN over embeddings already produced by the Batch
+          API run — no new embedding spend.
+Problem:  Re-embedding just to classify is wasteful when batch embeddings exist.
+Strategy: Load precomputed vectors, query the LanceDB ground-truth index, and vote
+          over nearest neighbours by cosine similarity.
+Status:   research/experiment — pairs with batch_embed_decisions + index_ground_truth
+          (experiments/ track). RFC: overlaps with analyze_with_rag — which is the
+          keeper?
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
@@ -13,8 +24,6 @@ for stream in (sys.stdout, sys.stderr):
 
 LOW_CONFIDENCE_THRESHOLD = 0.60
 HIGH_CONFIDENCE_THRESHOLD = 0.80
-
-"""Classify decisions using pre-computed batch embeddings + k-NN (zero additional cost)."""
 
 import json
 from collections import Counter

--- a/scripts/continuous_embedding_service.py
+++ b/scripts/continuous_embedding_service.py
@@ -1,15 +1,5 @@
 """Continuous embedding generation service for Cloud Run.
 
-Purpose:  Long-running worker that continuously embeds unembedded decisions.
-Problem:  The corpus needs steady embedding throughput without manual kicks; a 24/7
-          service drains the backlog over time.
-Strategy: Loop over unembedded decisions via EmbeddingPipeline (JINA v4) until
-          stopped; designed to deploy as a Cloud Run job.
-Status:   experimental long-running service — no deployment reference in-repo. RFC:
-          is the Cloud Run deployment live, and does it overlap with embedding_job's
-          'continuous' mode? Consolidate if so.
-
-
 This service runs 24/7 and continuously processes unembedded decisions.
 Designed for deployment on Google Cloud Run as a long-running job.
 

--- a/scripts/continuous_embedding_service.py
+++ b/scripts/continuous_embedding_service.py
@@ -1,5 +1,15 @@
 """Continuous embedding generation service for Cloud Run.
 
+Purpose:  Long-running worker that continuously embeds unembedded decisions.
+Problem:  The corpus needs steady embedding throughput without manual kicks; a 24/7
+          service drains the backlog over time.
+Strategy: Loop over unembedded decisions via EmbeddingPipeline (JINA v4) until
+          stopped; designed to deploy as a Cloud Run job.
+Status:   experimental long-running service — no deployment reference in-repo. RFC:
+          is the Cloud Run deployment live, and does it overlap with embedding_job's
+          'continuous' mode? Consolidate if so.
+
+
 This service runs 24/7 and continuously processes unembedded decisions.
 Designed for deployment on Google Cloud Run as a long-running job.
 

--- a/scripts/daily_benchmark_update.py
+++ b/scripts/daily_benchmark_update.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Daily incremental ground truth benchmark updater."""
+"""Daily incremental ground truth benchmark updater.
+
+Purpose:  Incrementally extend the gold benchmark with newly arrived decisions.
+Problem:  The benchmark goes stale as new decisions land; rebuilding from scratch
+          is wasteful.
+Strategy: Label only new decisions (LLM, with keyword prior + mock fallback) and
+          append to the existing benchmark built by build_gold_benchmark.
+Status:   ops/research — named 'daily' but no scheduling workflow was found. RFC:
+          should this run on a cron/GitHub Actions schedule, or stay manual?
+"""
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib

--- a/scripts/embedding_job.py
+++ b/scripts/embedding_job.py
@@ -6,9 +6,10 @@ Problem:  Embedding the corpus needs both a steady daily trickle and bulk catch-
           runs, under time/concurrency limits.
 Strategy: Two modes — 'daily' (last N days) and 'continuous' (as many as fit in a
           time budget) — with tunable concurrency.
-Status:   ops/embedding worker — standalone (no workflow reference found). RFC:
-          meant to be scheduled? Overlaps with continuous_embedding_service —
-          pick one.
+Status:   ops/embedding worker — the single canonical embedding entrypoint
+          (daily + continuous modes). The former continuous_embedding_service and
+          laptop_service variants were consolidated into this CLI. RFC: wire the
+          'daily' mode into a scheduled workflow?
 
 
 This script processes decisions that need embeddings. It can run in two modes:

--- a/scripts/embedding_job.py
+++ b/scripts/embedding_job.py
@@ -6,10 +6,9 @@ Problem:  Embedding the corpus needs both a steady daily trickle and bulk catch-
           runs, under time/concurrency limits.
 Strategy: Two modes — 'daily' (last N days) and 'continuous' (as many as fit in a
           time budget) — with tunable concurrency.
-Status:   ops/embedding worker — the single canonical embedding entrypoint
-          (daily + continuous modes). The former continuous_embedding_service and
-          laptop_service variants were consolidated into this CLI. RFC: wire the
-          'daily' mode into a scheduled workflow?
+Status:   ops/embedding worker — standalone (no workflow reference found). RFC:
+          meant to be scheduled? Overlaps with continuous_embedding_service —
+          pick one.
 
 
 This script processes decisions that need embeddings. It can run in two modes:

--- a/scripts/embedding_job.py
+++ b/scripts/embedding_job.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """Embedding generation job for high-throughput 24/7 processing or daily digest.
 
+Purpose:  Generate embeddings for decisions that don't have them yet.
+Problem:  Embedding the corpus needs both a steady daily trickle and bulk catch-up
+          runs, under time/concurrency limits.
+Strategy: Two modes — 'daily' (last N days) and 'continuous' (as many as fit in a
+          time budget) — with tunable concurrency.
+Status:   ops/embedding worker — standalone (no workflow reference found). RFC:
+          meant to be scheduled? Overlaps with continuous_embedding_service —
+          pick one.
+
+
 This script processes decisions that need embeddings. It can run in two modes:
 - 'daily': Processes decisions from the last N days (for daily digest).
 - 'continuous': Processes as many unembedded decisions as possible within a time limit.

--- a/scripts/evaluate_heuristics.py
+++ b/scripts/evaluate_heuristics.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Evaluate KeywordClassifier and ML models against the gold benchmark."""
+"""Evaluate KeywordClassifier and ML models against the gold benchmark.
+
+Purpose:  Score classifiers (keyword + ML) against the gold benchmark to compare
+          approaches.
+Problem:  The surface outcome label is posture-dependent, so naive accuracy is
+          misleading and the ~40% procedural 'unknown' mass can mask performance.
+Strategy: Run each classifier over the benchmark and report the invariant-winner
+          (A/P/draw) gate + conditional decomposition (see benchmark_metrics).
+Status:   research/eval harness — referenced by data/benchmark docs; manual run.
+"""
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib

--- a/scripts/export_daily_embeddings.py
+++ b/scripts/export_daily_embeddings.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """Export embeddings to Parquet for Internet Archive upload.
 
+Purpose:  Snapshot generated embeddings into archival Parquet for IA upload.
+Problem:  Embeddings live in the working DB; we want a portable, compressed copy
+          for archival and reuse.
+Strategy: Write compressed Parquet files optimized for archival storage.
+Status:   experimental/ops — no workflow reference found. RFC: still part of the
+          intended embeddings export path, or superseded?
+
 Creates compressed Parquet files optimized for archival storage.
 """
 

--- a/scripts/fp_centroid_filter.py
+++ b/scripts/fp_centroid_filter.py
@@ -1,5 +1,14 @@
 """Embedding-based false positive filter for silver span labels.
 
+Purpose:  Reject false-positive span labels using embedding similarity to known FPs.
+Problem:  Rule-based span labelling accrues ever-growing negative lookaheads to
+          suppress recurring false positives — brittle and unmaintainable.
+Strategy: Precompute a centroid per label from confirmed-FP context windows; reject
+          candidate spans whose context embedding is too close to that centroid.
+Status:   research/heuristic — used by prepare_privacy_filter_dataset (segmenter
+          dataset track).
+
+
 For each label a centroid is precomputed from confirmed-FP context windows.
 During dataset preparation, candidate spans are rejected when their context
 embedding has cosine similarity > threshold to the label's FP centroid.

--- a/scripts/index_ground_truth.py
+++ b/scripts/index_ground_truth.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Indexar ground truth no LanceDB com chunks prefixados."""
+"""Index ground-truth decisions into LanceDB with instruction-prefixed chunks.
+
+Purpose:  Build the LanceDB vector index of labelled decisions that the RAG/k-NN
+          classifiers retrieve from.
+Problem:  RAG classification needs a searchable embedding index of known-label
+          decisions, chunked consistently with query time.
+Strategy: Chunk each ground-truth decision with the same instruction prefix used at
+          query time, embed, and store in LanceDB.
+Status:   research/setup — prerequisite for analyze_with_rag and
+          classify_from_batch_embeddings (experiments/ track).
+"""
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib

--- a/scripts/prepare_privacy_filter_dataset.py
+++ b/scripts/prepare_privacy_filter_dataset.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 """Prepare span-extraction dataset for training a judicial decision segmenter.
 
+Purpose:  Produce a labelled token-classification dataset to train a decision
+          segmenter / privacy filter.
+Problem:  Training a segmenter needs span labels (sections, parties, PII, legal
+          refs); hand-labelling is infeasible and pure regex misses many.
+Strategy: Apply heuristic segmentation (regex + patterns, OAB-adjacency for lawyer
+          names) to label spans, emitting a format compatible with both the
+          openai/privacy-filter CLI and HuggingFace Trainer.
+Status:   research/dataset-prep — feeds notebooks/train_decision_segmenter.py. RFC:
+          which labels still need an LLM/NER pass before this is trustworthy (see
+          coverage table below)?
+
+
 Reads textos.parquet from data/test_parquets, applies heuristic segmentation to
 label each decision with structural spans, named entities, and legal references.
 

--- a/scripts/train_ml_document_classifier.py
+++ b/scripts/train_ml_document_classifier.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Train ML models to predict document types and procedural classes from embeddings."""
+"""Train ML models to predict document types and procedural classes from embeddings.
+
+Purpose:  Train doc-type and procedural-class classifiers (MLDocumentEnsemble) on
+          embedded corpus text.
+Problem:  Rule-based document classification has gaps; a learned model over
+          embeddings should generalise better.
+Strategy: Read the parquet labels produced by classify_documents, embed texts with
+          LocalEmbedder, fit the ensemble, and persist models to disk.
+Status:   research/training — depends on classify_documents output; not in any
+          production workflow. RFC: is this model consumed anywhere downstream yet?
+"""
 
 import sys
 from pathlib import Path

--- a/scripts/train_ml_from_parquets.py
+++ b/scripts/train_ml_from_parquets.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Train ML models (MLEnsemble and AnchorClassifier) using consolidated parquet data."""
+"""Train ML models (MLEnsemble and AnchorClassifier) using consolidated parquet data.
+
+Purpose:  Train the outcome classifiers (EmbeddingEnsemble + AnchorClassifier) from
+          consolidated parquet decisions.
+Problem:  Outcome prediction needs a learned model over the labelled corpus, with
+          parquet labels mapped to canonical Portuguese outcomes.
+Strategy: Load parquet, map WIN/LOSS/PARTIAL/SETTLEMENT → canonical outcomes, embed
+          with LocalEmbedder, and fit the ensemble.
+Status:   research/training in the outcome-classification R&D track. RFC: still the
+          active training entrypoint, or superseded by the RAG/heuristic path?
+"""
 
 import argparse
 import sys


### PR DESCRIPTION
Second batch of the scripts-clarification effort (`Purpose / Problem / Strategy / Status` template, per-category).

Documents the **embedding / ML / benchmark R&D track** (15 scripts). None are wired into production workflows — they form the experimentation track (several chain into each other and into `experiments/`), so most carry explicit **RFC** notes flagging consolidation questions.

| Script | Status |
|---|---|
| `batch_embed_decisions.py` | research/experiment — **RFC** (Batch vs JINA path) |
| `embedding_job.py` | ops worker, standalone — **RFC** (schedule? overlaps continuous service) |
| `export_daily_embeddings.py` | experimental/ops — **RFC** (superseded?) |
| `continuous_embedding_service.py` | experimental Cloud Run service — **RFC** (deployment live? overlap) |
| `classify_documents.py` | research/analysis — **RFC** |
| `classify_from_batch_embeddings.py` | research/experiment — **RFC** (overlap w/ RAG) |
| `train_ml_document_classifier.py` | research/training — **RFC** (consumed downstream?) |
| `train_ml_from_parquets.py` | research/training — **RFC** (still active entrypoint?) |
| `analyze_with_rag.py` | experiment — **RFC** (promote to canonical?) |
| `evaluate_heuristics.py` | research/eval harness |
| `fp_centroid_filter.py` | research/heuristic |
| `prepare_privacy_filter_dataset.py` | research/dataset-prep — **RFC** (labels needing LLM/NER) |
| `index_ground_truth.py` | research/setup |
| `build_gold_benchmark.py` | research/data-build |
| `daily_benchmark_update.py` | ops/research — **RFC** (cron vs manual) |

**The recurring RFC theme:** this track has several overlapping embedding/classification paths. The headers surface the "which is the keeper?" questions for you to answer.

Two small cleanups while here: `classify_from_batch_embeddings.py` had a stray no-op string literal mid-file instead of a module docstring (now a real docstring at top); `index_ground_truth.py`'s summary translated to English to match the rest.

Verified: `py_compile` OK on all 15; ruff error count **unchanged vs main** on these files (pre-existing body lint — PTH123/E501 etc. — left for the CI/ruff-health pass).

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_