### PR TITLE
Preservar contexto de busca em links compartilhados e expandir publicação referenciada

### DIFF
--- a/web/features/publicacoes-search.feature
+++ b/web/features/publicacoes-search.feature
@@ -40,3 +40,16 @@ Feature: Live DJEN publication search
     Given the DJEN API returns 30 publications out of 60 for each request
     When I search for "contrato", go to page 2, and replace the search with "mandado de segurança"
     Then the last DJEN query should request page 1 for "mandado de segurança"
+
+
+  Scenario: Shared result link preserves search params and expands result
+    Given the DJEN API returns 2 publications with stable identifiers
+    When I open a shared result link for "contrato" with tribunal "TJSP" pointing to the second publication
+    Then the second publication should be expanded after results load
+
+  Scenario: Copied result links preserve search params for DJEN and fallback IA
+    Given clipboard capture is enabled
+    When I copy a DJEN result link after searching "contrato" with tribunal "TJSP"
+    Then the copied DJEN link should include search params and a publication identifier
+    When I copy a fallback IA result link after searching "contrato" with tribunal "TJSP"
+    Then the copied fallback IA link should include search params and a publication identifier

--- a/web/src/components/PublicationCard.svelte
+++ b/web/src/components/PublicationCard.svelte
@@ -267,14 +267,38 @@
     }
   }
 
+  function publicationShareIdentity(): string | null {
+    if (pub.hash) return `pub/hash/${encodeURIComponent(pub.hash)}`;
+    if (pub.numeroComunicacao != null) {
+      return `pub/numeroComunicacao/${encodeURIComponent(String(pub.numeroComunicacao))}`;
+    }
+    if (pub.id != null) return `pub/id/${encodeURIComponent(String(pub.id))}`;
+    return null;
+  }
+
+  function publicationShareHash(): string {
+    const identity = publicationShareIdentity();
+
+    if (page && dateStr) {
+      let dateHash = `${dateStr}/pg/${page}`;
+      if (seq) dateHash += `/seq/${seq}`;
+      if (identity) dateHash += `/${identity}`;
+      return dateHash;
+    }
+
+    if (identity) return identity;
+
+    let fallbackHash = dateStr;
+    if (seq) fallbackHash += `/seq/${seq}`;
+    return fallbackHash;
+  }
+
   async function handleShare(e: MouseEvent, context: "main" | "reader" | "compact") {
     e.preventDefault();
     e.stopPropagation();
-    const base = window.location.pathname;
-    let hash = dateStr;
-    if (page) hash += `/${page}`;
-    if (seq) hash += `/${seq}`;
-    const url = `${window.location.origin}${base}#${hash}`;
+    const hash = publicationShareHash();
+    const pathAndSearch = `${window.location.pathname}${window.location.search}`;
+    const url = `${window.location.origin}${pathAndSearch}#${hash}`;
     const ok = await copyToClipboard(url);
     if (!ok) return;
     if (shareTimeoutId) clearTimeout(shareTimeoutId);

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -34,10 +34,15 @@
     | 'ratelimited'
     | 'validation';
 
+  type PublicationHashTarget =
+    | { kind: 'hash' | 'numeroComunicacao' | 'id'; value: string }
+    | { kind: 'seq'; value: number };
+
   let rawInput = $state('');
   let filters = $state<DjenComunicacaoQuery>({ itensPorPagina: 30, pagina: 1 });
   let showFilters = $state(false);
   let expandedSeq = $state<number | null>(null);
+  let pendingPublicationTarget = $state<PublicationHashTarget | null>(null);
   let searchInputRef = $state<HTMLInputElement | null>(null);
 
   // The query that was actually submitted (debounced or immediate on submit)
@@ -81,6 +86,35 @@
   );
 
   const resultsHeadingId = 'publication-search-results';
+
+  function parsePublicationHash(hash: string): PublicationHashTarget | null {
+    const value = hash.replace(/^#/, '');
+    if (!value) return null;
+
+    const pubMatch = value.match(/(?:^|\/)pub\/(hash|numeroComunicacao|id)\/([^/]+)/);
+    if (pubMatch) {
+      return {
+        kind: pubMatch[1] as 'hash' | 'numeroComunicacao' | 'id',
+        value: decodeURIComponent(pubMatch[2]),
+      };
+    }
+
+    const seqMatch = value.match(/(?:^|\/)seq\/(\d+)$/);
+    if (seqMatch) {
+      return { kind: 'seq', value: Number(seqMatch[1]) };
+    }
+
+    return null;
+  }
+
+  function publicationMatchesTarget(pub: DjenPublication, target: PublicationHashTarget): boolean {
+    if (target.kind === 'seq') return false;
+    if (target.kind === 'hash') return pub.hash === target.value;
+    if (target.kind === 'numeroComunicacao') {
+      return pub.numeroComunicacao != null && String(pub.numeroComunicacao) === target.value;
+    }
+    return pub.id != null && String(pub.id) === target.value;
+  }
 
   // TanStack Query for DJEN search.
   // - `signal` is injected by TanStack; changing `submittedQuery` (key) cancels the previous request.
@@ -131,6 +165,28 @@
   const canSubmit = $derived(
     status !== 'loading' && hasIdentity && cooldownRemaining === 0,
   );
+
+  $effect(() => {
+    const target = pendingPublicationTarget;
+    const _results = results;
+    void _results;
+
+    if (!target || !searchQuery.isSuccess) return;
+
+    if (target.kind === 'seq') {
+      if (target.value >= 1 && target.value <= results.length) {
+        expandedSeq = target.value;
+        pendingPublicationTarget = null;
+      }
+      return;
+    }
+
+    const index = results.findIndex((pub) => publicationMatchesTarget(pub, target));
+    if (index >= 0) {
+      expandedSeq = index + 1;
+      pendingPublicationTarget = null;
+    }
+  });
 
   // Watch for rate-limit errors and start the cooldown timer
   $effect(() => {
@@ -256,6 +312,7 @@
   // Hydrate from URL on mount
   onMount(() => {
     if (typeof window === 'undefined') return;
+    pendingPublicationTarget = parsePublicationHash(window.location.hash);
     const sp = new URLSearchParams(window.location.search);
     if ([...sp.keys()].length === 0) {
        // Focus input automatically if there are no search params
@@ -383,7 +440,7 @@
               dateStr={pub.data_disponibilizacao ?? ''}
               compact={expandedSeq !== i + 1}
               totalSeq={results.length}
-              source="djen"
+              source={usedFallback ? 'ia' : 'djen'}
               {usedFallback}
               onExpand={() => (expandedSeq = i + 1)}
               onCollapse={() => (expandedSeq = null)}

--- a/web/src/components/__steps__/publicacoes-search.steps.ts
+++ b/web/src/components/__steps__/publicacoes-search.steps.ts
@@ -11,7 +11,7 @@ const PublicationSearch = PublicationSearchRaw as unknown as Parameters<typeof r
 
 const feature = await loadFeature('features/publicacoes-search.feature');
 
-function samplePublication(id: number) {
+function samplePublication(id: number, overrides: Record<string, unknown> = {}) {
   return {
     id,
     numeroComunicacao: id,
@@ -22,17 +22,34 @@ function samplePublication(id: number) {
     nomeOrgao: 'Vara X',
     destinatarios: [],
     destinatarioadvogados: [],
+    ...overrides,
   };
 }
 
+function responseWithJson(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: init.headers,
+  });
+}
+
 function mockFetchOnce(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}) {
-  const fetchMock = vi.fn().mockImplementation(
-    async () =>
-      new Response(JSON.stringify(body), {
-        status: init.status ?? 200,
-        headers: init.headers,
-      }),
-  );
+  const fetchMock = vi.fn().mockImplementation(async () => responseWithJson(body, init));
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function mockFetchFallbackOnce(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+) {
+  const fetchMock = vi
+    .fn()
+    .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    .mockResolvedValueOnce(responseWithJson(body, init));
   global.fetch = fetchMock as unknown as typeof fetch;
   return fetchMock;
 }
@@ -51,6 +68,24 @@ function latestFetchUrl(fetchMock: ReturnType<typeof vi.fn>): URL {
 async function typeAndSubmit(input: HTMLInputElement, value: string) {
   await fireEvent.input(input, { target: { value } });
   await fireEvent.keyDown(input, { key: 'Enter' });
+}
+
+function enableClipboardCapture() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+}
+
+async function searchWithTribunal(text: string, tribunal: string) {
+  render(PublicationSearch);
+  const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
+  await fireEvent.click(screen.getByRole('button', { name: /Filtros avançados/ }));
+  const tribunalSelect = screen.getByRole('combobox') as HTMLSelectElement;
+  await fireEvent.change(tribunalSelect, { target: { value: tribunal } });
+  await typeAndSubmit(input, text);
 }
 
 describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) => {
@@ -242,4 +277,101 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
       expect(document.activeElement).toBe(input);
     });
   });
+
+  Scenario('Shared result link preserves search params and expands result', ({ Given, When, Then }) => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    Given('the DJEN API returns 2 publications with stable identifiers', () => {
+      fetchMock = mockFetchOnce(
+        {
+          items: [
+            samplePublication(1, { hash: 'hash-publicacao-1' }),
+            samplePublication(2, { hash: 'hash-publicacao-2' }),
+          ],
+          count: 2,
+        },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+    });
+
+    When(
+      'I open a shared result link for "contrato" with tribunal "TJSP" pointing to the second publication',
+      () => {
+        window.history.replaceState(
+          {},
+          '',
+          '/publicacoes?texto=contrato&siglaTribunal=TJSP#pub/hash/hash-publicacao-2',
+        );
+        render(PublicationSearch);
+      },
+    );
+
+    Then('the second publication should be expanded after results load', async () => {
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+        const lastUrl = latestFetchUrl(fetchMock);
+        expect(lastUrl.searchParams.get('texto')).toBe('contrato');
+        expect(lastUrl.searchParams.get('siglaTribunal')).toBe('TJSP');
+        expect(screen.getByRole('button', { name: 'Fechar' })).toBeTruthy();
+        expect(screen.getByText(/^hash-publicacao-/)).toBeTruthy();
+      });
+    });
+  });
+
+  Scenario('Copied result links preserve search params for DJEN and fallback IA', ({ Given, When, Then }) => {
+    let writeText: ReturnType<typeof vi.fn>;
+
+    Given('clipboard capture is enabled', () => {
+      writeText = enableClipboardCapture();
+    });
+
+    When('I copy a DJEN result link after searching "contrato" with tribunal "TJSP"', async () => {
+      mockFetchOnce(
+        { items: [samplePublication(101, { hash: 'hash-djen-101' })], count: 1 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+
+      await searchWithTribunal('contrato', 'TJSP');
+      await waitFor(() => expect(screen.getByText(/1 resultado/)).toBeTruthy());
+      await fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+    });
+
+    Then('the copied DJEN link should include search params and a publication identifier', async () => {
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      const copied = new URL(writeText.mock.calls.at(-1)?.[0] as string);
+      expect(copied.pathname).toBe('/');
+      expect(copied.searchParams.get('texto')).toBe('contrato');
+      expect(copied.searchParams.get('siglaTribunal')).toBe('TJSP');
+      expect(copied.hash).toBe('#pub/hash/hash-djen-101');
+    });
+
+    When('I copy a fallback IA result link after searching "contrato" with tribunal "TJSP"', async () => {
+      cleanup();
+      clearDjenSearchCache();
+      window.history.replaceState({}, '', '/');
+      writeText.mockClear();
+
+      mockFetchFallbackOnce(
+        { items: [samplePublication(202, { numeroComunicacao: 202 })], count: 1 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+
+      await searchWithTribunal('contrato', 'TJSP');
+      await waitFor(() => {
+        expect(screen.getByText(/1 resultado/)).toBeTruthy();
+        expect(screen.getByText('Fonte: Arquivo IA')).toBeTruthy();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Link' }));
+    });
+
+    Then('the copied fallback IA link should include search params and a publication identifier', async () => {
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      const copied = new URL(writeText.mock.calls.at(-1)?.[0] as string);
+      expect(copied.pathname).toBe('/');
+      expect(copied.searchParams.get('texto')).toBe('contrato');
+      expect(copied.searchParams.get('siglaTribunal')).toBe('TJSP');
+      expect(copied.hash).toBe('#pub/numeroComunicacao/202');
+    });
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Compartilhar links de resultado estava perdendo os parâmetros de busca (`search`), tornando impossível recriar o contexto ao abrir o link. 
- Fragmentos posicionais (#date/page/seq) são frágeis frente a reordenações/paginação; é necessário um identificador estável. 
- Ao abrir um link compartilhado com uma publicação alvo, o card correspondente deve ser expandido automaticamente após a carga dos resultados.

### Description
- UI: `PublicationCard.svelte` passa a preferir identificadores estáveis e monta o hash de compartilhamento com `window.location.pathname + window.location.search + #hash`; adiciona `publicationShareIdentity()` e `publicationShareHash()` para priorizar `hash`, `numeroComunicacao` e `id`, preservando contexto de data/página/seq quando aplicável.
- Hydration: `PublicationSearch.svelte` adiciona parsing de fragmento (`parsePublicationHash`), um estado pendente `pendingPublicationTarget` e um efeito que, após os resultados carregarem, expande automaticamente o card que corresponder ao identificador (por `hash`, `numeroComunicacao` ou `id`) ou por `seq` quando presente.
- Fallback/Source: ao renderizar cards em `PublicationSearch.svelte`, o `source` do `PublicationCard` agora é `usedFallback ? 'ia' : 'djen'` para preservar indicação de origem (DJEN vs fallback IA).
- Tests: adicionados cenários BDD e implementações de passos em `web/features/publicacoes-search.feature` e `web/src/components/__steps__/publicacoes-search.steps.ts` cobrindo:
  - Abertura de link compartilhado que preserva parâmetros de busca e expande o card correto.
  - Cópia de link para resultado DJEN e para resultado vindo do fallback IA, garantindo que o link copiado inclua os search params e um identificador de publicação.
- Test helpers: `samplePublication` ganhou `overrides`, adicionadas `responseWithJson`, `mockFetchFallbackOnce`, `enableClipboardCapture` e `searchWithTribunal` para suportar os cenários.
- Arquivos alterados: `web/src/components/PublicationCard.svelte`, `web/src/components/PublicationSearch.svelte`, `web/src/components/__steps__/publicacoes-search.steps.ts`, `web/features/publicacoes-search.feature`.

### Testing
- Executei os testes de BDD relevantes com `npm test -- --run src/components/__steps__/publicacoes-search.steps.ts` e todos os testes do arquivo passaram (`31 tests passed`).
- Rodei `npm run lint` sem erros reportados.
- Tentei `npm run typecheck` mas a verificação foi bloqueada localmente devido à versão do Node (o ambiente tem Node `v20.20.2` enquanto o projeto requer `>=22.12.0` para o `astro check`).
- Observações: os testes simulam o clipboard (`navigator.clipboard.writeText`) e as respostas DJEN/fallback para validar preservação de search params e formato do hash copiado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3ab6c99883258900a87b59278ce9)