### PR TITLE
Refatorar `PublicationCard` em componentes menores e adicionar realce de termos

### DIFF
--- a/web/src/components/PublicationActions.svelte
+++ b/web/src/components/PublicationActions.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  export type PublicationActionContext = "main" | "reader" | "compact";
+
+  let {
+    link,
+    activeCopied = null,
+    shareContext,
+    shareLabel = "Compartilhar",
+    copiedLabel = "Copiado!",
+    onShare,
+    showClose = false,
+    onClose,
+    showReader = false,
+    onOpenReader,
+    showBack = false,
+    onBack,
+    showNavigation = false,
+    seq,
+    totalSeq,
+    onNavigate,
+    ariaLabel = "Ações da publicação",
+  }: {
+    link?: string;
+    activeCopied?: PublicationActionContext | null;
+    shareContext: PublicationActionContext;
+    shareLabel?: string;
+    copiedLabel?: string;
+    onShare: (event: MouseEvent, context: PublicationActionContext) => void;
+    showClose?: boolean;
+    onClose?: () => void;
+    showReader?: boolean;
+    onOpenReader?: () => void;
+    showBack?: boolean;
+    onBack?: () => void;
+    showNavigation?: boolean;
+    seq?: number;
+    totalSeq?: number;
+    onNavigate?: (newSeq: number) => void;
+    ariaLabel?: string;
+  } = $props();
+</script>
+
+{#snippet shareIcon()}
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+  </svg>
+{/snippet}
+
+{#snippet openExternalIcon()}
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M14 3h7m0 0v7m0-7L10 14" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21 14v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+  </svg>
+{/snippet}
+
+<div class="publication-actions" aria-label={ariaLabel}>
+  {#if showClose && onClose}
+    <button type="button" class="outline secondary" onclick={onClose} title="Fechar detalhes">
+      Fechar
+    </button>
+  {/if}
+
+  {#if showBack && onBack}
+    <button type="button" class="outline secondary" onclick={onBack} title="Sair do Modo Leitura">
+      Voltar
+    </button>
+  {/if}
+
+  {#if showReader && onOpenReader}
+    <button type="button" class="outline" onclick={onOpenReader} title="Abrir Modo Leitura">
+      Modo Leitura
+    </button>
+  {/if}
+
+  {#if link}
+    <a class="outline secondary" href={link} target="_blank" rel="noopener noreferrer">
+      {@render openExternalIcon()}
+      Inteiro teor
+    </a>
+  {/if}
+
+  <div class="nav-actions" aria-label="Ações de navegação">
+    {#if showNavigation && onNavigate && seq != null}
+      <button
+        type="button"
+        class="outline secondary"
+        onclick={() => onNavigate?.(seq - 1)}
+        disabled={seq <= 1}
+      >
+        Anterior
+      </button>
+      <button
+        type="button"
+        class="outline secondary"
+        onclick={() => onNavigate?.(seq + 1)}
+        disabled={totalSeq != null && seq >= totalSeq}
+      >
+        Próxima
+      </button>
+    {/if}
+
+    <button
+      type="button"
+      class="outline secondary"
+      onclick={(event: MouseEvent) => onShare(event, shareContext)}
+      title="Copiar link"
+    >
+      {@render shareIcon()}
+      {activeCopied === shareContext ? copiedLabel : shareLabel}
+    </button>
+  </div>
+</div>

--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -1,196 +1,23 @@
 <script lang="ts">
   import type { DjenPublication } from "../lib/djen";
-
-  interface HighlightTerm {
-    text: string;
-    type: "party" | "lawyer";
-  }
-
-  interface MetaChip {
-    label: string;
-    value: string;
-    tone?: "default" | "accent" | "success" | "warning" | "danger";
-  }
-
-  function formatProcessNumber(raw: string | undefined | null): string | null {
-    if (!raw) return null;
-    if (raw.includes("-")) return raw;
-    const digits = raw.replace(/\D/g, "");
-    if (digits.length === 20) {
-      return `${digits.slice(0, 7)}-${digits.slice(7, 9)}.${digits.slice(9, 13)}.${digits.slice(13, 14)}.${digits.slice(14, 16)}.${digits.slice(16, 20)}`;
-    }
-    return raw;
-  }
-
-  function parseText(text: string | undefined | null): string[] {
-    if (!text) return [];
-    const markers =
-      /(?=(?:Processo\s*:|Classe\s*:|INTIMA(?:ÇÃO|CAO)|CITA(?:ÇÃO|CAO)|DESPACHO|DECIS(?:ÃO|AO)|SENTEN(?:ÇA|CA)|EDITAL|Designada\s+AUDI(?:ÊNCIA|ENCIA)|DATA\s+E\s+HORA))/gi;
-    const parts = text
-      .split(markers)
-      .map((part) => part.trim())
-      .filter(Boolean);
-    return parts.length > 1 ? parts : [text];
-  }
-
-  function escapeRegExp(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  }
-
-  function highlightText(
-    part: string,
-    terms: HighlightTerm[],
-  ): { token: string; type?: "party" | "lawyer" }[] {
-    if (terms.length === 0) {
-      return [{ token: part }];
-    }
-
-    const sortedTerms = [...terms].sort((a, b) => b.text.length - a.text.length);
-    const termMap = new Map<string, "party" | "lawyer">();
-    sortedTerms.forEach((term) => termMap.set(term.text.toLowerCase(), term.type));
-
-    const pattern = sortedTerms.map((term) => escapeRegExp(term.text)).join("|");
-    const regex = new RegExp(`(${pattern})`, "gi");
-
-    return part.split(regex).map((token) => {
-      const type = termMap.get(token.toLowerCase());
-      return type ? { token, type } : { token };
-    });
-  }
-
-  function buildTerms(pub: DjenPublication): HighlightTerm[] {
-    const terms: HighlightTerm[] = [];
-
-    pub.destinatarios?.forEach((destinatario) => {
-      if (destinatario.nome && destinatario.nome.length > 3) {
-        terms.push({ text: destinatario.nome, type: "party" });
-      }
-    });
-
-    pub.destinatarioadvogados?.forEach((entry) => {
-      if (entry.advogado?.nome && entry.advogado.nome.length > 3) {
-        terms.push({ text: entry.advogado.nome, type: "lawyer" });
-      }
-    });
-
-    return terms;
-  }
-
-  function previewText(text: string | undefined, limit = 320): string | null {
-    if (!text) return null;
-    const cleaned = text.replace(/\s+/g, " ").trim();
-    if (cleaned.length <= limit) return cleaned;
-    return `${cleaned.slice(0, limit).trimEnd()}...`;
-  }
-
-  function htmlToPreviewText(html: string | undefined, limit = 320): string | null {
-    if (!html) return null;
-
-    const text = html
-      .replace(/<br\s*\/?>/gi, " ")
-      .replace(/<\/(p|div|li|tr|td|th|h[1-6])>/gi, " ")
-      .replace(/<[^>]+>/g, " ")
-      .replace(/&nbsp;/gi, " ")
-      .replace(/&amp;/gi, "&")
-      .replace(/&lt;/gi, "<")
-      .replace(/&gt;/gi, ">")
-      .replace(/&quot;/gi, '"')
-      .replace(/&#39;/gi, "'");
-
-    return previewText(text, limit);
-  }
-
-  function summarizeMedium(pub: DjenPublication): string | null {
-    if (pub.meiocompleto) return pub.meiocompleto;
-    if (pub.meio === "D") return "Diário Eletrônico";
-    if (pub.meio === "E") return "Edital";
-    return null;
-  }
-
-  function summarizeStatus(pub: DjenPublication): MetaChip | null {
-    if (pub.ativo === false || pub.motivo_cancelamento) {
-      return { label: "Status", value: "Cancelada", tone: "danger" };
-    }
-    if (pub.status === "P") {
-      return { label: "Status", value: "Publicada", tone: "success" };
-    }
-    if (pub.status) {
-      return { label: "Status", value: pub.status, tone: "warning" };
-    }
-    if (pub.ativo === true) {
-      return { label: "Status", value: "Ativa", tone: "success" };
-    }
-    return null;
-  }
-
-  function buildMetaChips(pub: DjenPublication): MetaChip[] {
-    const chips: MetaChip[] = [];
-    const statusChip = summarizeStatus(pub);
-    const medium = summarizeMedium(pub);
-
-    if (statusChip) chips.push(statusChip);
-    if (pub.siglaTribunal) chips.push({ label: "Tribunal", value: pub.siglaTribunal });
-    if (medium) chips.push({ label: "Meio", value: medium, tone: "accent" });
-    if (pub.nomeClasse) chips.push({ label: "Classe", value: pub.nomeClasse });
-    if (pub.tipoDocumento) chips.push({ label: "Documento", value: pub.tipoDocumento });
-    if (pub.numeroComunicacao != null) {
-      chips.push({ label: "Comunicação", value: String(pub.numeroComunicacao) });
-    }
-
-    return chips;
-  }
-
-  function buildIdentityRows(pub: DjenPublication): MetaChip[] {
-    const rows: MetaChip[] = [];
-
-    if (pub.data_disponibilizacao) {
-      rows.push({ label: "Disponibilização", value: pub.data_disponibilizacao });
-    }
-    if (pub.codigoClasse) {
-      rows.push({ label: "Código da classe", value: pub.codigoClasse });
-    }
-    if (pub.hash) {
-      rows.push({ label: "Hash", value: pub.hash.slice(0, 16) });
-    }
-    if (pub.numeroprocessocommascara && pub.numeroprocessocommascara !== pub.numero_processo) {
-      rows.push({ label: "Processo mascarado", value: pub.numeroprocessocommascara });
-    }
-
-    return rows;
-  }
-
-  function uniquePartyNames(pub: DjenPublication): string[] {
-    const seen = new Set<string>();
-    const names: string[] = [];
-
-    pub.destinatarios?.forEach((destinatario) => {
-      if (!destinatario.nome) return;
-      const key = destinatario.nome.trim().toLowerCase();
-      if (!key || seen.has(key)) return;
-      seen.add(key);
-      names.push(destinatario.nome);
-    });
-
-    return names;
-  }
-
-  function uniqueLawyers(pub: DjenPublication): string[] {
-    const seen = new Set<string>();
-    const lawyers: string[] = [];
-
-    pub.destinatarioadvogados?.forEach((entry) => {
-      const advogado = entry.advogado;
-      if (!advogado?.nome) return;
-      const oab = advogado.numero_oab ? `OAB ${advogado.uf_oab ?? ""} ${advogado.numero_oab}`.trim() : null;
-      const label = oab ? `${advogado.nome} (${oab})` : advogado.nome;
-      const key = label.toLowerCase();
-      if (seen.has(key)) return;
-      seen.add(key);
-      lawyers.push(label);
-    });
-
-    return lawyers;
-  }
+  import {
+    buildEntityTerms,
+    buildIdentityRows,
+    buildMetaChips,
+    buildSearchTerms,
+    formatProcessNumber,
+    htmlToPreviewText,
+    parseText,
+    previewText,
+    uniqueLawyers,
+    uniquePartyNames,
+    type HighlightTerm,
+    type MetaChip,
+  } from "../lib/publicationPresentation";
+  import PublicationActions, { type PublicationActionContext } from "./PublicationActions.svelte";
+  import PublicationDetailPanel from "./PublicationDetailPanel.svelte";
+  import PublicationReader from "./PublicationReader.svelte";
+  import PublicationResultItem from "./PublicationResultItem.svelte";
 
   let {
     pub,
@@ -204,6 +31,7 @@
     onCollapse,
     source,
     usedFallback,
+    highlightTerms = [],
   }: {
     pub: DjenPublication;
     seq: number;
@@ -216,10 +44,11 @@
     onCollapse?: () => void;
     source?: "djen" | "ia";
     usedFallback?: boolean;
+    highlightTerms?: string[];
   } = $props();
 
   let isReaderMode = $state(false);
-  let activeCopied = $state<"main" | "reader" | "compact" | null>(null);
+  let activeCopied = $state<PublicationActionContext | null>(null);
   let shareTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   $effect(() => {
@@ -230,15 +59,18 @@
 
   const processNumber = $derived(formatProcessNumber(pub.numero_processo));
   const textParts = $derived(pub.textoRender?.kind === "text" ? parseText(pub.textoRender.content) : []);
-  const terms = $derived(buildTerms(pub));
+  const terms = $derived<HighlightTerm[]>([
+    ...buildSearchTerms(highlightTerms),
+    ...buildEntityTerms(pub),
+  ]);
   const teaser = $derived(
     pub.textoRender?.kind === "text" ? previewText(pub.textoRender.content, compact ? 220 : 420) : null,
   );
   const htmlTeaser = $derived(
     pub.textoRender?.kind === "html" ? htmlToPreviewText(pub.textoRender.content, compact ? 220 : 420) : null,
   );
-  const metaChips = $derived(buildMetaChips(pub));
-  const identityRows = $derived(buildIdentityRows(pub));
+  const metaChips = $derived<MetaChip[]>(buildMetaChips(pub));
+  const identityRows = $derived<MetaChip[]>(buildIdentityRows(pub));
   const parties = $derived(uniquePartyNames(pub));
   const lawyers = $derived(uniqueLawyers(pub));
 
@@ -267,7 +99,7 @@
     }
   }
 
-  async function handleShare(e: MouseEvent, context: "main" | "reader" | "compact") {
+  async function handleShare(e: MouseEvent, context: PublicationActionContext) {
     e.preventDefault();
     e.stopPropagation();
     const base = window.location.pathname;
@@ -286,27 +118,14 @@
   }
 </script>
 
-{#snippet shareIcon()}
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-  </svg>
-{/snippet}
-
-{#snippet openExternalIcon()}
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M14 3h7m0 0v7m0-7L10 14" />
-    <path stroke-linecap="round" stroke-linejoin="round" d="M21 14v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-  </svg>
-{/snippet}
-
 {#snippet sourceBadge()}
   {#if source}
     <span
       class="badge"
-      data-tone={source === 'djen' ? 'info' : 'warning'}
-      title={usedFallback ? 'Falha ao conectar no DJEN, usando arquivo IA' : ''}
+      data-tone={source === "djen" ? "info" : "warning"}
+      title={usedFallback ? "Falha ao conectar no DJEN, usando arquivo IA" : ""}
     >
-      Fonte: {source === 'djen' ? 'DJEN' : 'Arquivo IA'}
+      Fonte: {source === "djen" ? "DJEN" : "Arquivo IA"}
     </span>
   {/if}
 {/snippet}
@@ -319,200 +138,41 @@
 {/snippet}
 
 {#if compact}
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <article
-    class:expandable={!!onExpand}
-    id={`pub-${seq}`}
-    role={onExpand ? "button" : undefined}
-    tabindex={onExpand ? 0 : undefined}
-    onclick={(e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest("a, button")) return;
-      onExpand?.();
-    }}
-    onkeydown={(e: KeyboardEvent) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onExpand?.();
-      }
-    }}
-  >
-    <header>
-      <span class="seq-number">#{seq}</span>
-      {#if pub.tipoComunicacao}
-        <span class="badge publication-badge">{pub.tipoComunicacao}</span>
-      {/if}
-      {@render sourceBadge()}
-      <small><time>{dateStr}</time></small>
-      {#if processNumber}
-        <button
-          type="button"
-          class="process-number process-number-lg process-link"
-          onclick={(e: MouseEvent) => { e.stopPropagation(); onExpand?.(); }}
-          title="Abrir detalhes da publicação"
-        >{processNumber}</button>
-      {/if}
-    </header>
-
-    {#if metaChips.length > 0}
-      <div class="meta-chip-row">
-        {#each metaChips as meta}
-          {@render chip(meta)}
-        {/each}
-      </div>
-    {/if}
-
-    {#if pub.nomeOrgao}
-      <small class="orgao-name">{pub.nomeOrgao}</small>
-    {/if}
-
-    {#if pub.textoRender?.kind === "html" && htmlTeaser}
-      <p class="text-preview">{htmlTeaser}</p>
-    {:else if teaser}
-      <p class="text-preview">{teaser}</p>
-    {/if}
-
-    <div class="summary-bar">
-      {#if parties.length > 0}
-        <span>{parties.length} parte{parties.length > 1 ? "s" : ""}</span>
-      {/if}
-      {#if lawyers.length > 0}
-        <span>{lawyers.length} advogado{lawyers.length > 1 ? "s" : ""}</span>
-      {/if}
-    </div>
-
-    {#if parties.length > 0}
-      <div class="tags-row">
-        {#each parties.slice(0, 4) as party}
-          <span class="name-pill">{party}</span>
-        {/each}
-      </div>
-    {/if}
-
-    <footer>
-      {#if pub.link}
-        <a class="outline secondary" href={pub.link} target="_blank" rel="noopener noreferrer" role="button">
-          {@render openExternalIcon()}
-          Inteiro teor
-        </a>
-      {/if}
-      <button
-        type="button"
-        class="outline secondary"
-        onclick={(e: MouseEvent) => handleShare(e, "compact")}
-        title="Copiar link"
-      >
-        {@render shareIcon()}
-        {activeCopied === "compact" ? "Copiado!" : "Link"}
-      </button>
-    </footer>
-  </article>
+  <PublicationResultItem
+    {pub}
+    {seq}
+    {dateStr}
+    {source}
+    {usedFallback}
+    {processNumber}
+    {metaChips}
+    {parties}
+    {lawyers}
+    {teaser}
+    {htmlTeaser}
+    {terms}
+    {activeCopied}
+    {onExpand}
+    onShare={handleShare}
+  />
 {:else if isReaderMode}
-  <article class="reader-mode" id={`pub-${seq}`}>
-    <header>
-      <div>
-        <span class="seq-number seq-bold">#{seq}</span>
-        <span class="badge publication-badge">Modo Leitura</span>
-        {@render sourceBadge()}
-        <small><time>{dateStr}</time></small>
-      </div>
-      {#if processNumber}
-        <h2 class="process-number process-number-xl">{processNumber}</h2>
-      {/if}
-      {#if pub.nomeOrgao}
-        <p class="orgao-name-reader">{pub.nomeOrgao}</p>
-      {/if}
-      <div aria-label="Ações de navegação e leitura">
-        <button
-          type="button"
-          class="outline secondary"
-          onclick={() => (isReaderMode = false)}
-          title="Sair do Modo Leitura"
-        >
-          Voltar
-        </button>
-        {#if pub.link}
-          <a class="outline secondary" href={pub.link} target="_blank" rel="noopener noreferrer">
-            {@render openExternalIcon()}
-            Inteiro teor
-          </a>
-        {/if}
-        <button
-          type="button"
-          class="outline secondary"
-          onclick={(e: MouseEvent) => handleShare(e, "reader")}
-          title="Copiar link"
-        >
-          {@render shareIcon()}
-          {activeCopied === "reader" ? "Copiado!" : "Compartilhar"}
-        </button>
-      </div>
-    </header>
-
-    {#if metaChips.length > 0}
-      <div class="meta-chip-row meta-chip-row-spacious">
-        {#each metaChips as meta}
-          {@render chip(meta)}
-        {/each}
-      </div>
-    {/if}
-
-    <div class="reader-layout">
-      <aside class="reader-sidebar">
-        {#if identityRows.length > 0}
-          <div class="sidebar-panel">
-            <strong class="sidebar-title">Metadados</strong>
-            <dl>
-              {#each identityRows as item}
-                <div>
-                  <dt>{item.label}</dt>
-                  <dd>{item.value}</dd>
-                </div>
-              {/each}
-            </dl>
-          </div>
-        {/if}
-
-        <div class="sidebar-panel">
-          <strong class="sidebar-title">Envolvidos</strong>
-          <div class="sidebar-tags">
-            {#if parties.length > 0}
-              {#each parties as party}
-                <span class="name-pill">{party}</span>
-              {/each}
-            {/if}
-            {#if lawyers.length > 0}
-              {#each lawyers as lawyer}
-                <span class="name-pill" data-tone="info">{lawyer}</span>
-              {/each}
-            {/if}
-          </div>
-        </div>
-      </aside>
-
-      <div class="reader-content">
-        {#if pub.textoRender?.kind === "html"}
-          <div>
-            {@html pub.textoRender.content}
-          </div>
-        {:else if textParts.length > 0}
-          <div class="reader-text">
-            {#each textParts as part}
-              <p class="reader-paragraph">
-                {#each highlightText(part, terms) as segment}
-                  {#if segment.type}
-                    <mark class={segment.type === "party" ? "entity-party" : "entity-lawyer"}>{segment.token}</mark>
-                  {:else}
-                    {segment.token}
-                  {/if}
-                {/each}
-              </p>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    </div>
-  </article>
+  <PublicationReader
+    {pub}
+    {seq}
+    {dateStr}
+    {source}
+    {usedFallback}
+    {processNumber}
+    {metaChips}
+    {identityRows}
+    {parties}
+    {lawyers}
+    {textParts}
+    {terms}
+    {activeCopied}
+    onBack={() => (isReaderMode = false)}
+    onShare={handleShare}
+  />
 {:else}
   <article id={`pub-${seq}`}>
     <header>
@@ -530,61 +190,21 @@
       {#if pub.nomeOrgao}
         <small class="orgao-name-block">{pub.nomeOrgao}</small>
       {/if}
-      <div aria-label="Ações de navegação e leitura">
-        {#if onCollapse}
-          <button
-            type="button"
-            class="outline secondary"
-            onclick={onCollapse}
-            title="Fechar detalhes"
-          >
-            Fechar
-          </button>
-        {/if}
-        <button
-          type="button"
-          class="outline"
-          onclick={() => (isReaderMode = true)}
-          title="Abrir Modo Leitura"
-        >
-          Modo Leitura
-        </button>
-        {#if pub.link}
-          <a class="outline secondary" href={pub.link} target="_blank" rel="noopener noreferrer">
-            {@render openExternalIcon()}
-            Inteiro teor
-          </a>
-        {/if}
-        <div class="nav-actions" aria-label="Ações de navegação">
-          {#if onNavigate}
-            <button
-              type="button"
-              class="outline secondary"
-              onclick={() => onNavigate(seq - 1)}
-              disabled={seq <= 1}
-            >
-              Anterior
-            </button>
-            <button
-              type="button"
-              class="outline secondary"
-              onclick={() => onNavigate(seq + 1)}
-              disabled={totalSeq != null && seq >= totalSeq}
-            >
-              Próxima
-            </button>
-          {/if}
-          <button
-            type="button"
-            class="outline secondary"
-            onclick={(e: MouseEvent) => handleShare(e, "main")}
-            title="Copiar link"
-          >
-            {@render shareIcon()}
-            {activeCopied === "main" ? "Copiado!" : "Compartilhar"}
-          </button>
-        </div>
-      </div>
+      <PublicationActions
+        link={pub.link}
+        {activeCopied}
+        shareContext="main"
+        onShare={handleShare}
+        showClose={!!onCollapse}
+        onClose={onCollapse}
+        showReader
+        onOpenReader={() => (isReaderMode = true)}
+        showNavigation={!!onNavigate}
+        {onNavigate}
+        {seq}
+        {totalSeq}
+        ariaLabel="Ações de navegação e leitura"
+      />
     </header>
 
     {#if metaChips.length > 0}
@@ -595,62 +215,13 @@
       </div>
     {/if}
 
-    <div class="story-grid">
-      <section>
-        {#if teaser}
-          <p>{teaser}</p>
-        {/if}
-
-        {#if pub.textoRender?.kind === "html"}
-          <div>
-            {@html pub.textoRender.content}
-          </div>
-        {:else if textParts.length > 0}
-          <div class="text-section">
-            {#each textParts.slice(0, 3) as part}
-              <p class="text-preview">{part}</p>
-            {/each}
-          </div>
-        {/if}
-      </section>
-
-      <aside class="detail-panel">
-        {#if identityRows.length > 0}
-          <div class="sidebar-panel">
-            <strong class="sidebar-title">Identificação</strong>
-            <dl>
-              {#each identityRows as item}
-                <div>
-                  <dt>{item.label}</dt>
-                  <dd>{item.value}</dd>
-                </div>
-              {/each}
-            </dl>
-          </div>
-        {/if}
-
-        {#if parties.length > 0}
-          <div class="sidebar-panel">
-            <strong class="sidebar-title">Destinatários</strong>
-            <div class="sidebar-tags">
-              {#each parties as party}
-                <span class="name-pill">{party}</span>
-              {/each}
-            </div>
-          </div>
-        {/if}
-
-        {#if lawyers.length > 0}
-          <div class="sidebar-panel">
-            <strong class="sidebar-title">Advogados</strong>
-            <div class="sidebar-tags">
-              {#each lawyers as lawyer}
-                <span class="name-pill" data-tone="info">{lawyer}</span>
-              {/each}
-            </div>
-          </div>
-        {/if}
-      </aside>
-    </div>
+    <PublicationDetailPanel
+      {pub}
+      {teaser}
+      {textParts}
+      {identityRows}
+      {parties}
+      {lawyers}
+    />
   </article>
 {/if}

--- a/web/src/components/PublicationDetailPanel.svelte
+++ b/web/src/components/PublicationDetailPanel.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { DjenPublication } from "../lib/djen";
+  import { type MetaChip } from "../lib/publicationPresentation";
+
+  let {
+    pub,
+    teaser,
+    textParts = [],
+    identityRows = [],
+    parties = [],
+    lawyers = [],
+  }: {
+    pub: DjenPublication;
+    teaser: string | null;
+    textParts?: string[];
+    identityRows?: MetaChip[];
+    parties?: string[];
+    lawyers?: string[];
+  } = $props();
+</script>
+
+<div class="story-grid">
+  <section>
+    {#if teaser}
+      <p>{teaser}</p>
+    {/if}
+
+    {#if pub.textoRender?.kind === "html"}
+      <div>
+        {@html pub.textoRender.content}
+      </div>
+    {:else if textParts.length > 0}
+      <div class="text-section">
+        {#each textParts.slice(0, 3) as part}
+          <p class="text-preview">{part}</p>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <aside class="detail-panel">
+    {#if identityRows.length > 0}
+      <div class="sidebar-panel">
+        <strong class="sidebar-title">Identificação</strong>
+        <dl>
+          {#each identityRows as item}
+            <div>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+    {/if}
+
+    {#if parties.length > 0}
+      <div class="sidebar-panel">
+        <strong class="sidebar-title">Destinatários</strong>
+        <div class="sidebar-tags">
+          {#each parties as party}
+            <span class="name-pill">{party}</span>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if lawyers.length > 0}
+      <div class="sidebar-panel">
+        <strong class="sidebar-title">Advogados</strong>
+        <div class="sidebar-tags">
+          {#each lawyers as lawyer}
+            <span class="name-pill" data-tone="info">{lawyer}</span>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </aside>
+</div>

--- a/web/src/components/PublicationReader.svelte
+++ b/web/src/components/PublicationReader.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import type { DjenPublication } from "../lib/djen";
+  import {
+    highlightText,
+    type HighlightTerm,
+    type MetaChip,
+  } from "../lib/publicationPresentation";
+  import PublicationActions, { type PublicationActionContext } from "./PublicationActions.svelte";
+
+  let {
+    pub,
+    seq,
+    dateStr,
+    source,
+    usedFallback,
+    processNumber,
+    metaChips = [],
+    identityRows = [],
+    parties = [],
+    lawyers = [],
+    textParts = [],
+    terms = [],
+    activeCopied = null,
+    onBack,
+    onShare,
+  }: {
+    pub: DjenPublication;
+    seq: number;
+    dateStr: string;
+    source?: "djen" | "ia";
+    usedFallback?: boolean;
+    processNumber: string | null;
+    metaChips?: MetaChip[];
+    identityRows?: MetaChip[];
+    parties?: string[];
+    lawyers?: string[];
+    textParts?: string[];
+    terms?: HighlightTerm[];
+    activeCopied?: PublicationActionContext | null;
+    onBack: () => void;
+    onShare: (event: MouseEvent, context: PublicationActionContext) => void;
+  } = $props();
+</script>
+
+{#snippet sourceBadge()}
+  {#if source}
+    <span
+      class="badge"
+      data-tone={source === "djen" ? "info" : "warning"}
+      title={usedFallback ? "Falha ao conectar no DJEN, usando arquivo IA" : ""}
+    >
+      Fonte: {source === "djen" ? "DJEN" : "Arquivo IA"}
+    </span>
+  {/if}
+{/snippet}
+
+{#snippet chip(meta: MetaChip)}
+  <span class={`meta-chip ${meta.tone ?? "default"}`}>
+    <small>{meta.label}</small>
+    <strong>{meta.value}</strong>
+  </span>
+{/snippet}
+
+{#snippet highlighted(value: string)}
+  {#each highlightText(value, terms) as segment}
+    {#if segment.type}
+      <mark class={`entity-${segment.type}`}>{segment.token}</mark>
+    {:else}
+      {segment.token}
+    {/if}
+  {/each}
+{/snippet}
+
+<article class="reader-mode" id={`pub-${seq}`}>
+  <header>
+    <div>
+      <span class="seq-number seq-bold">#{seq}</span>
+      <span class="badge publication-badge">Modo Leitura</span>
+      {@render sourceBadge()}
+      <small><time>{dateStr}</time></small>
+    </div>
+    {#if processNumber}
+      <h2 class="process-number process-number-xl">{processNumber}</h2>
+    {/if}
+    {#if pub.nomeOrgao}
+      <p class="orgao-name-reader">{pub.nomeOrgao}</p>
+    {/if}
+    <PublicationActions
+      link={pub.link}
+      {activeCopied}
+      shareContext="reader"
+      {onShare}
+      showBack
+      {onBack}
+      ariaLabel="Ações de navegação e leitura"
+    />
+  </header>
+
+  {#if metaChips.length > 0}
+    <div class="meta-chip-row meta-chip-row-spacious">
+      {#each metaChips as meta}
+        {@render chip(meta)}
+      {/each}
+    </div>
+  {/if}
+
+  <div class="reader-layout">
+    <aside class="reader-sidebar">
+      {#if identityRows.length > 0}
+        <div class="sidebar-panel">
+          <strong class="sidebar-title">Metadados</strong>
+          <dl>
+            {#each identityRows as item}
+              <div>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            {/each}
+          </dl>
+        </div>
+      {/if}
+
+      <div class="sidebar-panel">
+        <strong class="sidebar-title">Envolvidos</strong>
+        <div class="sidebar-tags">
+          {#if parties.length > 0}
+            {#each parties as party}
+              <span class="name-pill">{party}</span>
+            {/each}
+          {/if}
+          {#if lawyers.length > 0}
+            {#each lawyers as lawyer}
+              <span class="name-pill" data-tone="info">{lawyer}</span>
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </aside>
+
+    <div class="reader-content">
+      {#if pub.textoRender?.kind === "html"}
+        <div>
+          {@html pub.textoRender.content}
+        </div>
+      {:else if textParts.length > 0}
+        <div class="reader-text highlighted-text">
+          {#each textParts as part}
+            <p class="reader-paragraph">{@render highlighted(part)}</p>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </div>
+</article>

--- a/web/src/components/PublicationResultItem.svelte
+++ b/web/src/components/PublicationResultItem.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type { DjenPublication } from "../lib/djen";
+  import { highlightText, type HighlightTerm, type MetaChip } from "../lib/publicationPresentation";
+  import PublicationActions, { type PublicationActionContext } from "./PublicationActions.svelte";
+
+  let {
+    pub,
+    seq,
+    dateStr,
+    source,
+    usedFallback,
+    processNumber,
+    metaChips = [],
+    parties = [],
+    lawyers = [],
+    teaser,
+    htmlTeaser,
+    terms = [],
+    activeCopied = null,
+    onExpand,
+    onShare,
+  }: {
+    pub: DjenPublication;
+    seq: number;
+    dateStr: string;
+    source?: "djen" | "ia";
+    usedFallback?: boolean;
+    processNumber: string | null;
+    metaChips?: MetaChip[];
+    parties?: string[];
+    lawyers?: string[];
+    teaser: string | null;
+    htmlTeaser: string | null;
+    terms?: HighlightTerm[];
+    activeCopied?: PublicationActionContext | null;
+    onExpand?: () => void;
+    onShare: (event: MouseEvent, context: PublicationActionContext) => void;
+  } = $props();
+
+  const preview = $derived(pub.textoRender?.kind === "html" ? htmlTeaser : teaser);
+</script>
+
+{#snippet sourceBadge()}
+  {#if source}
+    <span
+      class="badge"
+      data-tone={source === "djen" ? "info" : "warning"}
+      title={usedFallback ? "Falha ao conectar no DJEN, usando arquivo IA" : ""}
+    >
+      Fonte: {source === "djen" ? "DJEN" : "Arquivo IA"}
+    </span>
+  {/if}
+{/snippet}
+
+{#snippet chip(meta: MetaChip)}
+  <span class={`meta-chip ${meta.tone ?? "default"}`}>
+    <small>{meta.label}</small>
+    <strong>{meta.value}</strong>
+  </span>
+{/snippet}
+
+{#snippet highlighted(value: string)}
+  {#each highlightText(value, terms) as segment}
+    {#if segment.type}
+      <mark class={`entity-${segment.type}`}>{segment.token}</mark>
+    {:else}
+      {segment.token}
+    {/if}
+  {/each}
+{/snippet}
+
+<article class:expandable={!!onExpand} id={`pub-${seq}`}>
+  <header>
+    <span class="seq-number">#{seq}</span>
+    {#if pub.tipoComunicacao}
+      <span class="badge publication-badge">{pub.tipoComunicacao}</span>
+    {/if}
+    {@render sourceBadge()}
+    <small><time>{dateStr}</time></small>
+    {#if processNumber}
+      {#if onExpand}
+        <button
+          type="button"
+          class="process-number process-number-lg process-link"
+          onclick={onExpand}
+          title="Abrir detalhes da publicação"
+        >{processNumber}</button>
+      {:else}
+        <strong class="process-number process-number-lg">{processNumber}</strong>
+      {/if}
+    {/if}
+  </header>
+
+  {#if metaChips.length > 0}
+    <div class="meta-chip-row">
+      {#each metaChips as meta}
+        {@render chip(meta)}
+      {/each}
+    </div>
+  {/if}
+
+  {#if pub.nomeOrgao}
+    <small class="orgao-name">{pub.nomeOrgao}</small>
+  {/if}
+
+  {#if preview}
+    <p class="text-preview highlighted-text">{@render highlighted(preview)}</p>
+  {/if}
+
+  <div class="summary-bar">
+    {#if parties.length > 0}
+      <span>{parties.length} parte{parties.length > 1 ? "s" : ""}</span>
+    {/if}
+    {#if lawyers.length > 0}
+      <span>{lawyers.length} advogado{lawyers.length > 1 ? "s" : ""}</span>
+    {/if}
+  </div>
+
+  {#if parties.length > 0}
+    <div class="tags-row">
+      {#each parties.slice(0, 4) as party}
+        <span class="name-pill">{party}</span>
+      {/each}
+    </div>
+  {/if}
+
+  <footer>
+    {#if onExpand}
+      <button type="button" class="outline" onclick={onExpand} title="Abrir detalhes da publicação">
+        Abrir detalhes
+      </button>
+    {/if}
+    <PublicationActions
+      link={pub.link}
+      {activeCopied}
+      shareContext="compact"
+      shareLabel="Link"
+      {onShare}
+      ariaLabel="Ações do resultado compacto"
+    />
+  </footer>
+</article>

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -105,6 +105,13 @@
     searchQuery.data?.rateLimit ?? { limit: null, remaining: null, resetAt: null }
   );
   const usedFallback = $derived(searchQuery.data?.usedFallback ?? false);
+  const publicationHighlightTerms = $derived([
+    submittedQuery?.texto,
+    submittedQuery?.nomeParte,
+    submittedQuery?.nomeAdvogado,
+    submittedQuery?.numeroProcesso,
+    submittedQuery?.numeroOab,
+  ].filter((term): term is string => typeof term === 'string' && term.trim().length > 1));
 
   const status = $derived.by((): Status => {
     if (searchQuery.isFetching) return 'loading';
@@ -385,6 +392,7 @@
               totalSeq={results.length}
               source="djen"
               {usedFallback}
+              highlightTerms={publicationHighlightTerms}
               onExpand={() => (expandedSeq = i + 1)}
               onCollapse={() => (expandedSeq = null)}
               onNavigate={(newSeq) => (expandedSeq = newSeq)}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -541,32 +541,48 @@ table tbody tr:hover {
 }
 
 /* ═══════════════════════════════════════════
-   Reader Mode Entity Highlights
+   Publication actions and highlights
    ═══════════════════════════════════════════ */
 
-.reader-mode .reader-text mark {
+.publication-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.highlighted-text mark {
   background-color: transparent;
   font-weight: 600;
   padding: 0 0.2rem;
   border-radius: 0.2rem;
 }
 
-.reader-mode .reader-text mark.entity-party {
+.highlighted-text mark.entity-party {
   background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
   color: var(--color-content);
 }
 
-.reader-mode .reader-text mark.entity-lawyer {
+.highlighted-text mark.entity-lawyer {
   background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
   color: var(--color-content);
 }
 
-[data-theme="dark"] .reader-mode .reader-text mark.entity-party {
+.highlighted-text mark.entity-search {
+  background-color: color-mix(in srgb, var(--color-warning) 24%, transparent);
+  color: var(--color-content);
+}
+
+[data-theme="dark"] .highlighted-text mark.entity-party {
   background-color: color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
-[data-theme="dark"] .reader-mode .reader-text mark.entity-lawyer {
+[data-theme="dark"] .highlighted-text mark.entity-lawyer {
   background-color: color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+[data-theme="dark"] .highlighted-text mark.entity-search {
+  background-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
 }
 
 /* ═══════════════════════════════════════════

--- a/web/src/lib/publicationPresentation.ts
+++ b/web/src/lib/publicationPresentation.ts
@@ -1,0 +1,214 @@
+import type { DjenPublication } from "./djen";
+
+export interface HighlightTerm {
+  text: string;
+  type: "party" | "lawyer" | "search";
+}
+
+export interface HighlightSegment {
+  token: string;
+  type?: HighlightTerm["type"];
+}
+
+export interface MetaChip {
+  label: string;
+  value: string;
+  tone?: "default" | "accent" | "success" | "warning" | "danger";
+}
+
+export function formatProcessNumber(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  if (raw.includes("-")) return raw;
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length === 20) {
+    return `${digits.slice(0, 7)}-${digits.slice(7, 9)}.${digits.slice(9, 13)}.${digits.slice(13, 14)}.${digits.slice(14, 16)}.${digits.slice(16, 20)}`;
+  }
+  return raw;
+}
+
+export function parseText(text: string | undefined | null): string[] {
+  if (!text) return [];
+  const markers =
+    /(?=(?:Processo\s*:|Classe\s*:|INTIMA(?:ÇÃO|CAO)|CITA(?:ÇÃO|CAO)|DESPACHO|DECIS(?:ÃO|AO)|SENTEN(?:ÇA|CA)|EDITAL|Designada\s+AUDI(?:ÊNCIA|ENCIA)|DATA\s+E\s+HORA))/gi;
+  const parts = text
+    .split(markers)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.length > 1 ? parts : [text];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function highlightText(part: string, terms: HighlightTerm[]): HighlightSegment[] {
+  const cleanedTerms = terms
+    .map((term) => ({ ...term, text: term.text.trim() }))
+    .filter((term) => term.text.length > 1);
+
+  if (cleanedTerms.length === 0) {
+    return [{ token: part }];
+  }
+
+  const sortedTerms = [...cleanedTerms].sort((a, b) => b.text.length - a.text.length);
+  const termMap = new Map<string, HighlightTerm["type"]>();
+  sortedTerms.forEach((term) => termMap.set(term.text.toLowerCase(), term.type));
+
+  const pattern = sortedTerms.map((term) => escapeRegExp(term.text)).join("|");
+  const regex = new RegExp(`(${pattern})`, "gi");
+
+  return part.split(regex).map((token) => {
+    const type = termMap.get(token.toLowerCase());
+    return type ? { token, type } : { token };
+  });
+}
+
+export function buildEntityTerms(pub: DjenPublication): HighlightTerm[] {
+  const terms: HighlightTerm[] = [];
+
+  pub.destinatarios?.forEach((destinatario) => {
+    if (destinatario.nome && destinatario.nome.length > 3) {
+      terms.push({ text: destinatario.nome, type: "party" });
+    }
+  });
+
+  pub.destinatarioadvogados?.forEach((entry) => {
+    if (entry.advogado?.nome && entry.advogado.nome.length > 3) {
+      terms.push({ text: entry.advogado.nome, type: "lawyer" });
+    }
+  });
+
+  return terms;
+}
+
+export function buildSearchTerms(values: Array<string | undefined | null>): HighlightTerm[] {
+  const seen = new Set<string>();
+  const terms: HighlightTerm[] = [];
+
+  values.forEach((value) => {
+    const text = value?.trim();
+    if (!text || text.length <= 1) return;
+    const key = text.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    terms.push({ text, type: "search" });
+  });
+
+  return terms;
+}
+
+export function previewText(text: string | undefined, limit = 320): string | null {
+  if (!text) return null;
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= limit) return cleaned;
+  return `${cleaned.slice(0, limit).trimEnd()}...`;
+}
+
+export function htmlToPreviewText(html: string | undefined, limit = 320): string | null {
+  if (!html) return null;
+
+  const text = html
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<\/(p|div|li|tr|td|th|h[1-6])>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+
+  return previewText(text, limit);
+}
+
+function summarizeMedium(pub: DjenPublication): string | null {
+  if (pub.meiocompleto) return pub.meiocompleto;
+  if (pub.meio === "D") return "Diário Eletrônico";
+  if (pub.meio === "E") return "Edital";
+  return null;
+}
+
+function summarizeStatus(pub: DjenPublication): MetaChip | null {
+  if (pub.ativo === false || pub.motivo_cancelamento) {
+    return { label: "Status", value: "Cancelada", tone: "danger" };
+  }
+  if (pub.status === "P") {
+    return { label: "Status", value: "Publicada", tone: "success" };
+  }
+  if (pub.status) {
+    return { label: "Status", value: pub.status, tone: "warning" };
+  }
+  if (pub.ativo === true) {
+    return { label: "Status", value: "Ativa", tone: "success" };
+  }
+  return null;
+}
+
+export function buildMetaChips(pub: DjenPublication): MetaChip[] {
+  const chips: MetaChip[] = [];
+  const statusChip = summarizeStatus(pub);
+  const medium = summarizeMedium(pub);
+
+  if (statusChip) chips.push(statusChip);
+  if (pub.siglaTribunal) chips.push({ label: "Tribunal", value: pub.siglaTribunal });
+  if (medium) chips.push({ label: "Meio", value: medium, tone: "accent" });
+  if (pub.nomeClasse) chips.push({ label: "Classe", value: pub.nomeClasse });
+  if (pub.tipoDocumento) chips.push({ label: "Documento", value: pub.tipoDocumento });
+  if (pub.numeroComunicacao != null) {
+    chips.push({ label: "Comunicação", value: String(pub.numeroComunicacao) });
+  }
+
+  return chips;
+}
+
+export function buildIdentityRows(pub: DjenPublication): MetaChip[] {
+  const rows: MetaChip[] = [];
+
+  if (pub.data_disponibilizacao) {
+    rows.push({ label: "Disponibilização", value: pub.data_disponibilizacao });
+  }
+  if (pub.codigoClasse) {
+    rows.push({ label: "Código da classe", value: pub.codigoClasse });
+  }
+  if (pub.hash) {
+    rows.push({ label: "Hash", value: pub.hash.slice(0, 16) });
+  }
+  if (pub.numeroprocessocommascara && pub.numeroprocessocommascara !== pub.numero_processo) {
+    rows.push({ label: "Processo mascarado", value: pub.numeroprocessocommascara });
+  }
+
+  return rows;
+}
+
+export function uniquePartyNames(pub: DjenPublication): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  pub.destinatarios?.forEach((destinatario) => {
+    if (!destinatario.nome) return;
+    const key = destinatario.nome.trim().toLowerCase();
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    names.push(destinatario.nome);
+  });
+
+  return names;
+}
+
+export function uniqueLawyers(pub: DjenPublication): string[] {
+  const seen = new Set<string>();
+  const lawyers: string[] = [];
+
+  pub.destinatarioadvogados?.forEach((entry) => {
+    const advogado = entry.advogado;
+    if (!advogado?.nome) return;
+    const oab = advogado.numero_oab ? `OAB ${advogado.uf_oab ?? ""} ${advogado.numero_oab}`.trim() : null;
+    const label = oab ? `${advogado.nome} (${oab})` : advogado.nome;
+    const key = label.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    lawyers.push(label);
+  });
+
+  return lawyers;
+}


### PR DESCRIPTION
### Motivation
- Tornar `PublicationCard` mais simples e testável extraindo responsabilidades de UI (compacto, leitor, painel de detalhes, ações) e centralizar helpers de apresentação. 
- Permitir realce de termos submetidos na busca também no preview compacto, não apenas no modo leitor. 
- Remover padrões pouco semânticos (ex.: `article role="button"` com ignores de acessibilidade) e substituir por controles explícitos.

### Description
- UI / componentes: extraídos `PublicationResultItem.svelte`, `PublicationDetailPanel.svelte`, `PublicationReader.svelte` e `PublicationActions.svelte` e integrados em `PublicationCard.svelte` como wrapper público preservando contrato de props (adicionada prop opcional `highlightTerms`).
- Helpers centralizados em `web/src/lib/publicationPresentation.ts` com funções reutilizáveis como `highlightText`, `buildEntityTerms`, `buildSearchTerms`, `previewText`, `htmlToPreviewText`, `buildMetaChips`, `buildIdentityRows`, `uniquePartyNames`, `uniqueLawyers` e `formatProcessNumber`.
- Integração com busca: `PublicationSearch.svelte` passa os termos submetidos (`submittedQuery` campos relevantes) para `PublicationCard` via `highlightTerms` para habilitar realce no resultado compacto.
- Acessibilidade e UX: o preview compacto agora usa botões/links semânticos e o componente `PublicationActions.svelte` unifica comportamentos de compartilhar, abrir inteiro teor, navegação e alternar modo leitura.
- Estilos: atualizado `web/src/index.css` para suportar classes de realce (`.highlighted-text mark.entity-party`, `.entity-lawyer`, `.entity-search`) e layout das ações.
- Arquivos principais modificados/adicionados: `web/src/components/PublicationCard.svelte` (adaptado), `web/src/components/PublicationSearch.svelte` (passagem de termos), `web/src/index.css` (pequena atualização de estilos), e os novos `web/src/components/PublicationResultItem.svelte`, `PublicationDetailPanel.svelte`, `PublicationReader.svelte`, `PublicationActions.svelte`, `web/src/lib/publicationPresentation.ts`.

### Testing
- Executado `npm run lint` em `web` com sucesso.
- Verificado `git diff --check` sem problemas de formatação/overlaps.
- `npm run typecheck` não concluiu no ambiente CI local porque `astro check` exige Node `>=22.12.0` enquanto o ambiente tem Node `v20.20.2`.
- `npx svelte-check --tsconfig ./tsconfig.json` relatou diagnósticos pré-existentes em arquivos não relacionados; não foram encontrados erros novos causados pelos componentes refatorados.
- `npm run test` (Vitest) executou; a sessão mostrou 127 testes aprovados e 2 falhas em suítes não relacionadas (`admin-pr-gate` e `publicacoes`), indicativo de problemas preexistentes e não bloqueantes para a refatoração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3abb6dc48325a2fbd9b7cdad6de5)