### PR TITLE
docs(scripts): Purpose/Problem/Strategy/Status headers — validation/health batch

### DIFF
--- a/scripts/check_export_health.py
+++ b/scripts/check_export_health.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+"""Health check script for Parquet export system.
+
+Purpose:  Emit a single monitoring-friendly health signal for the Parquet export
+          system.
+Problem:  Monitors (Nagios/Prometheus) need an exit-code-driven status, not log
+          scraping, to alert on export failures or staleness.
+Strategy: Inspect recent export outcomes and map the failure rate to Nagios-style
+          exit codes (thresholds in WARNING/CRITICAL_FAILURE_RATE_PCT).
+Status:   ops/health check — built for monitoring integration; no workflow
+          reference found. RFC: is a monitor actually polling this?
+
+Exit codes:
+    0: OK - All exports successful
+    1: WARNING - Some exports failed (< 10% failure rate)
+    2: CRITICAL - Many exports failed (>= 10% failure rate) or no recent exports
+    3: UNKNOWN - Cannot determine status
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
@@ -13,18 +30,6 @@ for stream in (sys.stdout, sys.stderr):
 
 WARNING_FAILURE_RATE_PCT = 75.0
 CRITICAL_FAILURE_RATE_PCT = 90.0
-
-"""Health check script for Parquet export system.
-
-This script checks the health of the export system and returns
-appropriate exit codes for monitoring systems (Nagios, Prometheus, etc.).
-
-Exit codes:
-    0: OK - All exports successful
-    1: WARNING - Some exports failed (< 10% failure rate)
-    2: CRITICAL - Many exports failed (>= 10% failure rate) or no recent exports
-    3: UNKNOWN - Cannot determine status
-"""
 
 import sys
 from datetime import UTC, datetime, timedelta

--- a/scripts/check_ia_credentials.py
+++ b/scripts/check_ia_credentials.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """Check Internet Archive credentials for validity.
 
+Purpose:  Verify that the configured IA S3 credentials actually work.
+Problem:  Invalid IA keys cause uploads to fail late and confusingly; better to
+          fail fast with a clear signal.
+Strategy: Make a minimal IA S3 API request and exit 0 on success, 1 on invalid
+          keys (e.g. InvalidAccessKeyId).
+Status:   ops/preflight check — typically a guard before upload jobs.
+
+
 This script tests if IA_ACCESS_KEY and IA_SECRET_KEY secrets are valid
 by making a simple request to the IA S3 API. It exits with 0 on success,
 or 1 if the keys are invalid (e.g. InvalidAccessKeyId).

--- a/scripts/check_notebooks_synced.py
+++ b/scripts/check_notebooks_synced.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """CI check: every marimo notebook has an up-to-date exported .ipynb.
 
+Purpose:  Guarantee each marimo notebook's committed .ipynb export is current.
+Problem:  The committed .ipynb is generated from the marimo .py; if authors forget
+          to re-export, Colab users get a stale notebook.
+Strategy: Re-run the export (+ the mo-import-stripping post-process) for every
+          notebook and fail if the committed .ipynb is missing or differs; --fix
+          regenerates.
+Status:   production CI gate — runs in test.yml; documented in README/CONTRIBUTING.
+
+
 Notebooks in ``notebooks/`` are authored as marimo notebooks (``*.py``), and
 the committed ``*.ipynb`` is produced by ``marimo export ipynb`` followed by a
 small post-processing step (see ``export_ipynb``) that drops the standalone

--- a/scripts/validate_api_coverage.py
+++ b/scripts/validate_api_coverage.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """Script to validate PJe API coverage across different Brazilian courts.
 
+Purpose:  Determine which Brazilian courts are reachable via the PJe API.
+Problem:  Court API availability is patchy and changes over time; we need to know
+          which siglas actually respond before relying on them.
+Strategy: Attempt a minimal intimation fetch (last 7 days, 1 item) per court via
+          PJeAPIClient and report OK/failure per sigla.
+Status:   ops/diagnostic — manual run (no workflow reference). Import + call were
+          repaired to the clients.pje client in #726.
+
+
 This script attempts to fetch intimations from a list of courts to determine
 which ones are accessible via the API.
 """

--- a/scripts/validate_system_health.py
+++ b/scripts/validate_system_health.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """System Health Validation Script for CausaGanha V2.
 
+Purpose:  Smoke-check that the V2 database is reachable and structurally sound.
+Problem:  Silent DB/schema drift or missing tables lets downstream jobs fail
+          obscurely; we want one fast pre-flight signal.
+Strategy: Verify connectivity, schema presence, key-table row counts, and basic
+          referential integrity (orphaned records), reporting failures clearly.
+Status:   ops/health check — manual run (no workflow reference). RFC: wire into a
+          pre-deploy or scheduled health workflow?
+
+
 Checks:
 1. Database connectivity.
 2. Schema presence.

--- a/scripts/verify_v2_collection.py
+++ b/scripts/verify_v2_collection.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """Verify V2 Collection Pipeline.
 
+Purpose:  Exercise the V2 collection components end-to-end on a real tribunal.
+Problem:  We need a smoke test that the V2 collection path actually fetches metadata
+          and persists it, not just unit-level confidence.
+Strategy: Collect TJRO metadata via the V2 components and store it in DuckDB,
+          surfacing failures in the pipeline wiring.
+Status:   dev/smoke test — manual run (no workflow reference). RFC: still aligned
+          with the current V2 components, or stale scaffolding?
+
+
 Collects metadata from TJRO using V2 components and stores in DuckDB.
 """
 


### PR DESCRIPTION
Third batch of the scripts-clarification effort (`Purpose / Problem / Strategy / Status` template, per-category).

Documents the **validation / health** category (6 scripts).

| Script | Status |
|---|---|
| `validate_system_health.py` | ops/health check — **RFC** (schedule it?) |
| `validate_api_coverage.py` | ops/diagnostic (import repaired in #726) |
| `check_export_health.py` | ops/health check, Nagios exit codes — **RFC** (monitor polling it?) |
| `check_ia_credentials.py` | ops/preflight (guard before uploads) |
| `check_notebooks_synced.py` | **production CI gate** (test.yml) |
| `verify_v2_collection.py` | dev/smoke test — **RFC** (stale scaffolding?) |

Only `check_notebooks_synced` is wired into CI; the rest are manual ops/diagnostic checks, hence the RFC flags.

Cleanup while here: `check_export_health.py` had a stray no-op string literal mid-file instead of a module docstring (same pattern as the ML batch) — now a real top docstring that keeps the exit-code table.

Verified: `py_compile` OK on all 6; `ruff check` clean (0 errors) on these files.

Remaining batches: **catalog/web**, **monitoring**, **one-off**.

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_