### PR TITLE
docs(scripts): Purpose/Problem/Strategy/Status headers — catalog/web + export batch

### DIFF
--- a/scripts/create_sample_data.py
+++ b/scripts/create_sample_data.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Create sample data for testing Parquet export system."""
+"""Create sample data for testing the Parquet export system.
+
+Purpose:  Generate synthetic decisions so the Parquet export path can be exercised
+          without real data.
+Problem:  Testing export/upload locally shouldn't require pulling the real corpus.
+Strategy: Write small synthetic datasets in the shapes the export system expects.
+Status:   dev/test helper — manual run, not in any workflow.
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows

--- a/scripts/daily_export.py
+++ b/scripts/daily_export.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """Daily Parquet export runner for scheduled execution.
 
+Purpose:  Export yesterday's analyzed decisions to Parquet and upload them to IA.
+Problem:  Analyzed decisions accumulate daily and need scheduled publishing with
+          clear success/failure signalling.
+Strategy: Export the previous day across tribunals, upload to IA, and return
+          granular exit codes (0 ok / 1 partial / 2 none / 3 config).
+Status:   ops runner — built for cron/systemd; no GitHub Actions workflow references
+          it. RFC: scheduled anywhere, or superseded by the engine's export path?
+
 This script is designed to be called by cron or systemd timer.
 It exports yesterday's analyzed decisions to Parquet format and
 uploads them to Internet Archive.

--- a/scripts/extract_local_css.py
+++ b/scripts/extract_local_css.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Extract <style> blocks from all .astro/.svelte files and move them to index.css.
 
+Purpose:  Consolidate inline <style> blocks from components into a single index.css.
+Problem:  Styles scattered across .astro/.svelte files are hard to audit and dedupe.
+Strategy: Scan all .astro/.svelte files, extract their <style> blocks, and move them
+          into index.css (--dry-run to preview).
+Status:   dev/one-off refactor tool — manual run, not in any workflow.
+
 Usage: python scripts/extract_local_css.py [--dry-run]
 """
 from __future__ import annotations

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python3
+"""Generate the CausaGanha catalog artifacts for Internet Archive.
+
+Purpose:  Build the catalog/index artifacts (manifest, backfill-needed, SQL views,
+          DuckDB file, progress JSON) that describe everything archived on IA.
+Problem:  Consumers need a single queryable index of what's on IA and what's still
+          missing from DJEN, without scanning IA directly.
+Strategy: Aggregate IA contents into manifest.parquet + backfill-needed.parquet,
+          emit catalog.sql/catalog.duckdb with remote views, and snapshot the
+          collect/consolidate progress.
+Status:   production — runs in update-catalog.yml.
+
+Creates:
+- manifest.parquet: Index of all files in IA
+- backfill-needed.parquet: What's missing from DJEN
+- catalog.sql: SQL with remote views
+- catalog.duckdb: Ready-to-use DuckDB file
+- collect-progress.json + .jsonl: Download progress (current + history)
+- consolidate-progress.json + .jsonl: Consolidation progress (current + history)
+
+Usage:
+    python scripts/generate_catalog.py --upload
+    python scripts/generate_catalog.py --output ./catalog/
+"""
 
 
 # Safely reconfigure standard output and standard error encoding error handling on Windows
@@ -19,21 +42,6 @@ MAX_DAY_OF_MONTH = 31
 MAX_MONTH = 12
 MAX_YEAR_CUTOFF = 2030
 MIN_YEAR_CUTOFF = 2020
-
-"""Generate CausaGanha catalog for Internet Archive.
-
-Creates:
-- manifest.parquet: Index of all files in IA
-- backfill-needed.parquet: What's missing from DJEN
-- catalog.sql: SQL with remote views
-- catalog.duckdb: Ready-to-use DuckDB file
-- collect-progress.json + .jsonl: Download progress (current + history)
-- consolidate-progress.json + .jsonl: Consolidation progress (current + history)
-
-Usage:
-    python scripts/generate_catalog.py --upload
-    python scripts/generate_catalog.py --output ./catalog/
-"""
 
 import argparse
 import asyncio

--- a/scripts/generate_homepage_widgets.py
+++ b/scripts/generate_homepage_widgets.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """Generate homepage widget data from consolidated Parquet lake on Internet Archive.
 
+Purpose:  Build the homepage widget JSON (activity summary, top tribunals, top
+          lawyers) the dashboard renders at build time.
+Problem:  The Astro homepage needs pre-aggregated stats from the Parquet lake; it
+          can't query IA itself at build time.
+Strategy: Read manifest.parquet to find remote comunicacoes/advogados parquet URLs,
+          aggregate the three widgets via DuckDB, and write one JSON; on any widget
+          failure emit an empty value so the page still renders.
+Status:   production — runs in deploy-web.yml; consumed by web/src/pages/index.astro.
+
+
 Reads `manifest.parquet` from the causaganha-catalog to discover the remote URLs
 of all `*-comunicacoes.parquet` and `*-advogados.parquet` files, then aggregates
 three widgets:

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """Execute .qmd query files against the manifest and emit JSON.
 
+Purpose:  Turn the frontend's .qmd query contracts into the JSON datasets it loads.
+Problem:  The web app declares its data needs as .qmd files; something must execute
+          them against the manifest without depending on the Quarto binary.
+Strategy: Scan web/src/queries/*.qmd, parse the frontmatter (output/format) + SQL
+          fence, run each against the manifest via DuckDB, and write JSON under
+          web/public — staying Quarto-compatible for later HTML rendering.
+Status:   production — runs in deploy-web.yml, test.yml and update-catalog.yml; the
+          canonical manifest→frontend data path (see web/src/queries/README.md).
+
+
 Scans web/src/queries/*.qmd, parses Quarto-compatible frontmatter
 (``output`` and ``format`` fields), extracts the SQL code block,
 runs it against the manifest via DuckDB, and writes the result JSON

--- a/scripts/upload_to_ia.py
+++ b/scripts/upload_to_ia.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Upload Parquet files to Internet Archive.
 
+Purpose:  Upload compressed Parquet artifacts to Internet Archive for archival.
+Problem:  Locally produced Parquet exports need durable, public, long-term storage.
+Strategy: Push the compressed embedding/consolidated Parquet files to IA.
+Status:   production — invoked by collect-zips.yml and consolidate-parquet.yml.
+
 Uploads compressed embedding Parquet files to IA for long-term archival.
 """
 

--- a/scripts/vendor_pje_swagger.py
+++ b/scripts/vendor_pje_swagger.py
@@ -1,3 +1,13 @@
+"""Vendor the PJe ComunicaAPI (DJEN) OpenAPI/Swagger spec into the repo.
+
+Purpose:  Keep a local, version-controlled copy of the PJe DJEN OpenAPI spec.
+Problem:  The upstream PJe host is frequently geo-blocked (HTTP 403), so depending
+          on it at build/runtime is unreliable.
+Strategy: Fetch the swagger YAML (or read a local --input-file) and write it to
+          openapi/; on 403 print actionable mirroring/manual-download guidance.
+Status:   dev/maintenance tool — run manually to refresh the vendored spec.
+"""
+
 from __future__ import annotations
 
 import contextlib


### PR DESCRIPTION
Fourth batch of the scripts-clarification effort (`Purpose / Problem / Strategy / Status` template, per-category).

Documents the **catalog/web + export/upload** category (8 scripts).

| Script | Status |
|---|---|
| `generate_catalog.py` | production (update-catalog.yml) |
| `generate_homepage_widgets.py` | production (deploy-web.yml) |
| `render_queries.py` | production (deploy-web/test/update-catalog) — the `.qmd`→frontend data path |
| `upload_to_ia.py` | production (collect-zips/consolidate-parquet) |
| `daily_export.py` | ops cron runner — **RFC** (scheduled anywhere?) |
| `extract_local_css.py` | dev/one-off refactor tool |
| `create_sample_data.py` | dev/test helper |
| `vendor_pje_swagger.py` | dev/maintenance tool |

Cleanups while here: `generate_catalog.py` had a stray no-op string literal mid-file instead of a module docstring (now a real top docstring keeping the Creates/Usage detail); `vendor_pje_swagger.py` had **no** module docstring at all (added one).

Verified: `py_compile` OK on all 8; `ruff check` clean (0 errors) on these files.

**Last batch remaining:** monitoring/ops (`monitor_collect`, `monitor_github_backfill`, `analyze_pipeline_performance`, `stress_test_djen`, `probe_tribunal_start_dates`, `laptop_service`).

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_