### PR TITLE
Show removable active filter chips & refactor search filters

### DIFF
--- a/web/features/publicacoes-search.feature
+++ b/web/features/publicacoes-search.feature
@@ -40,3 +40,15 @@ Feature: Live DJEN publication search
     Given the DJEN API returns 30 publications out of 60 for each request
     When I search for "contrato", go to page 2, and replace the search with "mandado de segurança"
     Then the last DJEN query should request page 1 for "mandado de segurança"
+
+  Scenario: Active filters are shown and can be removed outside advanced filters
+    When I configure advanced filters and close the filters panel
+    Then I should see active chips for tribunal, period, OAB, UF, advogado, parte, meio and items per page
+    When I remove the tribunal active filter chip
+    Then the filters panel should remain closed
+    And the tribunal active filter chip should be removed
+
+  Scenario: Clearing all filters resets pagination and page size defaults
+    Given the DJEN API returns 30 publications out of 60 for each request
+    When I search for "contrato", go to page 2, set 100 items per page, and clear all filters
+    Then active filters should be empty and the URL should request page 1 with 30 items per page

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -46,6 +46,66 @@
   let cooldownUntil = $state<number | null>(null);
   let cooldownRemaining = $state(0);
 
+  type ActiveFilterChip = {
+    key: string;
+    label: string;
+    value: string;
+  };
+
+  const DEFAULT_ITEMS_PER_PAGE = 30;
+
+  function formatDateLabel(value: string): string {
+    const [year, month, day] = value.split('-');
+    if (!year || !month || !day) return value;
+    return `${day}/${month}/${year}`;
+  }
+
+  function periodLabel(query: DjenComunicacaoQuery): string | null {
+    const start = query.dataDisponibilizacaoInicio;
+    const end = query.dataDisponibilizacaoFim;
+    if (start && end) return `${formatDateLabel(start)} a ${formatDateLabel(end)}`;
+    if (start) return `A partir de ${formatDateLabel(start)}`;
+    if (end) return `Até ${formatDateLabel(end)}`;
+    return null;
+  }
+
+  const activeFilterChips = $derived.by((): ActiveFilterChip[] => {
+    const query = effectiveQuery;
+    const chips: ActiveFilterChip[] = [];
+    const period = periodLabel(query);
+
+    if (query.siglaTribunal) {
+      chips.push({ key: 'siglaTribunal', label: 'Tribunal', value: query.siglaTribunal });
+    }
+    if (period) {
+      chips.push({ key: 'periodo', label: 'Período', value: period });
+    }
+    if (query.numeroOab) {
+      chips.push({ key: 'numeroOab', label: 'OAB', value: query.numeroOab });
+    }
+    if (query.ufOab) {
+      chips.push({ key: 'ufOab', label: 'UF', value: query.ufOab });
+    }
+    if (query.nomeAdvogado) {
+      chips.push({ key: 'nomeAdvogado', label: 'Advogado', value: query.nomeAdvogado });
+    }
+    if (query.nomeParte) {
+      chips.push({ key: 'nomeParte', label: 'Parte', value: query.nomeParte });
+    }
+    if (query.meio) {
+      chips.push({ key: 'meio', label: 'Meio', value: query.meio === 'D' ? 'Diário' : 'Edital' });
+    }
+    if (query.itensPorPagina && query.itensPorPagina !== DEFAULT_ITEMS_PER_PAGE) {
+      chips.push({
+        key: 'itensPorPagina',
+        label: 'Itens por página',
+        value: String(query.itensPorPagina),
+      });
+    }
+
+    return chips;
+  });
+
   const smart = $derived(smartParseInput(rawInput));
   const effectiveQuery = $derived<DjenComunicacaoQuery>({ ...filters, ...smart.patch });
   const criteriaFilters = $derived({
@@ -210,6 +270,31 @@
     submitSearch({ page: next });
   }
 
+
+  function removeActiveFilter(key: ActiveFilterChip['key']) {
+    const patch: Partial<DjenComunicacaoQuery> = { pagina: 1 };
+
+    if (key === 'siglaTribunal') patch.siglaTribunal = undefined;
+    if (key === 'periodo') {
+      patch.dataDisponibilizacaoInicio = undefined;
+      patch.dataDisponibilizacaoFim = undefined;
+    }
+    if (key === 'numeroOab') {
+      patch.numeroOab = undefined;
+      if (smart.patch.numeroOab) rawInput = '';
+    }
+    if (key === 'ufOab') {
+      patch.ufOab = undefined;
+      if (smart.patch.ufOab) rawInput = '';
+    }
+    if (key === 'nomeAdvogado') patch.nomeAdvogado = undefined;
+    if (key === 'nomeParte') patch.nomeParte = undefined;
+    if (key === 'meio') patch.meio = undefined;
+    if (key === 'itensPorPagina') patch.itensPorPagina = DEFAULT_ITEMS_PER_PAGE;
+
+    filters = { ...filters, ...patch };
+  }
+
   // Debounced reactive trigger for criteria changes. Pagination changes are handled separately.
   $effect(() => {
     const _input = rawInput;
@@ -285,6 +370,31 @@
   <h2 id="publication-search-heading" class="sr-only">Busca de publicações</h2>
 
   <SmartSearchInput bind:value={rawInput} hint={smart.label} kind={smart.kind} onsubmit={handleSubmit} bind:inputRef={searchInputRef} />
+
+  <section aria-label="Filtros ativos">
+    <strong>Filtros ativos</strong>
+    {#if activeFilterChips.length > 0}
+      <ul aria-label="Lista de filtros ativos">
+        {#each activeFilterChips as chip (chip.key)}
+          <li>
+            <button
+              type="button"
+              class="secondary outline"
+              aria-label={`Remover filtro ${chip.label}: ${chip.value}`}
+              title={`Remover filtro ${chip.label}`}
+              onclick={() => removeActiveFilter(chip.key)}
+            >
+              <span>{chip.label}: {chip.value}</span>
+              <span aria-hidden="true">×</span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <small class="meta-text" data-tone="muted">Nenhum filtro ativo.</small>
+    {/if}
+  </section>
+
   {#if !rawInput}
     <div>
       <small>Experimente:</small>

--- a/web/src/components/SearchFilters.svelte
+++ b/web/src/components/SearchFilters.svelte
@@ -7,6 +7,16 @@
   }
 
   let { filters = $bindable() }: Props = $props();
+  let showSecondaryFilters = $state(false);
+
+  type DatePreset = 'today' | '7d' | '30d' | 'month';
+
+  const DATE_PRESETS: Array<{ value: DatePreset; label: string }> = [
+    { value: 'today', label: 'Hoje' },
+    { value: '7d', label: 'Últimos 7 dias' },
+    { value: '30d', label: 'Últimos 30 dias' },
+    { value: 'month', label: 'Este mês' },
+  ];
 
   function formatLocalDate(d: Date): string {
     // Format as YYYY-MM-DD in the browser's local timezone so presets don't
@@ -17,14 +27,13 @@
     return `${year}-${month}-${day}`;
   }
 
-  function setDatePreset(preset: 'today' | '7d' | '30d' | 'month') {
+  function datePresetRange(preset: DatePreset) {
     const now = new Date();
     const today = formatLocalDate(now);
     const start = new Date(now);
 
     if (preset === 'today') {
-      filters = { ...filters, dataDisponibilizacaoInicio: today, dataDisponibilizacaoFim: today };
-      return;
+      return { start: today, end: today };
     }
     if (preset === '7d') {
       start.setDate(start.getDate() - 7);
@@ -33,23 +42,39 @@
     } else if (preset === 'month') {
       start.setDate(1);
     }
-    filters = {
-      ...filters,
-      dataDisponibilizacaoInicio: formatLocalDate(start),
-      dataDisponibilizacaoFim: today,
-    };
+
+    return { start: formatLocalDate(start), end: today };
+  }
+
+  function isDatePresetActive(preset: DatePreset) {
+    const range = datePresetRange(preset);
+    return (
+      filters.dataDisponibilizacaoInicio === range.start &&
+      filters.dataDisponibilizacaoFim === range.end
+    );
+  }
+
+  function updateFilters(patch: Partial<DjenComunicacaoQuery>) {
+    filters = { ...filters, ...patch, pagina: 1 };
+  }
+
+  function setDatePreset(preset: DatePreset) {
+    const range = datePresetRange(preset);
+    updateFilters({
+      dataDisponibilizacaoInicio: range.start,
+      dataDisponibilizacaoFim: range.end,
+    });
   }
 
   function clearDates() {
-    filters = {
-      ...filters,
+    updateFilters({
       dataDisponibilizacaoInicio: undefined,
       dataDisponibilizacaoFim: undefined,
-    };
+    });
   }
 
   function clearAll() {
-    filters = { itensPorPagina: filters.itensPorPagina, pagina: 1 };
+    filters = { itensPorPagina: 30, pagina: 1 };
   }
 </script>
 
@@ -59,7 +84,7 @@
       Tribunal
       <select
         value={filters.siglaTribunal ?? ''}
-        onchange={(e) => (filters = { ...filters, siglaTribunal: (e.currentTarget.value || undefined) })}
+        onchange={(e) => updateFilters({ siglaTribunal: e.currentTarget.value || undefined })}
       >
         <option value="">Todos</option>
         {#each TRIBUNAL_GROUPS as group (group.name)}
@@ -73,61 +98,12 @@
     </label>
 
     <label>
-      OAB — número
-      <input
-        type="text"
-        inputmode="numeric"
-        pattern="[0-9]*"
-        autocomplete="off"
-        placeholder="123456"
-        value={filters.numeroOab ?? ''}
-        oninput={(e) => (filters = { ...filters, numeroOab: e.currentTarget.value || undefined })}
-      />
-    </label>
-
-    <label>
-      OAB — UF
-      <input
-        type="text"
-        autocapitalize="characters"
-        autocomplete="off"
-        placeholder="SP"
-        maxlength="2"
-        value={filters.ufOab ?? ''}
-        oninput={(e) => (filters = { ...filters, ufOab: e.currentTarget.value.toUpperCase() || undefined })}
-      />
-    </label>
-
-    <label>
-      Nome do advogado
-      <input
-        type="text"
-        autocomplete="off"
-        placeholder="Ex.: João da Silva"
-        value={filters.nomeAdvogado ?? ''}
-        oninput={(e) => (filters = { ...filters, nomeAdvogado: e.currentTarget.value || undefined })}
-      />
-    </label>
-
-    <label>
-      Nome da parte
-      <input
-        type="text"
-        autocomplete="off"
-        placeholder="Ex.: Empresa XYZ LTDA"
-        value={filters.nomeParte ?? ''}
-        oninput={(e) => (filters = { ...filters, nomeParte: e.currentTarget.value || undefined })}
-      />
-    </label>
-
-    <label>
       Data início
       <input
         type="date"
         value={filters.dataDisponibilizacaoInicio ?? ''}
         oninput={(e) =>
-          (filters = {
-            ...filters,
+          updateFilters({
             dataDisponibilizacaoInicio: e.currentTarget.value || undefined,
           })}
       />
@@ -139,63 +115,124 @@
         type="date"
         value={filters.dataDisponibilizacaoFim ?? ''}
         oninput={(e) =>
-          (filters = {
-            ...filters,
+          updateFilters({
             dataDisponibilizacaoFim: e.currentTarget.value || undefined,
           })}
       />
     </label>
+  </div>
 
-    <fieldset>
-      <legend>Meio</legend>
-      <label>
-        <input
-          type="radio"
-          name="meio"
-          checked={filters.meio == null}
-          onchange={() => (filters = { ...filters, meio: undefined })}
-        /> Todos
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="meio"
-          checked={filters.meio === 'D'}
-          onchange={() => (filters = { ...filters, meio: 'D' })}
-        /> Diário
-      </label>
-      <label>
-        <input
-          type="radio"
-          name="meio"
-          checked={filters.meio === 'E'}
-          onchange={() => (filters = { ...filters, meio: 'E' })}
-        /> Edital
-      </label>
-    </fieldset>
+  <div aria-label="Presets de período mais usados">
+    <small>Período:</small>
+    {#each DATE_PRESETS as preset (preset.value)}
+      <button
+        type="button"
+        class:contrast={isDatePresetActive(preset.value)}
+        class:secondary={!isDatePresetActive(preset.value)}
+        class:outline={!isDatePresetActive(preset.value)}
+        aria-pressed={isDatePresetActive(preset.value)}
+        onclick={() => setDatePreset(preset.value)}
+      >{preset.label}</button>
+    {/each}
+    <button type="button" class="outline" onclick={clearDates}>Limpar datas</button>
+  </div>
 
-    <fieldset>
-      <legend>Itens por página</legend>
-      {#each [5, 30, 100] as size (size)}
+  <details bind:open={showSecondaryFilters}>
+    <summary>Mais filtros</summary>
+    <div class="auto-grid-sm">
+      <label>
+        OAB — número
+        <input
+          type="text"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          autocomplete="off"
+          placeholder="123456"
+          value={filters.numeroOab ?? ''}
+          oninput={(e) => updateFilters({ numeroOab: e.currentTarget.value || undefined })}
+        />
+      </label>
+
+      <label>
+        OAB — UF
+        <input
+          type="text"
+          autocapitalize="characters"
+          autocomplete="off"
+          placeholder="SP"
+          maxlength="2"
+          value={filters.ufOab ?? ''}
+          oninput={(e) => updateFilters({ ufOab: e.currentTarget.value.toUpperCase() || undefined })}
+        />
+      </label>
+
+      <label>
+        Nome do advogado
+        <input
+          type="text"
+          autocomplete="off"
+          placeholder="Ex.: João da Silva"
+          value={filters.nomeAdvogado ?? ''}
+          oninput={(e) => updateFilters({ nomeAdvogado: e.currentTarget.value || undefined })}
+        />
+      </label>
+
+      <label>
+        Nome da parte
+        <input
+          type="text"
+          autocomplete="off"
+          placeholder="Ex.: Empresa XYZ LTDA"
+          value={filters.nomeParte ?? ''}
+          oninput={(e) => updateFilters({ nomeParte: e.currentTarget.value || undefined })}
+        />
+      </label>
+
+      <fieldset>
+        <legend>Meio</legend>
         <label>
           <input
             type="radio"
-            name="itensPorPagina"
-            checked={(filters.itensPorPagina ?? 30) === size}
-            onchange={() => (filters = { ...filters, itensPorPagina: size, pagina: 1 })}
-          /> {size}
+            name="meio"
+            checked={filters.meio == null}
+            onchange={() => updateFilters({ meio: undefined })}
+          /> Todos
         </label>
-      {/each}
-    </fieldset>
-  </div>
+        <label>
+          <input
+            type="radio"
+            name="meio"
+            checked={filters.meio === 'D'}
+            onchange={() => updateFilters({ meio: 'D' })}
+          /> Diário
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="meio"
+            checked={filters.meio === 'E'}
+            onchange={() => updateFilters({ meio: 'E' })}
+          /> Edital
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Itens por página</legend>
+        {#each [5, 30, 100] as size (size)}
+          <label>
+            <input
+              type="radio"
+              name="itensPorPagina"
+              checked={(filters.itensPorPagina ?? 30) === size}
+              onchange={() => updateFilters({ itensPorPagina: size })}
+            /> {size}
+          </label>
+        {/each}
+      </fieldset>
+    </div>
+  </details>
 
   <div>
-    <small>Período:</small>
-    <button type="button" onclick={() => setDatePreset('today')}>Hoje</button>
-    <button type="button" onclick={() => setDatePreset('7d')}>7 dias</button>
-    <button type="button" onclick={() => setDatePreset('30d')}>30 dias</button>
-    <button type="button" onclick={() => setDatePreset('month')}>Este mês</button>
-    <button type="button" class="outline" onclick={clearDates}>Limpar datas</button>
     <button type="button" class="outline" data-tone="error" onclick={clearAll}>Limpar tudo</button>
   </div>
 </fieldset>

--- a/web/src/components/__steps__/publicacoes-search.steps.ts
+++ b/web/src/components/__steps__/publicacoes-search.steps.ts
@@ -202,6 +202,106 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
     });
   });
 
+
+  Scenario('Active filters are shown and can be removed outside advanced filters', ({ When, Then, And }) => {
+    When('I configure advanced filters and close the filters panel', async () => {
+      render(PublicationSearch);
+
+      await fireEvent.click(screen.getByRole('button', { name: /Filtros avançados/ }));
+      await fireEvent.change(screen.getByLabelText('Tribunal'), { target: { value: 'TJSP' } });
+      await fireEvent.input(screen.getByLabelText('Data início'), { target: { value: '2026-05-01' } });
+      await fireEvent.input(screen.getByLabelText('Data fim'), { target: { value: '2026-05-30' } });
+      await fireEvent.click(screen.getByText('Mais filtros'));
+      await fireEvent.input(screen.getByLabelText('OAB — número'), { target: { value: '123456' } });
+      await fireEvent.input(screen.getByLabelText('OAB — UF'), { target: { value: 'SP' } });
+      await fireEvent.input(screen.getByLabelText('Nome do advogado'), { target: { value: 'Maria Silva' } });
+      await fireEvent.input(screen.getByLabelText('Nome da parte'), { target: { value: 'Empresa XYZ' } });
+      await fireEvent.click(screen.getByRole('radio', { name: 'Edital' }));
+      await fireEvent.click(screen.getByRole('radio', { name: '100' }));
+      await fireEvent.click(screen.getByRole('button', { name: /Ocultar filtros/ }));
+    });
+
+    Then(
+      'I should see active chips for tribunal, period, OAB, UF, advogado, parte, meio and items per page',
+      () => {
+        expect(screen.getByRole('button', { name: /Remover filtro Tribunal: TJSP/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro Período: 01\/05\/2026 a 30\/05\/2026/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro OAB: 123456/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro UF: SP/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro Advogado: Maria Silva/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro Parte: Empresa XYZ/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro Meio: Edital/ })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Remover filtro Itens por página: 100/ })).toBeTruthy();
+      },
+    );
+
+    When('I remove the tribunal active filter chip', async () => {
+      await fireEvent.click(screen.getByRole('button', { name: /Remover filtro Tribunal: TJSP/ }));
+    });
+
+    Then('the filters panel should remain closed', () => {
+      expect(screen.queryByLabelText('Tribunal')).toBeNull();
+      expect(screen.getByRole('button', { name: /Filtros avançados/ })).toBeTruthy();
+    });
+
+    And('the tribunal active filter chip should be removed', () => {
+      expect(screen.queryByRole('button', { name: /Remover filtro Tribunal: TJSP/ })).toBeNull();
+    });
+  });
+
+  Scenario('Clearing all filters resets pagination and page size defaults', ({ Given, When, Then }) => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    Given('the DJEN API returns 30 publications out of 60 for each request', () => {
+      fetchMock = mockFetchOnce(
+        { items: Array.from({ length: 30 }, (_, i) => samplePublication(i + 1)), count: 60 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+    });
+
+    When(
+      'I search for "contrato", go to page 2, set 100 items per page, and clear all filters',
+      async () => {
+        render(PublicationSearch);
+        const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
+
+        await typeAndSubmit(input, 'contrato');
+        await waitFor(() => {
+          expect(fetchMock).toHaveBeenCalled();
+          expect(screen.getByText(/Página 1 de 2/)).toBeTruthy();
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Próxima/ }));
+        await waitFor(() => {
+          expect(latestFetchUrl(fetchMock).searchParams.get('pagina')).toBe('2');
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Filtros avançados/ }));
+        await fireEvent.click(screen.getByText('Mais filtros'));
+        await fireEvent.click(screen.getByRole('radio', { name: '100' }));
+        await waitFor(() => {
+          const lastUrl = latestFetchUrl(fetchMock);
+          expect(lastUrl.searchParams.get('pagina')).toBe('1');
+          expect(lastUrl.searchParams.get('itensPorPagina')).toBe('100');
+        });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Limpar tudo/ }));
+      },
+    );
+
+    Then(
+      'active filters should be empty and the URL should request page 1 with 30 items per page',
+      async () => {
+        expect(screen.getByText(/Nenhum filtro ativo/)).toBeTruthy();
+        await waitFor(() => {
+          const currentUrl = new URL(window.location.href);
+          expect(currentUrl.searchParams.get('pagina')).toBe('1');
+          expect(currentUrl.searchParams.get('itensPorPagina')).toBe('30');
+        });
+      },
+    );
+  });
+
   Scenario('User uses Ctrl+K to focus search input', ({ When, Then }) => {
     When('I press Ctrl+K', () => {
       render(PublicationSearch);


### PR DESCRIPTION
### Motivation
- Tornar visíveis e removíveis os filtros ativos sem precisar reabrir o painel avançado. 
- Destacar presets de data de uso comum e reduzir a complexidade do painel movendo filtros menos frequentes para uma seção colapsável. 
- Garantir que `clearAll()` e remoção de chips resetem paginação e restaurem o tamanho de página pretendido.

### Description
- UI: adiciona uma barra “Filtros ativos” em `PublicationSearch.svelte` que renderiza chips derivados de `effectiveQuery` para tribunal, período, OAB, UF, advogado, parte, meio e itens por página.  
- Interação: implementa `removeActiveFilter()` em `PublicationSearch.svelte` para remover cada chip individualmente e forçar `pagina: 1`, limpando também `rawInput` quando o valor veio do smart parser (OAB).  
- Filtros avançados: refatora `SearchFilters.svelte` para expor presets de data (`Hoje`, `Últimos 7 dias`, `Últimos 30 dias`, `Este mês`) com estado ativo, adiciona `details` colapsável para filtros secundários e centraliza atualizações via `updateFilters()` que sempre reseta `pagina` para `1`.  
- Clear all: atualiza `clearAll()` para restaurar `itensPorPagina` ao padrão de `30` e `pagina` a `1`.  
- Testes e especificação: estende `web/features/publicacoes-search.feature` e adiciona/atualiza steps em `web/src/components/__steps__/publicacoes-search.steps.ts` cobrindo chips ativos, remoção sem abrir painel e comportamento de `Limpar tudo` quanto à paginação/tamanho de página.

### Testing
- Executados: `npm test -- src/components/__steps__/publicacoes-search.steps.ts`, todos os testes do arquivo passaram (`31 passed`).
- Lint: `npm run lint` executado com sucesso (no erros). 
- Typecheck: `npm run typecheck` foi executado mas falhou na máquina de CI local por incompatibilidade de Node (`v20.20.2`) com a versão requerida pelo Astro (>= `22.12.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3ab2faa08325b988710633ab82cf)