### PR TITLE
Replace presentational <mark> with badge elements, improve search and calendar accessibility/layout, and update CSS

### DIFF
--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -301,12 +301,13 @@
 
 {#snippet sourceBadge()}
   {#if source}
-    <mark
+    <span
+      class="badge"
       data-tone={source === 'djen' ? 'info' : 'warning'}
       title={usedFallback ? 'Falha ao conectar no DJEN, usando arquivo IA' : ''}
     >
       Fonte: {source === 'djen' ? 'DJEN' : 'Arquivo IA'}
-    </mark>
+    </span>
   {/if}
 {/snippet}
 
@@ -339,7 +340,7 @@
     <header>
       <span class="seq-number">#{seq}</span>
       {#if pub.tipoComunicacao}
-        <mark class="publication-badge">{pub.tipoComunicacao}</mark>
+        <span class="badge publication-badge">{pub.tipoComunicacao}</span>
       {/if}
       {@render sourceBadge()}
       <small><time>{dateStr}</time></small>
@@ -383,7 +384,7 @@
     {#if parties.length > 0}
       <div class="tags-row">
         {#each parties.slice(0, 4) as party}
-          <mark class="name-pill">{party}</mark>
+          <span class="name-pill">{party}</span>
         {/each}
       </div>
     {/if}
@@ -411,7 +412,7 @@
     <header>
       <div>
         <span class="seq-number seq-bold">#{seq}</span>
-        <mark class="publication-badge">Modo Leitura</mark>
+        <span class="badge publication-badge">Modo Leitura</span>
         {@render sourceBadge()}
         <small><time>{dateStr}</time></small>
       </div>
@@ -477,12 +478,12 @@
           <div class="sidebar-tags">
             {#if parties.length > 0}
               {#each parties as party}
-                <mark class="name-pill">{party}</mark>
+                <span class="name-pill">{party}</span>
               {/each}
             {/if}
             {#if lawyers.length > 0}
               {#each lawyers as lawyer}
-                <mark data-tone="info">{lawyer}</mark>
+                <span class="name-pill" data-tone="info">{lawyer}</span>
               {/each}
             {/if}
           </div>
@@ -518,7 +519,7 @@
       <div>
         <span class="seq-number seq-bold">#{seq}</span>
         {#if pub.tipoComunicacao}
-          <mark class="publication-badge">{pub.tipoComunicacao}</mark>
+          <span class="badge publication-badge">{pub.tipoComunicacao}</span>
         {/if}
         {@render sourceBadge()}
         <small><time>{dateStr}</time></small>
@@ -633,7 +634,7 @@
             <strong class="sidebar-title">Destinatários</strong>
             <div class="sidebar-tags">
               {#each parties as party}
-                <mark class="name-pill">{party}</mark>
+                <span class="name-pill">{party}</span>
               {/each}
             </div>
           </div>
@@ -644,7 +645,7 @@
             <strong class="sidebar-title">Advogados</strong>
             <div class="sidebar-tags">
               {#each lawyers as lawyer}
-                <mark data-tone="info">{lawyer}</mark>
+                <span class="name-pill" data-tone="info">{lawyer}</span>
               {/each}
             </div>
           </div>

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -30,12 +30,14 @@
   }
 </script>
 
-<search>
-  <label>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+<form class="smart-search" role="search" onsubmit={(e) => { e.preventDefault(); onsubmit?.(); }}>
+  <div class="smart-search__field">
+    <label class="smart-search__label" for="publication-smart-search">Buscar publicações</label>
+    <svg class="smart-search__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
     </svg>
     <input
+      id="publication-smart-search"
       type="search"
       bind:this={inputRef}
       bind:value
@@ -44,14 +46,73 @@
       autocomplete="off"
       spellcheck="false"
       enterkeyhint="search"
-      aria-label="Buscar publicações"
     />
     {#if value}
-      <button type="reset" class="secondary outline" onclick={() => (value = '')} aria-label="Limpar busca">×</button>
+      <button type="reset" class="smart-search__clear secondary outline" onclick={() => (value = '')} aria-label="Limpar busca">×</button>
     {/if}
-  </label>
-  <span class="search-shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd><kbd>K</kbd></span>
+  </div>
+  <span class="smart-search__shortcut search-shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd><kbd>K</kbd></span>
   {#if hint}
-    <small data-kind={kind} role="status" aria-live="polite">{hint}</small>
+    <small class="smart-search__hint" data-kind={kind} role="status" aria-live="polite">{hint}</small>
   {/if}
-</search>
+</form>
+
+<style>
+  .smart-search {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .smart-search__field {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .smart-search__label {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .smart-search__icon {
+    position: absolute;
+    inset-inline-start: 1rem;
+    inline-size: 1rem;
+    block-size: 1rem;
+    flex: 0 0 auto;
+    color: var(--fg-muted, var(--color-content-tertiary));
+    pointer-events: none;
+  }
+
+  .smart-search__field :global(input[type='search']) {
+    inline-size: 100%;
+    padding-inline-start: 2.75rem;
+    padding-inline-end: 3rem;
+  }
+
+  .smart-search__clear {
+    position: absolute;
+    inset-inline-end: 0.5rem;
+    inline-size: 2rem;
+    block-size: 2rem;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .smart-search__shortcut {
+    justify-self: start;
+  }
+
+  .smart-search__hint {
+    color: var(--fg-muted, var(--color-content-tertiary));
+  }
+</style>

--- a/web/src/components/TribunalCalendar.svelte
+++ b/web/src/components/TribunalCalendar.svelte
@@ -124,42 +124,44 @@
 </script>
 
 <div class="cal-control">
-  <div class="cal-control__pick">
-    <span class="kicker" style="margin-bottom: 4px;">Tribunal</span>
-    <select class="select cal-control__select" bind:value={selectedTribunal}>
-      {#each TRIBUNAL_GROUPS as group}
-        <optgroup label={group.name}>
-          {#each group.tribunals as t}
-            <option value={t}>{t}{TRIBUNAL_NAMES[t] ? ' — ' + TRIBUNAL_NAMES[t] : ''}</option>
-          {/each}
-        </optgroup>
-      {/each}
-    </select>
+  <div class="cal-control__selectors">
+    <div class="cal-control__pick">
+      <label class="kicker" for="tribunal-calendar-tribunal" style="margin-bottom: 4px;">Tribunal</label>
+      <select id="tribunal-calendar-tribunal" class="select cal-control__select" bind:value={selectedTribunal}>
+        {#each TRIBUNAL_GROUPS as group}
+          <optgroup label={group.name}>
+            {#each group.tribunals as t}
+              <option value={t}>{t}{TRIBUNAL_NAMES[t] ? ' — ' + TRIBUNAL_NAMES[t] : ''}</option>
+            {/each}
+          </optgroup>
+        {/each}
+      </select>
+    </div>
+
+    <div class="cal-control__pick">
+      <label class="kicker" for="tribunal-calendar-year" style="margin-bottom: 4px;">Ano</label>
+      <select id="tribunal-calendar-year" class="select cal-control__select" bind:value={selectedYear}>
+        {#each Array.from({ length: currentYear - 2018 + 1 }, (_, i) => currentYear - i) as y}
+          <option value={y}>{y}</option>
+        {/each}
+      </select>
+    </div>
   </div>
 
-  <div class="cal-control__pick" style="max-width: 120px;">
-    <span class="kicker" style="margin-bottom: 4px;">Ano</span>
-    <select class="select cal-control__select" bind:value={selectedYear}>
-      {#each Array.from({ length: currentYear - 2018 + 1 }, (_, i) => currentYear - i) as y}
-        <option value={y}>{y}</option>
-      {/each}
-    </select>
-  </div>
-
-  <div class="cal-control__stats">
-    <div>
-      <div class="kicker" style="margin-bottom: 2px;">Cobertura</div>
-      <div class="cal-stat cal-stat--azul">{stats.pct.toFixed(1)}%</div>
+  <dl class="cal-control__stats" aria-label="Resumo de cobertura do calendário">
+    <div class="cal-control__stat">
+      <dt class="kicker">Cobertura</dt>
+      <dd class="cal-stat cal-stat--azul">{stats.pct.toFixed(1)}%</dd>
     </div>
-    <div>
-      <div class="kicker" style="margin-bottom: 2px;">Arquivados</div>
-      <div class="cal-stat">{stats.up.toLocaleString('pt-BR')}</div>
+    <div class="cal-control__stat">
+      <dt class="kicker">Arquivados</dt>
+      <dd class="cal-stat">{stats.up.toLocaleString('pt-BR')}</dd>
     </div>
-    <div>
-      <div class="kicker" style="margin-bottom: 2px;">Pendentes</div>
-      <div class="cal-stat cal-stat--ocre">{stats.pend.toLocaleString('pt-BR')}</div>
+    <div class="cal-control__stat">
+      <dt class="kicker">Pendentes</dt>
+      <dd class="cal-stat cal-stat--ocre">{stats.pend.toLocaleString('pt-BR')}</dd>
     </div>
-  </div>
+  </dl>
 
   <a class="btn btn--secondary btn--sm" href={detailHref}>Ver página →</a>
 </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -366,11 +366,30 @@ article > footer {
   margin-top: var(--space-sm);
 }
 
-/* ─── mark[data-tone] — semantic color tokens ─── */
-mark[data-tone='info']    { background: color-mix(in srgb, var(--color-info)    20%, transparent); color: var(--color-info); }
-mark[data-tone='success'] { background: color-mix(in srgb, var(--color-success) 20%, transparent); color: var(--color-success); }
-mark[data-tone='warning'] { background: color-mix(in srgb, var(--color-warning) 20%, transparent); color: var(--color-warning); }
-mark[data-tone='error']   { background: color-mix(in srgb, var(--color-error)   20%, transparent); color: var(--color-error); }
+/* ─── inline badges and semantic color tokens ─── */
+mark[data-tone='info'], .badge[data-tone='info']       { background: color-mix(in srgb, var(--color-info)    20%, transparent); color: var(--color-info); }
+mark[data-tone='success'], .badge[data-tone='success'] { background: color-mix(in srgb, var(--color-success) 20%, transparent); color: var(--color-success); }
+mark[data-tone='warning'], .badge[data-tone='warning'] { background: color-mix(in srgb, var(--color-warning) 20%, transparent); color: var(--color-warning); }
+mark[data-tone='error'], .badge[data-tone='error']     { background: color-mix(in srgb, var(--color-error)   20%, transparent); color: var(--color-error); }
+
+.badge,
+.publication-badge,
+.name-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.45rem;
+  border-radius: var(--radius-selector);
+  background: var(--color-surface-overlay);
+  color: var(--color-content);
+  font-size: 0.875em;
+  line-height: 1.35;
+}
+
+.name-pill[data-tone='info'] {
+  background: color-mix(in srgb, var(--color-info) 14%, transparent);
+  color: var(--color-info);
+}
 
 /* ─── Responsive auto-grid: equal columns, collapses to 1 on narrow screens ─── */
 .auto-grid {
@@ -689,7 +708,7 @@ table tbody tr:hover {
 [data-tone='warning'] { color: var(--color-warning); accent-color: var(--color-warning); }
 [data-tone='error']   { color: var(--color-error);   accent-color: var(--color-error); }
 [data-tone='info']    { color: var(--color-info);    accent-color: var(--color-info); }
-[data-tone='muted']   { opacity: 0.3; }
+[data-tone='muted']   { color: var(--fg-muted, var(--color-content-tertiary)); }
 
 /* ═══════════════════════════════════════════
    Header
@@ -1075,7 +1094,7 @@ dialog.nav-drawer a:focus-visible {
 }
 
 /* ── Dark mode — mata atlântica ───────────────────────── */
-body[data-theme="dark"] {
+:root[data-theme="dark"] {
   --papel-00: #103025;
   --papel-10: #0A2118;
   --papel-20: #051711;
@@ -1412,7 +1431,7 @@ body[data-theme="dark"] {
    ════════════════════════════════════════════════════════ */
 .cal-control {
   display: grid;
-  grid-template-columns: minmax(220px, 320px) 110px 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--s-5);
   align-items: center;
   padding: var(--s-4) var(--s-5);
@@ -1421,7 +1440,13 @@ body[data-theme="dark"] {
   box-shadow: var(--shadow-1);
   margin-bottom: var(--s-4);
 }
-.cal-control__pick { display: flex; flex-direction: column; }
+.cal-control__selectors {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(96px, 120px);
+  gap: var(--s-5);
+  min-width: 0;
+}
+.cal-control__pick { display: flex; flex-direction: column; min-width: 0; }
 .cal-control__select {
   font-family: var(--font-display);
   font-weight: 700;
@@ -1444,12 +1469,15 @@ body[data-theme="dark"] {
 }
 .cal-control__stats {
   display: grid;
-  grid-template-columns: repeat(3, auto);
-  gap: var(--s-6);
-  padding-left: var(--s-5);
-  border-left: 1.5px solid var(--border);
+  grid-template-columns: repeat(3, minmax(0, auto));
+  gap: var(--s-5);
+  padding: 0;
+  margin: 0;
   align-items: end;
 }
+.cal-control__stat { margin: 0; min-width: 0; }
+.cal-control__stat dt { margin: 0 0 2px; }
+.cal-control__stat dd { margin: 0; }
 .cal-stat {
   font-family: var(--font-display);
   font-weight: 800;
@@ -1545,122 +1573,143 @@ body[data-theme="dark"] {
 .mini-day.is-today { box-shadow: inset 0 0 0 2px var(--vermelho); }
 
 /* Dark mode cal */
-body[data-theme="dark"] .cal-control {
+:root[data-theme="dark"] .cal-control {
   background: var(--papel-00);
   border-color: var(--border-strong);
   box-shadow: 2px 2px 0 var(--border-strong);
 }
-body[data-theme="dark"] .cal-control__select {
+:root[data-theme="dark"] .cal-control__select {
   border-bottom-color: var(--border-strong);
   color: var(--fg-heading);
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8'><path d='M1 1 L6 7 L11 1' stroke='%23C2D1C7' stroke-width='1.5' fill='none'/></svg>");
 }
-body[data-theme="dark"] .cal-control__stats { border-left-color: var(--border-strong); }
-body[data-theme="dark"] .mini-month { background: var(--papel-00); border-color: var(--border-strong); }
-body[data-theme="dark"] .mini-month__head { border-bottom-color: var(--border); }
-body[data-theme="dark"] .mini-month__name { color: var(--fg-heading); }
-body[data-theme="dark"] .mini-day { background: var(--papel-20); color: var(--fg-muted); }
-body[data-theme="dark"] .mini-day--uploaded { background: var(--azul); color: var(--papel-10); border-color: var(--azul); }
-body[data-theme="dark"] .mini-day--partial { background: var(--ocre); color: var(--papel-10); border-color: var(--ocre-deep); }
-body[data-theme="dark"] .mini-day--absent { background: var(--papel-20); color: var(--concreto-60); }
-body[data-theme="dark"] .mini-day:hover:not(.mini-day--future):not(.mini-day--empty) { outline-color: var(--fg-heading); }
+:root[data-theme="dark"] .cal-control__stats { border-left-color: var(--border-strong); }
+:root[data-theme="dark"] .mini-month { background: var(--papel-00); border-color: var(--border-strong); }
+:root[data-theme="dark"] .mini-month__head { border-bottom-color: var(--border); }
+:root[data-theme="dark"] .mini-month__name { color: var(--fg-heading); }
+:root[data-theme="dark"] .mini-day { background: var(--papel-20); color: var(--fg-muted); }
+:root[data-theme="dark"] .mini-day--uploaded { background: var(--azul); color: var(--papel-10); border-color: var(--azul); }
+:root[data-theme="dark"] .mini-day--partial { background: var(--ocre); color: var(--papel-10); border-color: var(--ocre-deep); }
+:root[data-theme="dark"] .mini-day--absent { background: var(--papel-20); color: var(--concreto-60); }
+:root[data-theme="dark"] .mini-day:hover:not(.mini-day--future):not(.mini-day--empty) { outline-color: var(--fg-heading); }
 
 /* Dark mode hero */
-body[data-theme="dark"] .hero { background: var(--papel-10); border-bottom-color: var(--border-strong); }
-body[data-theme="dark"] .hero__meta { border-top-color: var(--border-strong); }
-body[data-theme="dark"] .hero__search-input {
+:root[data-theme="dark"] .hero { background: var(--papel-10); border-bottom-color: var(--border-strong); }
+:root[data-theme="dark"] .hero__meta { border-top-color: var(--border-strong); }
+:root[data-theme="dark"] .hero__search-input {
   background: var(--papel-00);
   border-color: var(--border-strong);
   color: var(--fg);
   box-shadow: 2px 2px 0 var(--border-strong);
 }
-body[data-theme="dark"] .hero__search-input::placeholder { color: var(--fg-muted); }
-body[data-theme="dark"] .hero__chips .search-hint {
+:root[data-theme="dark"] .hero__search-input::placeholder { color: var(--fg-muted); }
+:root[data-theme="dark"] .hero__chips .search-hint {
   background: var(--papel-00);
   border-color: var(--border-strong);
   color: var(--fg);
 }
-body[data-theme="dark"] .hero__chips .search-hint b { color: var(--fg-heading); }
-body[data-theme="dark"] .hero__chips .search-hint:hover {
+:root[data-theme="dark"] .hero__chips .search-hint b { color: var(--fg-heading); }
+:root[data-theme="dark"] .hero__chips .search-hint:hover {
   background: rgba(230, 188, 104, 0.12);
   border-color: var(--ocre);
   color: var(--ocre);
 }
-body[data-theme="dark"] .hero__chip-k { border-right-color: var(--border-strong); color: var(--vermelho); }
+:root[data-theme="dark"] .hero__chip-k { border-right-color: var(--border-strong); color: var(--vermelho); }
 
 /* Dark mode buttons */
-body[data-theme="dark"] .btn,
-body[data-theme="dark"] button.btn,
-body[data-theme="dark"] a.btn {
+:root[data-theme="dark"] .btn,
+:root[data-theme="dark"] button.btn,
+:root[data-theme="dark"] a.btn {
   background: var(--fg-heading);
   color: var(--papel-10);
   border-color: var(--fg-heading);
   box-shadow: 2px 2px 0 var(--fg-heading);
 }
-body[data-theme="dark"] .btn:hover { box-shadow: 3px 3px 0 var(--fg-heading); color: var(--papel-10); }
-body[data-theme="dark"] .btn:active { box-shadow: 0 0 0 var(--fg-heading); }
-body[data-theme="dark"] .btn--secondary {
+:root[data-theme="dark"] .btn:hover { box-shadow: 3px 3px 0 var(--fg-heading); color: var(--papel-10); }
+:root[data-theme="dark"] .btn:active { box-shadow: 0 0 0 var(--fg-heading); }
+:root[data-theme="dark"] .btn--secondary {
   background: var(--papel-00); color: var(--fg-heading);
   border-color: var(--border-strong); box-shadow: 2px 2px 0 var(--border-strong);
 }
-body[data-theme="dark"] .btn--secondary:hover { background: var(--papel-20); color: var(--fg-heading); box-shadow: 3px 3px 0 var(--border-strong); }
-body[data-theme="dark"] .btn--accent {
+:root[data-theme="dark"] .btn--secondary:hover { background: var(--papel-20); color: var(--fg-heading); box-shadow: 3px 3px 0 var(--border-strong); }
+:root[data-theme="dark"] .btn--accent {
   background: var(--vermelho); border-color: var(--vermelho-deep);
   color: #FFFFFF; box-shadow: 2px 2px 0 var(--vermelho-deep);
 }
-body[data-theme="dark"] .btn--accent:hover { box-shadow: 3px 3px 0 var(--vermelho-deep); color: #FFFFFF; }
-body[data-theme="dark"] .btn--azul {
+:root[data-theme="dark"] .btn--accent:hover { box-shadow: 3px 3px 0 var(--vermelho-deep); color: #FFFFFF; }
+:root[data-theme="dark"] .btn--azul {
   background: var(--azul); border-color: var(--azul-bright);
   color: var(--papel-10); box-shadow: 2px 2px 0 var(--azul-bright);
 }
-body[data-theme="dark"] .btn--ghost,
-body[data-theme="dark"] button.btn--ghost,
-body[data-theme="dark"] a.btn--ghost {
+:root[data-theme="dark"] .btn--ghost,
+:root[data-theme="dark"] button.btn--ghost,
+:root[data-theme="dark"] a.btn--ghost {
   background: transparent; color: var(--fg-heading); box-shadow: none; border-color: transparent;
 }
-body[data-theme="dark"] .btn--ghost:hover,
-body[data-theme="dark"] button.btn--ghost:hover,
-body[data-theme="dark"] a.btn--ghost:hover { background: var(--papel-20); color: var(--fg-heading); box-shadow: none; }
+:root[data-theme="dark"] .btn--ghost:hover,
+:root[data-theme="dark"] button.btn--ghost:hover,
+:root[data-theme="dark"] a.btn--ghost:hover { background: var(--papel-20); color: var(--fg-heading); box-shadow: none; }
 
 /* Dark mode cards */
-body[data-theme="dark"] .card { background: var(--papel-00); border-color: var(--border-strong); }
-body[data-theme="dark"] .card--sunken { background: var(--papel-20); }
+:root[data-theme="dark"] .card { background: var(--papel-00); border-color: var(--border-strong); }
+:root[data-theme="dark"] .card--sunken { background: var(--papel-20); }
 
 /* Dark mode forms */
-body[data-theme="dark"] .input,
-body[data-theme="dark"] .textarea,
-body[data-theme="dark"] .select {
+:root[data-theme="dark"] .input,
+:root[data-theme="dark"] .textarea,
+:root[data-theme="dark"] .select {
   background: var(--papel-00); border-color: var(--border-strong); color: var(--fg);
 }
-body[data-theme="dark"] .input:focus,
-body[data-theme="dark"] .textarea:focus,
-body[data-theme="dark"] .select:focus {
+:root[data-theme="dark"] .input:focus,
+:root[data-theme="dark"] .textarea:focus,
+:root[data-theme="dark"] .select:focus {
   border-color: var(--azul); box-shadow: 3px 3px 0 var(--azul);
 }
-body[data-theme="dark"] .select {
+:root[data-theme="dark"] .select {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8'><path d='M1 1 L6 7 L11 1' stroke='%23C2D1C7' stroke-width='1.5' fill='none'/></svg>");
 }
 
 /* Dark mode pull quote */
-body[data-theme="dark"] .pull { color: var(--fg-heading); border-left-color: var(--vermelho); }
+:root[data-theme="dark"] .pull { color: var(--fg-heading); border-left-color: var(--vermelho); }
 
 /* ════════════════════════════════════════════════════════
    Responsive — BM supplement
    ════════════════════════════════════════════════════════ */
 @media (max-width: 860px) {
   .cal-control {
+    grid-template-columns: 1fr;
+    gap: var(--s-4);
+  }
+  .cal-control__selectors {
     grid-template-columns: 1fr 1fr;
     gap: var(--s-4);
   }
   .cal-control__stats {
-    grid-column: 1 / -1;
-    padding-left: 0;
-    border-left: 0;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     border-top: 1px solid var(--border);
     padding-top: var(--s-3);
   }
-  .cal-control > a.btn { grid-column: 1 / -1; justify-self: start; }
+  .cal-control > a.btn { justify-self: start; }
 }
+
+@media (max-width: 520px) {
+  .cal-control {
+    padding: var(--s-4);
+  }
+  .cal-control__selectors,
+  .cal-control__stats {
+    grid-template-columns: 1fr;
+  }
+  .cal-control__select {
+    inline-size: 100%;
+    max-inline-size: 100%;
+  }
+  .cal-control > a.btn {
+    inline-size: 100%;
+    justify-content: center;
+  }
+}
+
 @media (max-width: 980px) {
   .hero__inner { padding: var(--s-6) var(--s-4) var(--s-5); }
   .hero h1.mega { font-size: clamp(48px, 12vw, 88px); }


### PR DESCRIPTION
### Motivation
- Standardize inline badges and name pills by replacing presentational `mark` elements with semantic `span` badges to allow consistent styling and better semantics.
- Improve accessibility and semantics of the search input by using a real `form` with an associated `label` and clearer keyboard behavior.
- Make the tribunal calendar controls more accessible and responsive by adding labeled `select`s, using a `dl` for stats, and refining layout CSS.

### Description
- Updated `PublicationCard.svelte` to replace several `<mark>` elements with `<span class="badge">` or `<span class="name-pill">` and preserved `data-tone` attributes for semantic coloring.
- Reworked `SmartSearchInput.svelte` to use a `<form>` (with `role="search"`), added a visually-hidden `label` with `id="publication-smart-search"`, adjusted the clear button class, and added component-scoped CSS for layout and visuals.
- Modified `TribunalCalendar.svelte` to add explicit `label` elements and `id`s for the tribunal and year selects, grouped selectors under `.cal-control__selectors`, converted the stats area to a `dl` with `dt`/`dd`, and adjusted markup for better responsive behavior.
- Extended `web/src/index.css` to add styling for `.badge`, `.publication-badge`, and `.name-pill`, broaden `data-tone` rules to include `.badge`, convert `body[data-theme="dark"]` selectors to `:root[data-theme="dark"]` for scoping, and updated many calendar/control layout and responsive rules.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2fccba788325be123db0639009ae)