### PR TITLE
Improve mobile nav drawer UI and global keyboard shortcuts

### DIFF
--- a/web/src/components/CommandPalette.astro
+++ b/web/src/components/CommandPalette.astro
@@ -1,31 +1,48 @@
 ---
+const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 <dialog
   id="command-palette-dialog"
-  aria-labelledby="command-palette-title">
+  class="command-palette"
+  aria-labelledby="command-palette-title"
+  data-publicacoes-href={BASE + 'publicacoes'}>
   <article>
     <header>
-      <h3 id="command-palette-title">Atalhos de teclado</h3>
+      <h3 id="command-palette-title">Atalhos e comandos</h3>
       <form method="dialog">
         <button
           id="command-palette-close"
           class="outline"
           aria-label="Fechar diálogo">
-          ✕
+          Fechar
         </button>
       </form>
     </header>
 
     <dl>
       <div>
-        <dt>Abrir paleta de comandos / ajuda</dt>
+        <dt>Focar busca</dt>
         <dd>
           <kbd>Ctrl</kbd>
           +
           <kbd>K</kbd>
+        </dd>
+      </div>
+
+      <div>
+        <dt>Abrir atalhos e comandos</dt>
+        <dd>
+          <kbd>Ctrl</kbd>
+          +
+          <kbd>/</kbd>
           ou
           <kbd>?</kbd>
         </dd>
+      </div>
+
+      <div>
+        <dt>Ir para publicações</dt>
+        <dd><a href={BASE + 'publicacoes'}>Buscar no DJEN</a></dd>
       </div>
 
       <div>
@@ -50,40 +67,74 @@
     </dl>
 
     <footer>
-      <small>O modo de acessibilidade está sempre ativo. Use Tab para navegar pelos elementos interativos.</small>
+      <small>Use <kbd>Ctrl</kbd> + <kbd>K</kbd> apenas para busca. Use <kbd>Ctrl</kbd> + <kbd>/</kbd> ou <kbd>?</kbd> para ajuda e navegação.</small>
     </footer>
   </article>
 </dialog>
 
 <script>
   function setupCommandPalette() {
-    const dialog = document.getElementById('command-palette-dialog') as HTMLDialogElement;
+    const dialog = document.getElementById('command-palette-dialog') as HTMLDialogElement | null;
     const closeBtn = document.getElementById('command-palette-close');
 
-    if (!dialog) return;
+    if (!dialog || dialog.dataset.commandPaletteBound === 'true') return;
+    dialog.dataset.commandPaletteBound = 'true';
+
+    function isTypingInField() {
+      const active = document.activeElement as HTMLElement | null;
+      if (!active) return false;
+      return active.matches('input, textarea, select, [contenteditable="true"]');
+    }
+
+    function findSearchTarget() {
+      return document.querySelector<HTMLElement>([
+        '[data-global-search]',
+        '#publication-smart-search',
+        '#ia-search-input',
+        'form[role="search"] input[type="search"]',
+        'search input[type="search"]',
+        'input[type="search"]',
+      ].join(','));
+    }
+
+    function focusSearch() {
+      const target = findSearchTarget();
+      if (!target) {
+        window.location.href = dialog.dataset.publicacoesHref ?? '/publicacoes';
+        return;
+      }
+
+      if (dialog.open) dialog.close();
+      target.focus();
+      if (target instanceof HTMLInputElement) target.select();
+    }
 
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+      const key = e.key.toLowerCase();
+      const hasCommandModifier = e.ctrlKey || e.metaKey;
+
+      if (hasCommandModifier && key === 'k') {
         e.preventDefault();
-        const searchInput = document.getElementById('ia-search-input');
-        if (searchInput && document.activeElement !== searchInput) {
-          searchInput.focus();
-        } else {
-          toggleDialog();
-        }
-      } else if (e.key === '?' && !['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName ?? '')) {
+        focusSearch();
+        return;
+      }
+
+      if ((hasCommandModifier && e.key === '/') || (e.key === '?' && !isTypingInField())) {
         e.preventDefault();
         toggleDialog();
-      } else if (e.key === 'Escape' && dialog.open) {
+        return;
+      }
+
+      if (e.key === 'Escape' && dialog.open) {
         dialog.close();
       }
     }
 
     function toggleDialog() {
-      if (dialog.open) {
+      if (dialog?.open) {
         dialog.close();
       } else {
-        dialog.showModal();
+        dialog?.showModal();
       }
     }
 
@@ -96,6 +147,7 @@
     // Cleanup logic for View Transitions
     document.addEventListener('astro:before-swap', () => {
       document.removeEventListener('keydown', handleKeyDown);
+      delete dialog.dataset.commandPaletteBound;
     }, { once: true });
   }
 

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -89,13 +89,26 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
         </li>
         <li><ThemeToggle /></li>
         <li class="mobile-only">
-          <button class="btn-menu" aria-label="Abrir menu de navegação" aria-haspopup="dialog"
-            onclick={`document.getElementById('nav-drawer-${drawerIdSuffix}').showModal()`}>
+          <button
+            class="btn-menu"
+            aria-label="Abrir menu de navegação"
+            aria-haspopup="dialog"
+            aria-controls={`nav-drawer-${drawerIdSuffix}`}
+            data-nav-drawer-trigger
+            type="button">
             <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
               <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <dialog id={`nav-drawer-${drawerIdSuffix}`} class="nav-drawer">
+          <dialog id={`nav-drawer-${drawerIdSuffix}`} class="nav-drawer" aria-labelledby={`nav-drawer-title-${drawerIdSuffix}`}>
+            <div class="nav-drawer__header">
+              <h2 id={`nav-drawer-title-${drawerIdSuffix}`}>Menu</h2>
+              <button class="nav-drawer__close" type="button" data-nav-drawer-close>Fechar</button>
+            </div>
+            <a href={BASE + 'publicacoes'} class="nav-drawer__primary">
+              <span>Buscar publicações</span>
+              <small>Pesquisa pública no DJEN · Ctrl+K</small>
+            </a>
             <ul>
               <li class="menu-title">Principal</li>
               {primaryLinks.map(link => (
@@ -171,13 +184,26 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
         </li>
         <li><ThemeToggle /></li>
         <li class="mobile-only">
-          <button class="btn-menu" aria-label="Abrir menu de navegação" aria-haspopup="dialog"
-            onclick={`document.getElementById('nav-drawer-${drawerIdSuffix}').showModal()`}>
+          <button
+            class="btn-menu"
+            aria-label="Abrir menu de navegação"
+            aria-haspopup="dialog"
+            aria-controls={`nav-drawer-${drawerIdSuffix}`}
+            data-nav-drawer-trigger
+            type="button">
             <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
               <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <dialog id={`nav-drawer-${drawerIdSuffix}`} class="nav-drawer">
+          <dialog id={`nav-drawer-${drawerIdSuffix}`} class="nav-drawer" aria-labelledby={`nav-drawer-title-${drawerIdSuffix}`}>
+            <div class="nav-drawer__header">
+              <h2 id={`nav-drawer-title-${drawerIdSuffix}`}>Menu</h2>
+              <button class="nav-drawer__close" type="button" data-nav-drawer-close>Fechar</button>
+            </div>
+            <a href={BASE + 'publicacoes'} class="nav-drawer__primary">
+              <span>Buscar publicações</span>
+              <small>Pesquisa pública no DJEN · Ctrl+K</small>
+            </a>
             <ul>
               <li><a href={BASE}>Início</a></li>
               <li role="separator" class="drawer-divider" aria-hidden="true"></li>
@@ -204,14 +230,40 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
 )}
 
 <script>
-  function bindDrawerBackdropClicks() {
-    document.querySelectorAll<HTMLDialogElement>('dialog.nav-drawer').forEach(dialog => {
-      if (dialog.dataset.backdropBound === 'true') return;
+  const drawerOpeners = new WeakMap<HTMLDialogElement, HTMLElement>();
 
-      dialog.dataset.backdropBound = 'true';
+  function returnFocusToDrawerOpener(dialog: HTMLDialogElement) {
+    const opener = drawerOpeners.get(dialog);
+    if (!opener || !document.contains(opener)) return;
+    opener.focus();
+  }
+
+  function bindDrawerControls() {
+    document.querySelectorAll<HTMLButtonElement>('[data-nav-drawer-trigger]').forEach(trigger => {
+      if (trigger.dataset.drawerTriggerBound === 'true') return;
+
+      trigger.dataset.drawerTriggerBound = 'true';
+      trigger.addEventListener('click', () => {
+        const drawerId = trigger.getAttribute('aria-controls');
+        const dialog = drawerId ? document.getElementById(drawerId) as HTMLDialogElement | null : null;
+        if (!dialog) return;
+
+        drawerOpeners.set(dialog, trigger);
+        dialog.showModal();
+      });
+    });
+
+    document.querySelectorAll<HTMLDialogElement>('dialog.nav-drawer').forEach(dialog => {
+      if (dialog.dataset.drawerBound === 'true') return;
+
+      dialog.dataset.drawerBound = 'true';
       dialog.addEventListener('click', (e) => {
         if (e.target === dialog) dialog.close();
       });
+      dialog.querySelectorAll<HTMLButtonElement>('[data-nav-drawer-close]').forEach(button => {
+        button.addEventListener('click', () => dialog.close());
+      });
+      dialog.addEventListener('close', () => returnFocusToDrawerOpener(dialog));
     });
   }
 
@@ -234,15 +286,15 @@ const drawerIdSuffix = variant === 'home' ? 'home' : 'page';
     });
   }
 
-  bindDrawerBackdropClicks();
+  bindDrawerControls();
 
   if (!(window as any).__navHandlersBound) {
     (window as any).__navHandlersBound = true;
     setupNavHandlers();
   }
 
-  // Re-bind dialog backdrop clicks after Astro view transitions
+  // Re-bind dialog controls after Astro view transitions
   document.addEventListener('astro:page-load', () => {
-    bindDrawerBackdropClicks();
+    bindDrawerControls();
   });
 </script>

--- a/web/src/components/IASearchBar.svelte
+++ b/web/src/components/IASearchBar.svelte
@@ -104,7 +104,7 @@
   }
 
   function handleGlobalKeydown(e: KeyboardEvent) {
-    if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== 'k') return;
+    if (e.defaultPrevented || !(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== 'k') return;
 
     const commandPalette = document.getElementById('command-palette-dialog') as HTMLDialogElement | null;
     if (commandPalette?.open) return;
@@ -129,6 +129,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" /></svg>
       <input
         id="ia-search-input"
+        data-global-search
         bind:this={inputRef}
         type="search"
         value={query}

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -240,12 +240,10 @@
   // Global keydown for Ctrl+K
   onMount(() => {
     function handleGlobalKeydown(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
-        e.preventDefault();
-        if (searchInputRef) {
-          searchInputRef.focus();
-        }
-      }
+      if (e.defaultPrevented || !(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== 'k') return;
+
+      e.preventDefault();
+      searchInputRef?.focus();
     }
     window.addEventListener('keydown', handleGlobalKeydown);
     return () => {

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -38,6 +38,7 @@
     </svg>
     <input
       id="publication-smart-search"
+      data-global-search
       type="search"
       bind:this={inputRef}
       bind:value

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -792,13 +792,60 @@ dialog.nav-drawer {
   left: auto;
   top: 0;
   bottom: 0;
-  width: 20rem;
+  width: min(22rem, 92vw);
   height: 100%;
   max-height: 100%;
   margin: 0;
   padding: var(--space-4);
   border-radius: var(--pico-border-radius) 0 0 var(--pico-border-radius);
   overflow-y: auto;
+}
+
+.nav-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.nav-drawer__header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.nav-drawer__close {
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-base-300);
+  border-radius: var(--radius-btn);
+  background: transparent;
+  color: var(--color-base-content);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.nav-drawer__close:hover,
+.nav-drawer__close:focus-visible {
+  background: var(--color-base-200);
+}
+
+.nav-drawer__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 35%, transparent);
+  border-radius: var(--radius-box);
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  font-weight: 700;
+}
+
+.nav-drawer__primary small {
+  color: var(--color-content-tertiary);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
 }
 
 dialog.nav-drawer > ul {
@@ -817,6 +864,12 @@ dialog.nav-drawer a {
   font-size: var(--font-size-sm);
   text-decoration: none;
   color: var(--color-base-content);
+}
+
+dialog.nav-drawer a.nav-drawer__primary {
+  display: flex;
+  padding: var(--space-3);
+  border-radius: var(--radius-box);
 }
 
 dialog.nav-drawer a:hover     { background: var(--color-base-300); }
@@ -2020,6 +2073,60 @@ details.filter-group > summary:hover > h4 { color: var(--fg-heading); }
 [data-theme="dark"] .reader { background: var(--papel-00); border-left-color: var(--border-strong); }
 [data-theme="dark"] .reader__head { background: var(--papel-20); color: var(--fg-heading); border-bottom-color: var(--ocre); }
 [data-theme="dark"] .reader__meta-grid { background: var(--papel-20); border-color: var(--border); }
+
+/* ════════════════════════════════════════════════════════
+   Global command palette
+   ════════════════════════════════════════════════════════ */
+.command-palette {
+  width: min(38rem, calc(100vw - 2rem));
+  padding: 0;
+  border-radius: var(--radius-box);
+}
+
+.command-palette article {
+  margin: 0;
+}
+
+.command-palette header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.command-palette header h3 {
+  margin: 0;
+}
+
+.command-palette dl {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.command-palette dl > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-base-300);
+}
+
+.command-palette dt {
+  color: var(--color-base-content);
+  font-weight: 600;
+}
+
+.command-palette dd {
+  margin: 0;
+  color: var(--color-content-tertiary);
+  text-align: right;
+}
+
+.command-palette footer {
+  margin-top: var(--space-4);
+}
 
 /* ════════════════════════════════════════════════════════
    kbd badges

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../index.css';
 import { ClientRouter } from 'astro:transitions';
 import Footer from '../components/Footer.astro';
 import NetworkStatusBanner from '../components/NetworkStatusBanner.astro';
+import CommandPalette from '../components/CommandPalette.astro';
 
 interface Props {
   title: string;
@@ -79,6 +80,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     <main id="main-content" class:list={[{ container: !fullWidth }]}>
       <slot />
     </main>
+    <CommandPalette />
     <Footer />
   </body>
 </html>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -36,6 +36,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <fieldset role="group">
           <input
             class="input hero__search-input"
+            data-global-search
             name="texto"
             type="search"
             placeholder="0001234-56.2024.8.26.0100  ·  OAB/SP 245.812  ·  texto livre"


### PR DESCRIPTION
### Motivation
- Mobile navigation lacked a clear header and explicit close control, and the primary search entry was not prominent in the drawer. 
- The command palette component was present but not mounted globally, and `Ctrl+K` handling was duplicated across components causing potential conflicts. 
- Need consistent, accessible behavior when opening/closing drawers and restoring focus to the opener.

### Description
- Header/drawer UI: added a `Menu` header and a `Fechar` button inside `dialog.nav-drawer`, and a highlighted primary link to `publicacoes` (`Buscar publicações`) in both drawer variants, with associated styles in `web/src/index.css`. (files: `web/src/components/Header.astro`, `web/src/index.css`).
- Drawer behavior: removed inline `onclick` open calls and added `data-nav-drawer-trigger`/`aria-controls` on the opener; implemented `WeakMap` to track the opener and restore focus on dialog `close`, and wired the close button/backdrop to call `dialog.close()` (file: `web/src/components/Header.astro`).
- Command palette & shortcuts: mounted `CommandPalette` in the global layout, made the palette handle `Ctrl+/` and `?` for help/commands, standardized `Ctrl+K` as global search focus, and updated `CommandPalette` to locate `[data-global-search]` or known search inputs and fallback to `/publicacoes` (files: `web/src/components/CommandPalette.astro`, `web/src/layouts/Layout.astro`).
- Inputs and handlers: marked main search fields with `data-global-search` and updated per-component `Ctrl+K` listeners to respect `event.defaultPrevented` so only one handler responds (files: `web/src/components/SmartSearchInput.svelte`, `web/src/components/IASearchBar.svelte`, `web/src/components/PublicationSearch.svelte`, `web/src/pages/index.astro`).

### Testing
- Ran `npm run lint` (ESLint) — passed without errors. 
- Ran `git diff --check` — no whitespace/merge issues detected. 
- Attempted `npm run typecheck` (Astro check), but it failed in this environment due to Node.js being `v20.20.2` while Astro requires `>=22.12.0`; typecheck should be re-run on CI or a dev machine with a supported Node version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3ac2c2e08325be222e81d9674cc4)