### PR TITLE
Evolui alertas de cobertura por tribunal

### DIFF
--- a/web/features/tribunal-detail.feature
+++ b/web/features/tribunal-detail.feature
@@ -17,3 +17,15 @@ Feature: Tribunal Detail
     When the tribunal detail page loads
     Then the selector should contain "STJ" as an option
     And the selector should contain "TRT1" as an option
+
+  Scenario: Highlight tribunal coverage gap state
+    Given tribunal "STF" has 12 missing days and 4 absent days
+    When the tribunal detail page loads
+    Then I should see a coverage gap attention card
+    And I should see explanatory next action text
+
+  Scenario: Highlight tribunal anomaly state
+    Given tribunal "STJ" has low completion coverage
+    When the tribunal detail page loads
+    Then I should see an anomaly attention card
+    And I should see the anomaly impact text

--- a/web/src/components/LatencyHeatmap.svelte
+++ b/web/src/components/LatencyHeatmap.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
-  import CellTooltip from './CellTooltip.svelte';
   import MonthPicker from './MonthPicker.svelte';
   import { completedItemsStore } from '../lib/completedItemsStore.svelte';
+  import {
+    buildCatalogAttentionCards,
+    countCoverageFilters,
+    filterCoverageDays,
+    getDayStatusLabel,
+    summarizeCatalogDay,
+    type CoverageFilter,
+  } from '../lib/coverageInsights';
 
   onMount(() => completedItemsStore.load());
 
@@ -16,6 +23,8 @@
   const _now = new Date();
   let selectedYear  = $state(_now.getUTCFullYear());
   let selectedMonth = $state(_now.getUTCMonth());
+  let coverageFilter = $state<CoverageFilter>('all');
+  let expandedDate = $state<string | null>(null);
 
   const data    = $derived(completedItemsStore.data);
   const loading = $derived(completedItemsStore.loading);
@@ -43,13 +52,18 @@
   });
 
   // Days of the selected month, sorted descending (most recent first)
-  let displayDates = $derived.by(() => {
+  let monthDays = $derived.by(() => {
     if (!data) return [];
     const prefix = `djen-${selectedYear}-${String(selectedMonth + 1).padStart(2, '0')}-`;
     return Object.keys(data)
       .filter(k => k.startsWith(prefix))
-      .sort((a, b) => b.localeCompare(a));
+      .sort((a, b) => b.localeCompare(a))
+      .map(key => summarizeCatalogDay(key, data[key]));
   });
+
+  let filterCounts = $derived(countCoverageFilters(monthDays));
+  let displayDates = $derived(filterCoverageDays(monthDays, coverageFilter));
+  let attentionCards = $derived(buildCatalogAttentionCards([...monthDays].sort((a, b) => a.date.localeCompare(b.date))));
 
   const TRIBUNALS = [
     'STF', 'STJ', 'TST', 'TSE', 'STM',
@@ -72,6 +86,15 @@
   function formatDuration(duration_s: number | null): string {
     return duration_s === null ? 'N/A' : duration_s.toFixed(1) + 's';
   }
+
+  function setFilter(filter: CoverageFilter) {
+    coverageFilter = filter;
+    expandedDate = null;
+  }
+
+  function toggleDate(date: string) {
+    expandedDate = expandedDate === date ? null : date;
+  }
 </script>
 
 <article>
@@ -82,15 +105,16 @@
       </svg>
       Latência de Coleta
     </h2>
-    <p>Tempo para download e backup do ZIP de cada tribunal.</p>
+    <p>Tempo para download e backup do ZIP de cada tribunal, com status textual e drilldown para lacunas de cobertura.</p>
   </header>
 
   <MonthPicker bind:selectedYear bind:selectedMonth {monthSummaries} />
 
   <ul class="auto-grid-sm" aria-label="Legenda">
-    <li><span class="legend-dot cell-success" aria-hidden="true"></span> &lt; 5s</li>
-    <li><span class="legend-dot cell-warning" aria-hidden="true"></span> 5–20s</li>
-    <li><span class="legend-dot cell-error" aria-hidden="true"></span> &gt; 20s</li>
+    <li><span class="legend-dot cell-success" aria-hidden="true"></span> ✓ &lt; 5s rápido</li>
+    <li><span class="legend-dot cell-warning" aria-hidden="true"></span> ⚠ 5–20s atenção</li>
+    <li><span class="legend-dot cell-error" aria-hidden="true"></span> ⏱ &gt; 20s lento</li>
+    <li><span class="legend-dot cell-empty" aria-hidden="true"></span> ○ ausente/pendente</li>
   </ul>
 
   {#if loading}
@@ -99,7 +123,30 @@
     <mark data-tone="error">Erro ao carregar dados: {error}</mark>
   {:else}
     {#key `${selectedYear}-${selectedMonth}`}
-      <div class="table-wrap" transition:fade={{ duration: fadeDuration }}>
+      <div transition:fade={{ duration: fadeDuration }}>
+        <section class="auto-grid" aria-label="Cartões de atenção da latência">
+          {#each attentionCards as card}
+            <article class="attention-card" data-tone={card.tone}>
+              <header>
+                <strong><span aria-hidden="true">{card.icon}</span> {card.title}</strong>
+                <span class="badge" data-tone={card.tone}>{card.summary}</span>
+              </header>
+              <p>{card.impact}</p>
+              <p>{card.cause}</p>
+              <p><strong>{card.action}</strong></p>
+            </article>
+          {/each}
+        </section>
+
+        <fieldset class="filter-pills" aria-label="Filtro rápido de dias da latência">
+          <legend>Filtrar dias</legend>
+          <button type="button" class:contrast={coverageFilter === 'all'} onclick={() => setFilter('all')}>Todos ({filterCounts.all})</button>
+          <button type="button" class:contrast={coverageFilter === 'failed'} onclick={() => setFilter('failed')}>⚠ Dias com falha ({filterCounts.failed})</button>
+          <button type="button" class:contrast={coverageFilter === 'complete'} onclick={() => setFilter('complete')}>✓ Dias completos ({filterCounts.complete})</button>
+          <button type="button" class:contrast={coverageFilter === 'no-data'} onclick={() => setFilter('no-data')}>○ Dias sem dados ({filterCounts.noData})</button>
+        </fieldset>
+
+        <div class="table-wrap">
         <table>
           <thead>
             <tr>
@@ -110,14 +157,19 @@
             </tr>
           </thead>
           <tbody>
-            {#each displayDates as dateStr}
+            {#each displayDates as day}
+              {@const dateStr = day.key}
               {@const dayData = data?.[dateStr]}
               {@const latencies = dayData?.latencies || {}}
               {@const coletados = dayData?.tribunais_coletados || []}
               {@const ausentes  = dayData?.tribunais_ausentes  || []}
               <tr>
                 <td>
-                  {dateStr.replace('djen-', '')}
+                  <button type="button" class="link-button" aria-expanded={expandedDate === day.date} onclick={() => toggleDate(day.date)}>
+                    {day.date}
+                  </button>
+                  <br />
+                  <span class="badge" data-tone={day.status === 'complete' ? 'success' : day.status === 'failed' ? 'warning' : 'info'}>{getDayStatusLabel(day)}</span>
                 </td>
                 {#each TRIBUNALS as tribunal}
                   {@const isColetado = coletados.includes(tribunal)}
@@ -125,33 +177,48 @@
                   {@const status  = isColetado ? 'coletado' : isAusente ? 'ausente' : 'pendente'}
                   {@const latency = latencies[tribunal] ?? null}
                   <td>
-                    <CellTooltip
-                      date={dateStr.replace('djen-', '')}
-                      tribunal={tribunal}
-                      {status}
-                      fileName={isColetado ? `djen-${dateStr.replace('djen-', '')}-${tribunal}.zip` : undefined}
-                      detail={isColetado && latency !== null ? `Latency: ${formatDuration(latency)}` : undefined}
+                    <div
+                      class="heatmap-cell {isColetado ? getLatencyColor(latency) : 'cell-empty'}"
+                      role="button"
+                      tabindex="0"
+                      title="{tribunal} em {dateStr.replace('djen-', '')}: {isColetado && latency !== null ? `Latência: ${formatDuration(latency)}` : isAusente ? 'Tribunal ausente nesta data' : 'Sem dado de latência'}"
+                      aria-label="{tribunal} em {dateStr.replace('djen-', '')}: {isColetado ? formatDuration(latency) : status}"
                     >
-                      <div
-                        class="heatmap-cell {isColetado ? getLatencyColor(latency) : 'cell-empty'}"
-                        role="button"
-                        tabindex="0"
-                        aria-label="{tribunal} em {dateStr.replace('djen-', '')}: {isColetado ? formatDuration(latency) : status}"
-                      ></div>
-                    </CellTooltip>
+                      <span class="sr-only">{isColetado ? formatDuration(latency) : status}</span>
+                    </div>
                   </td>
                 {/each}
               </tr>
+              {#if expandedDate === day.date}
+                <tr>
+                  <td colspan={TRIBUNALS.length + 1}>
+                    <div class="drilldown-panel">
+                      <strong>Tribunais faltantes em {day.date}</strong>
+                      <p>Impacto: células vazias podem significar ausência oficial, pendência de coleta ou latência ainda não registrada.</p>
+                      {#if day.missingTribunals.length > 0}
+                        <ul class="chip-list">
+                          {#each day.missingTribunals as tribunal}
+                            <li><span class="badge" data-tone="warning">⚠ {tribunal}</span></li>
+                          {/each}
+                        </ul>
+                      {:else}
+                        <p>Nenhum tribunal ausente registrado para esta data.</p>
+                      {/if}
+                    </div>
+                  </td>
+                </tr>
+              {/if}
             {/each}
             {#if displayDates.length === 0}
               <tr>
                 <td colspan={TRIBUNALS.length + 1} class="empty-state">
-                  Sem dados para este mês.
+                  Sem dados para este filtro neste mês.
                 </td>
               </tr>
             {/if}
           </tbody>
         </table>
+        </div>
       </div>
     {/key}
   {/if}

--- a/web/src/components/TribunalCoverageHeatmap.svelte
+++ b/web/src/components/TribunalCoverageHeatmap.svelte
@@ -2,6 +2,14 @@
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { getCoverageColorClass } from '../lib/colorUtils';
+  import {
+    buildCatalogAttentionCards,
+    countCoverageFilters,
+    filterCoverageDays,
+    getDayStatusLabel,
+    summarizeCatalogDay,
+    type CoverageFilter,
+  } from '../lib/coverageInsights';
   import MonthPicker from './MonthPicker.svelte';
   import { completedItemsStore } from '../lib/completedItemsStore.svelte';
 
@@ -10,6 +18,8 @@
   const _now = new Date();
   let selectedYear  = $state(_now.getUTCFullYear());
   let selectedMonth = $state(_now.getUTCMonth());
+  let coverageFilter = $state<CoverageFilter>('all');
+  let expandedDate = $state<string | null>(null);
 
   const data    = $derived(completedItemsStore.data);
   const loading = $derived(completedItemsStore.loading);
@@ -37,18 +47,35 @@
   });
 
   // Days belonging to the selected month, sorted ascending
-  let displayDates = $derived.by(() => {
+  let monthDays = $derived.by(() => {
     if (!data) return [];
     const prefix = `djen-${selectedYear}-${String(selectedMonth + 1).padStart(2, '0')}-`;
     return Object.keys(data)
       .filter(k => k.startsWith(prefix))
-      .sort((a, b) => a.localeCompare(b));
+      .sort((a, b) => a.localeCompare(b))
+      .map(key => summarizeCatalogDay(key, data[key]));
   });
 
+  let filterCounts = $derived(countCoverageFilters(monthDays));
+  let displayDates = $derived(filterCoverageDays(monthDays, coverageFilter));
+  let attentionCards = $derived(buildCatalogAttentionCards(monthDays));
+
+  function setFilter(filter: CoverageFilter) {
+    coverageFilter = filter;
+    expandedDate = null;
+  }
+
+  function toggleDate(date: string) {
+    expandedDate = expandedDate === date ? null : date;
+  }
 </script>
 
 <article>
   <h3>Cobertura do Catálogo</h3>
+  <p>
+    Acompanhe falhas por dia sem depender só da cor: cada linha mostra status textual,
+    contagens e uma lista dos tribunais ausentes quando houver lacuna.
+  </p>
 
   <MonthPicker bind:selectedYear bind:selectedMonth {monthSummaries} />
 
@@ -59,44 +86,100 @@
   {:else}
     {#key `${selectedYear}-${selectedMonth}`}
       <div transition:fade={{ duration: 120 }}>
+        <section class="auto-grid" aria-label="Cartões de atenção da cobertura">
+          {#each attentionCards as card}
+            <article class="attention-card" data-tone={card.tone}>
+              <header>
+                <strong><span aria-hidden="true">{card.icon}</span> {card.title}</strong>
+                <span class="badge" data-tone={card.tone}>{card.summary}</span>
+              </header>
+              <p>{card.impact}</p>
+              <p>{card.cause}</p>
+              <p><strong>{card.action}</strong></p>
+            </article>
+          {/each}
+        </section>
+
+        <fieldset class="filter-pills" aria-label="Filtro rápido de cobertura">
+          <legend>Filtrar dias</legend>
+          <button type="button" class:contrast={coverageFilter === 'all'} onclick={() => setFilter('all')}>
+            Todos ({filterCounts.all})
+          </button>
+          <button type="button" class:contrast={coverageFilter === 'failed'} onclick={() => setFilter('failed')}>
+            ⚠ Dias com falha ({filterCounts.failed})
+          </button>
+          <button type="button" class:contrast={coverageFilter === 'complete'} onclick={() => setFilter('complete')}>
+            ✓ Dias completos ({filterCounts.complete})
+          </button>
+          <button type="button" class:contrast={coverageFilter === 'no-data'} onclick={() => setFilter('no-data')}>
+            ○ Dias sem dados ({filterCounts.noData})
+          </button>
+        </fieldset>
+
         <div class="table-wrap">
           <table class="striped">
             <thead>
               <tr>
                 <th>Data</th>
+                <th>Status</th>
                 <th>ZIPs Coletados</th>
                 <th>Ausentes</th>
                 <th>Cobertura %</th>
                 <th>Barra</th>
+                <th>Drilldown</th>
               </tr>
             </thead>
             <tbody>
-              {#each displayDates as dateKey}
-                {@const item = data![dateKey]}
-                {@const tribunalCount = item.tribunal_count || 0}
-                {@const absentCount = item.absent_count || 0}
-                {@const total = tribunalCount + absentCount}
-                {@const pct = total > 0 ? Math.min(100, (tribunalCount / total) * 100) : 0}
-                {@const displayDate = dateKey.replace('djen-', '')}
-                {@const colorClasses = getCoverageColorClass(pct)}
+              {#each displayDates as day}
+                {@const colorClasses = getCoverageColorClass(day.pct)}
                 {@const textClass = colorClasses.split(' ')[0]}
-                {@const bgClass = colorClasses.split(' ')[1]}
                 <tr>
-                  <td>{displayDate}</td>
-                  <td>{tribunalCount}</td>
-                  <td>{absentCount}</td>
-                  <td class={total === 0 ? undefined : textClass}>{pct.toFixed(1)}%</td>
+                  <td>{day.date}</td>
+                  <td><span class="badge" data-tone={day.status === 'complete' ? 'success' : day.status === 'failed' ? 'warning' : 'info'}>{getDayStatusLabel(day)}</span></td>
+                  <td>{day.collected}</td>
+                  <td>{day.absent}</td>
+                  <td class={day.total === 0 ? undefined : textClass}>{day.pct.toFixed(1)}%</td>
                   <td>
                     <progress
-                      value={Math.min(100, pct)}
+                      value={Math.min(100, day.pct)}
                       max="100"
-                      aria-label="{displayDate}: {pct.toFixed(1)}% cobertura"
+                      aria-label="{day.date}: {day.pct.toFixed(1)}% cobertura; {day.absent} tribunais ausentes"
                     ></progress>
                   </td>
+                  <td>
+                    <button
+                      type="button"
+                      class="outline secondary"
+                      disabled={day.missingTribunals.length === 0}
+                      aria-expanded={expandedDate === day.date}
+                      onclick={() => toggleDate(day.date)}
+                    >
+                      Ver ausentes ({day.missingTribunals.length})
+                    </button>
+                  </td>
                 </tr>
+                {#if expandedDate === day.date}
+                  <tr>
+                    <td colspan="7">
+                      <div class="drilldown-panel">
+                        <strong>Tribunais ausentes em {day.date}</strong>
+                        {#if day.missingTribunals.length > 0}
+                          <p>Impacto: essas siglas podem não aparecer em buscas e agregações desta data.</p>
+                          <ul class="chip-list">
+                            {#each day.missingTribunals as tribunal}
+                              <li><span class="badge" data-tone="warning">⚠ {tribunal}</span></li>
+                            {/each}
+                          </ul>
+                        {:else}
+                          <p>Nenhum tribunal ausente registrado para esta data.</p>
+                        {/if}
+                      </div>
+                    </td>
+                  </tr>
+                {/if}
               {/each}
               {#if displayDates.length === 0}
-                <tr><td colspan="5" class="empty-state">Sem dados para este mês.</td></tr>
+                <tr><td colspan="7" class="empty-state">Sem dados para este filtro neste mês.</td></tr>
               {/if}
             </tbody>
           </table>

--- a/web/src/components/TribunalDetail.svelte
+++ b/web/src/components/TribunalDetail.svelte
@@ -9,6 +9,7 @@
   import DateDetail from './DateDetail.svelte';
   import DataAccessPanel from './DataAccessPanel.svelte';
   import TribunalStatsBar from './TribunalStatsBar.svelte';
+  import { buildTribunalAttentionCards } from '../lib/coverageInsights';
 
   interface HashState {
     date: string | null;
@@ -179,6 +180,17 @@
   let syncedPct = $derived(totalForBar > 0 ? (selectedCoverage.size / totalForBar) * 100 : 0);
   let completionStatusText = $derived(isComplete ? "Concluído" : "Em andamento");
 
+  let tribunalAttentionCards = $derived(buildTribunalAttentionCards({
+    tribunal: selectedTribunal,
+    missingDays: actualMissingDays,
+    absentCount,
+    expectedDays,
+    coverageSize: selectedCoverage.size,
+    completionPct,
+    velocityRegressionPct: velocityMetrics?.regressionDrop,
+    isStopped,
+  }));
+
   let hasFeaturedPub = $derived(hashState.seq != null);
 
   let iaYear = $derived(activeDate ? parseInt(activeDate.substring(0, 4)) : new Date().getFullYear());
@@ -311,6 +323,22 @@
       {actualMissingDays}
       {genesisDate}
     />
+
+    {#if tribunalAttentionCards.length > 0}
+      <section class="auto-grid" aria-label="Atenção da cobertura do tribunal">
+        {#each tribunalAttentionCards as card}
+          <article class="attention-card" data-tone={card.tone}>
+            <header>
+              <strong><span aria-hidden="true">{card.icon}</span> {card.title}</strong>
+              <span class="badge" data-tone={card.tone}>{card.summary}</span>
+            </header>
+            <p>{card.impact}</p>
+            <p>{card.cause}</p>
+            <p><strong>{card.action}</strong></p>
+          </article>
+        {/each}
+      </section>
+    {/if}
 
     <details open>
       <summary>Calendário</summary>

--- a/web/src/components/__steps__/tribunal-detail.steps.ts
+++ b/web/src/components/__steps__/tribunal-detail.steps.ts
@@ -79,4 +79,66 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       expect(values).toContain('TRT1');
     });
   });
+
+  Scenario('Highlight tribunal coverage gap state', ({ Given, When, Then, And }) => {
+    Given('tribunal "STF" has 12 missing days and 4 absent days', () => {
+      props = makeProps('STF');
+      props.initialCoverage = { STF: ['2024-01-01', '2024-01-02'] };
+      props.initialEtas = {
+        STF: {
+          missing_days: 12,
+          absent_days_count: 4,
+          completion_pct: 14,
+          eta_days: 21,
+          genesis_date: '2024-01-01',
+        },
+      };
+      props.initialStartDates = { STF: '2024-01-01' };
+    });
+
+    When('the tribunal detail page loads', () => {
+      render(TribunalDetail, props);
+    });
+
+    Then('I should see a coverage gap attention card', () => {
+      expect(document.body.textContent).toContain('Lacuna de cobertura do tribunal');
+      expect(document.body.textContent).toContain('STF tem 12 dias sem publicação coletada');
+    });
+
+    And('I should see explanatory next action text', () => {
+      expect(document.body.textContent).toContain('Próxima ação: revisar o calendário');
+      expect(document.body.textContent).toContain('Possível causa: backfill pendente');
+    });
+  });
+
+  Scenario('Highlight tribunal anomaly state', ({ Given, When, Then, And }) => {
+    Given('tribunal "STJ" has low completion coverage', () => {
+      props = makeProps('STJ');
+      props.initialCoverage = { STJ: ['2024-01-01'] };
+      props.initialEtas = {
+        STJ: {
+          missing_days: 0,
+          absent_days_count: 0,
+          completion_pct: 20,
+          eta_days: null,
+          genesis_date: '2024-01-01',
+        },
+      };
+      props.initialStartDates = { STJ: '2024-01-01' };
+    });
+
+    When('the tribunal detail page loads', () => {
+      render(TribunalDetail, props);
+    });
+
+    Then('I should see an anomaly attention card', () => {
+      expect(document.body.textContent).toContain('Destaque de anomalia');
+    });
+
+    And('I should see the anomaly impact text', () => {
+      expect(document.body.textContent).toContain('Impacto: o tempo para concluir o histórico pode aumentar.');
+      expect(document.body.textContent).toContain('Próxima ação: comparar velocidade');
+    });
+  });
+
 });

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2039,3 +2039,100 @@ kbd {
   line-height: 1.3;
 }
 [data-theme="dark"] kbd { background: var(--papel-20); border-color: var(--border-strong); color: var(--fg-heading); }
+
+/* Coverage attention and drilldown helpers */
+.attention-card {
+  border: 1px solid var(--color-border);
+  border-left: 0.35rem solid var(--color-info);
+  background: color-mix(in srgb, var(--color-info) 5%, var(--color-surface));
+  margin-bottom: var(--space-sm);
+}
+
+.attention-card[data-tone='success'] {
+  border-left-color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 6%, var(--color-surface));
+}
+
+.attention-card[data-tone='warning'] {
+  border-left-color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 8%, var(--color-surface));
+}
+
+.attention-card[data-tone='error'] {
+  border-left-color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 7%, var(--color-surface));
+}
+
+.attention-card > header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+
+.attention-card p {
+  margin-bottom: 0.35rem;
+}
+
+.filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-block: var(--space-sm);
+  padding: 0;
+  border: 0;
+}
+
+.filter-pills legend {
+  width: 100%;
+  margin-bottom: 0.25rem;
+  font-weight: 700;
+}
+
+.filter-pills button {
+  width: auto;
+  margin: 0;
+  padding: 0.4rem 0.75rem;
+}
+
+.drilldown-panel {
+  padding: var(--space-sm);
+  background: var(--color-surface-overlay);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-box);
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding: 0;
+  margin: var(--space-xs) 0 0;
+  list-style: none;
+}
+
+.link-button {
+  width: auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--pico-primary);
+  text-decoration: underline;
+  font: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/web/src/lib/coverageInsights.ts
+++ b/web/src/lib/coverageInsights.ts
@@ -1,0 +1,230 @@
+export type CoverageFilter = 'all' | 'failed' | 'complete' | 'no-data';
+
+export interface CompletedCatalogDay {
+  tribunal_count?: number;
+  absent_count?: number;
+  tribunais_coletados?: string[];
+  tribunais_ausentes?: string[];
+  latencies?: Record<string, number>;
+}
+
+export interface CoverageDaySummary {
+  key: string;
+  date: string;
+  collected: number;
+  absent: number;
+  total: number;
+  pct: number;
+  status: 'complete' | 'failed' | 'no-data';
+  missingTribunals: string[];
+}
+
+export interface AttentionCard {
+  id: string;
+  tone: 'info' | 'success' | 'warning' | 'error';
+  icon: string;
+  title: string;
+  summary: string;
+  impact: string;
+  cause: string;
+  action: string;
+}
+
+export function summarizeCatalogDay(key: string, item: CompletedCatalogDay | undefined): CoverageDaySummary {
+  const collectedList = item?.tribunais_coletados || [];
+  const absentList = item?.tribunais_ausentes || [];
+  const collected = item?.tribunal_count ?? collectedList.length;
+  const absent = item?.absent_count ?? absentList.length;
+  const total = collected + absent;
+  const pct = total > 0 ? Math.min(100, (collected / total) * 100) : 0;
+  return {
+    key,
+    date: key.replace('djen-', ''),
+    collected,
+    absent,
+    total,
+    pct,
+    status: total === 0 ? 'no-data' : absent > 0 || pct < 100 ? 'failed' : 'complete',
+    missingTribunals: absentList,
+  };
+}
+
+export function filterCoverageDays(days: CoverageDaySummary[], filter: CoverageFilter): CoverageDaySummary[] {
+  if (filter === 'all') return days;
+  return days.filter(day => day.status === filter);
+}
+
+export function countCoverageFilters(days: CoverageDaySummary[]) {
+  return {
+    all: days.length,
+    failed: days.filter(day => day.status === 'failed').length,
+    complete: days.filter(day => day.status === 'complete').length,
+    noData: days.filter(day => day.status === 'no-data').length,
+  };
+}
+
+export function getDayStatusLabel(day: CoverageDaySummary): string {
+  if (day.status === 'complete') return '✓ Completo';
+  if (day.status === 'no-data') return '○ Sem dados';
+  return `⚠ Falha (${day.absent} ausente${day.absent === 1 ? '' : 's'})`;
+}
+
+export function buildCatalogAttentionCards(days: CoverageDaySummary[]): AttentionCard[] {
+  const cards: AttentionCard[] = [];
+  const daysWithData = days.filter(day => day.total > 0).sort((a, b) => a.date.localeCompare(b.date));
+  const noDataDays = days.filter(day => day.status === 'no-data');
+  const lowCoverageDays = daysWithData.filter(day => day.pct < 95);
+
+  if (lowCoverageDays.length > 0) {
+    const worst = [...lowCoverageDays].sort((a, b) => a.pct - b.pct)[0];
+    cards.push({
+      id: 'low-coverage',
+      tone: worst.pct < 80 ? 'error' : 'warning',
+      icon: '⚠',
+      title: 'Dias com baixa cobertura',
+      summary: `${lowCoverageDays.length} dia${lowCoverageDays.length === 1 ? '' : 's'} abaixo de 95%; pior caso ${worst.date} com ${worst.pct.toFixed(1)}%.`,
+      impact: 'Impacto: buscas e métricas podem omitir publicações desses tribunais.',
+      cause: 'Possível causa: ZIP indisponível, coleta parcial ou atraso no DJEN.',
+      action: 'Próxima ação: abrir o drilldown do dia e priorizar recoleta dos tribunais ausentes.',
+    });
+  }
+
+  const recent = daysWithData.slice(-8);
+  const latest = recent.at(-1);
+  const previous = recent.slice(0, -1);
+  if (latest && previous.length >= 3) {
+    const previousAvg = previous.reduce((sum, day) => sum + day.pct, 0) / previous.length;
+    const drop = previousAvg - latest.pct;
+    if (drop >= 10) {
+      cards.push({
+        id: 'recent-drop',
+        tone: drop >= 25 ? 'error' : 'warning',
+        icon: '↘',
+        title: 'Queda recente de cobertura',
+        summary: `${latest.date} ficou ${drop.toFixed(1)} p.p. abaixo da média recente (${previousAvg.toFixed(1)}%).`,
+        impact: 'Impacto: o dia mais recente pode parecer incompleto para usuários e relatórios.',
+        cause: 'Possível causa: lote ainda em processamento ou falha temporária de upload.',
+        action: 'Próxima ação: verificar o status do pipeline antes de fechar o dia como completo.',
+      });
+    }
+  }
+
+  const latestRun = [...days].sort((a, b) => b.date.localeCompare(a.date));
+  let persistentFailures = 0;
+  for (const day of latestRun) {
+    if (day.status !== 'failed') break;
+    persistentFailures += 1;
+  }
+  if (persistentFailures >= 3) {
+    cards.push({
+      id: 'persistent-absence',
+      tone: 'error',
+      icon: '⏱',
+      title: 'Ausência persistente',
+      summary: `${persistentFailures} dias consecutivos recentes têm tribunais ausentes.`,
+      impact: 'Impacto: a lacuna pode afetar séries históricas e alertas recorrentes.',
+      cause: 'Possível causa: integração de tribunal interrompida ou credencial/endpoint instável.',
+      action: 'Próxima ação: comparar os tribunais repetidos no drilldown e abrir tarefa de correção.',
+    });
+  }
+
+  if (noDataDays.length > 0) {
+    cards.push({
+      id: 'no-data',
+      tone: 'info',
+      icon: '○',
+      title: 'Dias sem dados registrados',
+      summary: `${noDataDays.length} dia${noDataDays.length === 1 ? '' : 's'} sem total de cobertura neste mês.`,
+      impact: 'Impacto: não há evidência suficiente para dizer se houve coleta ou ausência oficial.',
+      cause: 'Possível causa: dia fora da janela, catálogo ainda não publicado ou ingestão zerada.',
+      action: 'Próxima ação: confirmar se o dia era esperado e reprocessar o manifesto se necessário.',
+    });
+  }
+
+  if (cards.length === 0 && daysWithData.length > 0) {
+    cards.push({
+      id: 'healthy',
+      tone: 'success',
+      icon: '✓',
+      title: 'Cobertura sem anomalias fortes',
+      summary: `${daysWithData.length} dia${daysWithData.length === 1 ? '' : 's'} com cobertura completa ou dentro do esperado.`,
+      impact: 'Impacto: consultas e métricas tendem a refletir a base disponível.',
+      cause: 'Possível causa: pipeline e upload operando dentro do padrão recente.',
+      action: 'Próxima ação: manter monitoramento e revisar apenas novas quedas.',
+    });
+  }
+
+  return cards;
+}
+
+export function buildTribunalAttentionCards(params: {
+  tribunal: string;
+  missingDays: number;
+  absentCount: number;
+  expectedDays: number;
+  coverageSize: number;
+  completionPct: number;
+  velocityRegressionPct?: number;
+  isStopped?: boolean;
+}): AttentionCard[] {
+  const cards: AttentionCard[] = [];
+  const completion = params.expectedDays > 0
+    ? (params.coverageSize / params.expectedDays) * 100
+    : params.completionPct;
+
+  if (params.missingDays > 0) {
+    cards.push({
+      id: 'tribunal-gap',
+      tone: params.missingDays > 30 ? 'error' : 'warning',
+      icon: '⚠',
+      title: 'Lacuna de cobertura do tribunal',
+      summary: `${params.tribunal} tem ${params.missingDays} dia${params.missingDays === 1 ? '' : 's'} sem publicação coletada na janela monitorada.`,
+      impact: 'Impacto: pesquisas por processo, OAB ou parte podem não encontrar intimações desses dias.',
+      cause: 'Possível causa: backfill pendente, diário indisponível ou dia ainda não conciliado.',
+      action: 'Próxima ação: revisar o calendário e priorizar os dias marcados como ausentes.',
+    });
+  }
+
+  if (params.absentCount >= 3) {
+    cards.push({
+      id: 'tribunal-persistent-absence',
+      tone: 'error',
+      icon: '⏱',
+      title: 'Ausência persistente declarada',
+      summary: `${params.absentCount} dia${params.absentCount === 1 ? '' : 's'} aparecem como ausentes para ${params.tribunal}.`,
+      impact: 'Impacto: a ausência repetida reduz a confiança na completude histórica.',
+      cause: 'Possível causa: o tribunal não publicou nesses dias ou a fonte retornou vazio continuamente.',
+      action: 'Próxima ação: validar se a ausência é oficial antes de abrir recoleta.',
+    });
+  }
+
+  if ((params.velocityRegressionPct ?? 0) >= 25 || completion < 90) {
+    cards.push({
+      id: 'tribunal-anomaly',
+      tone: 'warning',
+      icon: '↘',
+      title: 'Destaque de anomalia',
+      summary: completion < 90
+        ? `Completude estimada em ${completion.toFixed(1)}% para a janela atual.`
+        : `Velocidade recente caiu ${params.velocityRegressionPct?.toFixed(0)}% contra o ritmo anterior.`,
+      impact: 'Impacto: o tempo para concluir o histórico pode aumentar.',
+      cause: 'Possível causa: desaceleração no backfill ou filas maiores de coleta.',
+      action: 'Próxima ação: comparar velocidade, cursor e dias faltantes antes de ajustar ETA.',
+    });
+  }
+
+  if (params.isStopped) {
+    cards.push({
+      id: 'tribunal-stopped',
+      tone: 'error',
+      icon: '■',
+      title: 'Pipeline interrompido',
+      summary: `${params.tribunal} foi marcado como interrompido após ausência prolongada.`,
+      impact: 'Impacto: novas buscas podem permanecer sem atualização até intervenção.',
+      cause: 'Possível causa: 60 dias sem publicações identificadas ou fonte instável.',
+      action: 'Próxima ação: confirmar a regra de parada e reativar apenas se a fonte voltou.',
+    });
+  }
+
+  return cards;
+}

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -35,6 +35,20 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </div>
   </section>
 
+  <section aria-label="Como interpretar lacunas de cobertura">
+    <div class="wrap wrap--wide">
+      <article class="attention-card" data-tone="info">
+        <header>
+          <strong>○ Cobertura e lacunas por tribunal</strong>
+          <span class="badge" data-tone="info">Status textual, contagens e calendário</span>
+        </header>
+        <p>Impacto: dias sem dados podem omitir publicações em buscas por processo, OAB ou parte.</p>
+        <p>Possível causa: ausência oficial do diário, backfill pendente ou falha temporária de coleta.</p>
+        <p><strong>Próxima ação:</strong> abra a página de um tribunal para ver cards de atenção, calendário e dias ausentes.</p>
+      </article>
+    </div>
+  </section>
+
   <!-- ═══════════ SEARCH ═══════════ -->
   <section style="padding: var(--s-7) 0 var(--s-9);">
     <div class="wrap wrap--wide">


### PR DESCRIPTION
### Motivation
- Melhorar a detectabilidade e investigabilidade de lacunas de cobertura em mapas e páginas de tribunal, reduzindo dependência apenas de cor. 
- Dar operadores instruções rápidas (impacto, possível causa, próxima ação) e permitir filtragem e drilldown por dias com falha, completos ou sem dados. 

### Description
- UI: adiciona cards de atenção, filtros rápidos, labels/ícones textuais e painel de drilldown em `TribunalCoverageHeatmap.svelte` e `LatencyHeatmap.svelte`. 
- Tribunal detail: inclui cards de atenção específicos por tribunal em `TribunalDetail.svelte` usando lógica compartilhada. 
- Shared logic: novo utilitário `web/src/lib/coverageInsights.ts` para sumarizar dias, filtrar por estado e gerar cards de atenção (baixa cobertura, queda recente, ausência persistente, sem dados, anomalia). 
- Pages & styles: adiciona explicador na página de publicações (`web/src/pages/publicacoes/index.astro`) e regras CSS para cards, filtros e drilldown em `web/src/index.css`. 
- Tests: amplia BDD em `web/features/tribunal-detail.feature` e steps em `web/src/components/__steps__/tribunal-detail.steps.ts` para cobrir estados de lacuna e anomalia. 

### Testing
- `npm run lint` (web) — OK after a small fix to `coverageInsights.ts`. 
- `npm run test -- tribunal-detail` — OK (todos os testes desse arquivo passaram). 
- `npm run test` (web) — executado; 2 cenários preexistentes falharam (não introduzidos por este PR): `admin-pr-gate` e `publicacoes` falharam por expectativas de teste específicas. 
- Svelte compile smoke-check via `svelte/compiler` para componentes alterados — OK (compilação cliente gerada). 
- `npm run typecheck` / `npm run dev` não puderam concluir no ambiente CI local porque Astro requer Node.js >= 22.12.0 (ambiente atual: Node.js v20.20.2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3ad0a7a08325b864deb1683288c7)