### PR TITLE
Explicit DJEN publication search flow: prepared criteria, explicit submit and clearer rate-limit messaging

### DIFF
--- a/web/features/publicacoes-search.feature
+++ b/web/features/publicacoes-search.feature
@@ -1,16 +1,28 @@
-Feature: Live DJEN publication search
-  Users can search publications directly against the djen API
-  from the publications overview page.
+Feature: Explicit DJEN publication search
+  Users can prepare publication search criteria locally and submit
+  explicit searches against the DJEN API from the publications overview page.
 
   Scenario: Idle state shows instructions
     When the publication search loads with no URL params
     Then I should see instructions about OAB, processo or texto livre
+
+  Scenario: Typing prepares criteria without submitting to DJEN
+    Given the DJEN API returns 2 publications for the next request
+    When I type "OAB/SP 123456" without submitting
+    Then I should see the prepared OAB criteria "OAB/SP 123456"
+    And the DJEN API should not have been called
 
   Scenario: User searches by OAB and sees results
     Given the DJEN API returns 2 publications for the next request
     When I enter "OAB/SP 123456" and press Enter
     Then I should see 2 result cards
     And I should see "OAB SP/123456 detectada" as the hint
+
+  Scenario: User submits with the Buscar button
+    Given the DJEN API returns 1 publication for the next request
+    When I type "mandado de segurança" and click Buscar
+    Then I should see 1 result card
+    And the last DJEN query should include text "mandado de segurança"
 
   Scenario: User pastes a CNJ process number
     Given the DJEN API returns 1 publication for the next request
@@ -21,7 +33,7 @@ Feature: Live DJEN publication search
   Scenario: User hits the rate limit
     Given the DJEN API responds with HTTP 429 and retry-after 60
     When I enter "contrato" with tribunal "TJSP" and press Enter
-    Then I should see a rate-limit banner with a countdown
+    Then I should see a DJEN rate-limit banner with a countdown and historical archive action
 
   Scenario: User uses Ctrl+K to focus search input
     When I press Ctrl+K
@@ -36,7 +48,7 @@ Feature: Live DJEN publication search
     When the publication search loads with no URL params
     Then the search input should be focused
 
-  Scenario: Search criteria changes reset pagination
+  Scenario: Search criteria changes reset pagination only after explicit submit
     Given the DJEN API returns 30 publications out of 60 for each request
-    When I search for "contrato", go to page 2, and replace the search with "mandado de segurança"
+    When I search for "contrato", go to page 2, type "mandado de segurança", and click Buscar
     Then the last DJEN query should request page 1 for "mandado de segurança"

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onMount } from 'svelte';
   import { createQuery, setQueryClientContext } from '@tanstack/svelte-query';
   import {
     searchDjenComunicacoes,
@@ -40,13 +40,14 @@
   let expandedSeq = $state<number | null>(null);
   let searchInputRef = $state<HTMLInputElement | null>(null);
 
-  // The query that was actually submitted (debounced or immediate on submit)
+  // The query that was actually submitted by Enter or the explicit Buscar button.
   let submittedQuery = $state<DjenComunicacaoQuery | null>(null);
+  let preparedInput = $state('');
 
   let cooldownUntil = $state<number | null>(null);
   let cooldownRemaining = $state(0);
 
-  const smart = $derived(smartParseInput(rawInput));
+  const smart = $derived(smartParseInput(preparedInput));
   const effectiveQuery = $derived<DjenComunicacaoQuery>({ ...filters, ...smart.patch });
   const criteriaFilters = $derived({
     siglaTribunal: filters.siglaTribunal,
@@ -70,17 +71,8 @@
     'numeroProcesso',
   ] as const;
 
-  const hasIdentity = $derived(
-    identityKeys.some((k) => {
-      const v = effectiveQuery[k];
-      return typeof v === 'string' && v.trim().length > 0;
-    }) ||
-      (typeof effectiveQuery.itensPorPagina === 'number' &&
-        effectiveQuery.itensPorPagina > 0 &&
-        effectiveQuery.itensPorPagina <= 5),
-  );
-
   const resultsHeadingId = 'publication-search-results';
+  const historicalArchiveHref = `${import.meta.env.BASE_URL.replace(/\/?$/, '/')}dados`;
 
   // TanStack Query for DJEN search.
   // - `signal` is injected by TanStack; changing `submittedQuery` (key) cancels the previous request.
@@ -89,7 +81,7 @@
   const searchQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.djenSearch(submittedQuery as Record<string, unknown>),
     queryFn: ({ signal }) => searchDjenComunicacoes(submittedQuery!, { signal }),
-    enabled: submittedQuery !== null && hasIdentity && cooldownRemaining === 0,
+    enabled: submittedQuery !== null && queryHasIdentity(submittedQuery) && cooldownRemaining === 0,
     staleTime: 60_000,
     retry: (failureCount, error) => {
       if (error instanceof DjenRateLimitError) return false;
@@ -128,9 +120,29 @@
     return (err as Error).message || 'Erro desconhecido';
   });
 
-  const canSubmit = $derived(
-    status !== 'loading' && hasIdentity && cooldownRemaining === 0,
+  const hasPendingInput = $derived(
+    rawInput.trim().length >= 3 ||
+      hasAnyQueryValue({
+        ...filters,
+        itensPorPagina: undefined,
+        pagina: undefined,
+      }),
   );
+
+  const canSubmit = $derived(
+    status !== 'loading' && hasPendingInput && cooldownRemaining === 0,
+  );
+
+  const preparedSummary = $derived.by(() => buildCriteriaSummary(effectiveQuery));
+  const submittedSummary = $derived.by(() =>
+    submittedQuery ? buildCriteriaSummary(submittedQuery) : null,
+  );
+  const hasPreparedCriteria = $derived(preparedSummary.some((item) => item.value !== '—' && item.value !== 'Todos'));
+  const isPreparedDifferent = $derived.by(() => {
+    if (!submittedQuery) return hasPreparedCriteria;
+    return JSON.stringify({ ...effectiveQuery, pagina: undefined }) !==
+      JSON.stringify({ ...submittedQuery, pagina: undefined });
+  });
 
   // Watch for rate-limit errors and start the cooldown timer
   $effect(() => {
@@ -150,7 +162,7 @@
   });
 
   let cooldownInterval: ReturnType<typeof setInterval> | null = null;
-  let debounceId: ReturnType<typeof setTimeout> | null = null;
+  let validationDebounceId: ReturnType<typeof setTimeout> | null = null;
 
   function startCooldownTick() {
     stopCooldownTick();
@@ -179,13 +191,24 @@
     return () => stopCooldownTick();
   });
 
+  function queryHasIdentity(query: DjenComunicacaoQuery): boolean {
+    return identityKeys.some((k) => {
+      const v = query[k];
+      return typeof v === 'string' && v.trim().length > 0;
+    }) ||
+      (typeof query.itensPorPagina === 'number' &&
+        query.itensPorPagina > 0 &&
+        query.itensPorPagina <= 5);
+  }
+
   function submitSearch({
     page,
     resetPage = false,
-  }: { page?: number; resetPage?: boolean } = {}) {
-    if (cooldownRemaining > 0 || !hasIdentity) return;
-    const nextPage = page ?? (resetPage ? 1 : (effectiveQuery.pagina ?? 1));
-    const nextQuery = { ...effectiveQuery, pagina: nextPage };
+    query = effectiveQuery,
+  }: { page?: number; resetPage?: boolean; query?: DjenComunicacaoQuery } = {}) {
+    if (cooldownRemaining > 0 || !queryHasIdentity(query)) return;
+    const nextPage = page ?? (resetPage ? 1 : (query.pagina ?? 1));
+    const nextQuery = { ...query, pagina: nextPage };
 
     if (resetPage && filters.pagina !== nextPage) {
       filters = { ...filters, pagina: nextPage };
@@ -196,11 +219,15 @@
   }
 
   function handleSubmit() {
-    if (debounceId) {
-      clearTimeout(debounceId);
-      debounceId = null;
+    if (validationDebounceId) {
+      clearTimeout(validationDebounceId);
+      validationDebounceId = null;
     }
-    submitSearch({ resetPage: true });
+    preparedInput = rawInput;
+    submitSearch({
+      resetPage: true,
+      query: { ...filters, ...smartParseInput(rawInput).patch },
+    });
   }
 
   function handlePageChange(delta: number) {
@@ -210,30 +237,57 @@
     submitSearch({ page: next });
   }
 
-  // Debounced reactive trigger for criteria changes. Pagination changes are handled separately.
+
+  function formatDate(value?: string): string {
+    if (!value) return '';
+    const [year, month, day] = value.split('-');
+    if (year && month && day) return `${day}/${month}/${year}`;
+    return value;
+  }
+
+  function buildCriteriaSummary(query: DjenComunicacaoQuery) {
+    const periodStart = formatDate(query.dataDisponibilizacaoInicio);
+    const periodEnd = formatDate(query.dataDisponibilizacaoFim);
+    const period = periodStart && periodEnd
+      ? `${periodStart} a ${periodEnd}`
+      : periodStart
+        ? `a partir de ${periodStart}`
+        : periodEnd
+          ? `até ${periodEnd}`
+          : '—';
+
+    const oab = query.numeroOab
+      ? [query.ufOab ? `OAB/${query.ufOab}` : 'OAB', query.numeroOab].join(' ')
+      : '—';
+
+    const textParts = [query.texto, query.nomeParte, query.nomeAdvogado]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map((value) => value.trim());
+
+    return [
+      { label: 'Tribunal', value: query.siglaTribunal || 'Todos' },
+      { label: 'Período', value: period },
+      { label: 'OAB', value: oab },
+      { label: 'Processo', value: query.numeroProcesso || '—' },
+      { label: 'Texto / pessoa', value: textParts.length ? textParts.join(' · ') : '—' },
+    ];
+  }
+
+  // Debounce only the local preparation layer: validation, hints and smart parsing.
+  // Network requests are fired exclusively by Enter, the Buscar button or pagination.
   $effect(() => {
     const _input = rawInput;
     const _criteriaFilters = criteriaFilters;
     void _input;
     void _criteriaFilters;
 
-    if (debounceId) clearTimeout(debounceId);
-    debounceId = setTimeout(() => {
-      untrack(() => {
-        const trimmed = rawInput.trim();
-        const hasFilterValues = hasAnyQueryValue({
-          ...filters,
-          itensPorPagina: undefined,
-          pagina: undefined,
-        });
-        if (trimmed.length >= 3 || hasFilterValues) {
-          submitSearch({ resetPage: true });
-        }
-      });
-    }, 400);
+    if (validationDebounceId) clearTimeout(validationDebounceId);
+    validationDebounceId = setTimeout(() => {
+      preparedInput = rawInput;
+    }, 300);
 
     return () => {
-      if (debounceId) clearTimeout(debounceId);
+      if (validationDebounceId) clearTimeout(validationDebounceId);
     };
   });
 
@@ -277,14 +331,24 @@
     } else if (hydrated.numeroProcesso) {
       rawInput = hydrated.numeroProcesso;
     }
-    // debounced effect will fire the search
+    preparedInput = rawInput;
+    submitSearch({ resetPage: false });
   });
 </script>
 
 <section aria-labelledby="publication-search-heading">
   <h2 id="publication-search-heading" class="sr-only">Busca de publicações</h2>
 
-  <SmartSearchInput bind:value={rawInput} hint={smart.label} kind={smart.kind} onsubmit={handleSubmit} bind:inputRef={searchInputRef} />
+  <SmartSearchInput
+    bind:value={rawInput}
+    hint={smart.label}
+    kind={smart.kind}
+    onsubmit={handleSubmit}
+    bind:inputRef={searchInputRef}
+    disabled={!canSubmit}
+    busy={status === 'loading'}
+    submitLabel={status === 'loading' ? 'Buscando…' : cooldownRemaining > 0 ? `Aguarde ${cooldownRemaining}s` : 'Buscar'}
+  />
   {#if !rawInput}
     <div>
       <small>Experimente:</small>
@@ -304,23 +368,36 @@
     >
       {showFilters ? 'Ocultar filtros' : 'Filtros avançados'}
     </button>
-    <button
-      type="button"
-      disabled={!canSubmit}
-      aria-busy={status === 'loading'}
-      onclick={handleSubmit}
-    >
-      {#if status === 'loading'}
-        <span aria-busy="true" aria-hidden="true"></span>
-        Buscando…
-      {:else if cooldownRemaining > 0}
-        Aguarde {cooldownRemaining}s
-      {:else}
-        Buscar
-      {/if}
-    </button>
     <RateLimitBadge limit={rateLimit.limit} remaining={rateLimit.remaining} {usedFallback} />
   </div>
+
+
+
+  <section class="criteria-summary" aria-labelledby="criteria-summary-heading">
+    <div>
+      <strong id="criteria-summary-heading">Critério preparado</strong>
+      <p class="meta-text" data-tone="muted">
+        {#if hasPreparedCriteria}
+          Confira o que será enviado ao DJEN. A API só será chamada ao pressionar Enter ou Buscar.
+        {:else}
+          Digite uma OAB, processo CNJ, nome ou texto para preparar a busca antes de enviar.
+        {/if}
+      </p>
+    </div>
+    <dl>
+      {#each preparedSummary as item}
+        <div>
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      {/each}
+    </dl>
+    {#if submittedSummary && !isPreparedDifferent}
+      <small data-tone="muted">Este é o mesmo critério da última busca executada.</small>
+    {:else if hasPreparedCriteria}
+      <small data-tone="warning">Critério preparado, mas ainda não enviado.</small>
+    {/if}
+  </section>
 
   {#if showFilters}
     <div id="search-filters-panel">
@@ -339,7 +416,9 @@
     {:else if status === 'ratelimited'}
       <div class="alert" data-level="warning">
         <strong>Limite de requisições atingido.</strong>
-        <p>A API do DJEN controla a taxa por IP. Tente novamente em <b>{cooldownRemaining}s</b>.</p>
+        <p>Origem: API DJEN online. A cota é controlada por IP pelo DJEN; tente novamente em <b>{cooldownRemaining}s</b>.</p>
+        <p>Alternativa: use o arquivo histórico preservado no Internet Archive, que não consome a cota da busca online.</p>
+        <a href={historicalArchiveHref} class="secondary outline" role="button">Usar arquivo histórico</a>
       </div>
     {:else if status === 'error'}
       <div class="alert" data-level="error">
@@ -393,7 +472,38 @@
         {/each}
       </ul>
     {:else}
-      <p class="meta-text" data-tone="muted">Comece digitando um número de OAB, um processo CNJ ou um termo livre para buscar ao vivo no DJEN.</p>
+      <p class="meta-text" data-tone="muted">Comece digitando um número de OAB, um processo CNJ ou um termo livre. A busca só será enviada ao DJEN quando você pressionar Enter ou Buscar.</p>
     {/if}
   </div>
 </section>
+
+
+<style>
+  .criteria-summary {
+    margin-block: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--border, var(--concreto-90, #d8d8d8));
+    border-radius: var(--radius, 0.75rem);
+    background: var(--papel-20, rgba(0, 0, 0, 0.02));
+  }
+
+  .criteria-summary dl {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: 0.75rem;
+    margin: 0.75rem 0;
+  }
+
+  .criteria-summary dt {
+    font-size: 0.75rem;
+    color: var(--fg-muted, var(--color-content-tertiary));
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .criteria-summary dd {
+    margin: 0;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/web/src/components/SmartSearchInput.svelte
+++ b/web/src/components/SmartSearchInput.svelte
@@ -8,6 +8,9 @@
     placeholder?: string;
     onsubmit?: () => void;
     inputRef?: HTMLInputElement | null;
+    disabled?: boolean;
+    busy?: boolean;
+    submitLabel?: string;
   }
 
   let {
@@ -17,6 +20,9 @@
     placeholder = 'OAB, número do processo ou texto livre...',
     onsubmit,
     inputRef = $bindable(null),
+    disabled = false,
+    busy = false,
+    submitLabel = 'Buscar',
   }: Props = $props();
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -31,25 +37,33 @@
 </script>
 
 <form class="smart-search" role="search" onsubmit={(e) => { e.preventDefault(); onsubmit?.(); }}>
-  <div class="smart-search__field">
-    <label class="smart-search__label" for="publication-smart-search">Buscar publicações</label>
-    <svg class="smart-search__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
-    </svg>
-    <input
-      id="publication-smart-search"
-      type="search"
-      bind:this={inputRef}
-      bind:value
-      onkeydown={handleKeyDown}
-      {placeholder}
-      autocomplete="off"
-      spellcheck="false"
-      enterkeyhint="search"
-    />
-    {#if value}
-      <button type="reset" class="smart-search__clear secondary outline" onclick={() => (value = '')} aria-label="Limpar busca">×</button>
-    {/if}
+  <div class="smart-search__row">
+    <div class="smart-search__field">
+      <label class="smart-search__label" for="publication-smart-search">Buscar publicações</label>
+      <svg class="smart-search__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+      </svg>
+      <input
+        id="publication-smart-search"
+        type="search"
+        bind:this={inputRef}
+        bind:value
+        onkeydown={handleKeyDown}
+        {placeholder}
+        autocomplete="off"
+        spellcheck="false"
+        enterkeyhint="search"
+      />
+      {#if value}
+        <button type="reset" class="smart-search__clear secondary outline" onclick={() => (value = '')} aria-label="Limpar busca">×</button>
+      {/if}
+    </div>
+    <button type="submit" class="smart-search__submit" disabled={disabled} aria-busy={busy}>
+      {#if busy}
+        <span aria-busy="true" aria-hidden="true"></span>
+      {/if}
+      {submitLabel}
+    </button>
   </div>
   <span class="smart-search__shortcut search-shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd><kbd>K</kbd></span>
   {#if hint}
@@ -63,10 +77,18 @@
     gap: 0.5rem;
   }
 
+  .smart-search__row {
+    display: flex;
+    gap: 0.75rem;
+    align-items: stretch;
+  }
+
   .smart-search__field {
     position: relative;
     display: flex;
     align-items: center;
+    flex: 1 1 18rem;
+    min-inline-size: 0;
   }
 
   .smart-search__label {
@@ -108,11 +130,25 @@
     justify-content: center;
   }
 
+  .smart-search__submit {
+    flex: 0 0 auto;
+  }
+
   .smart-search__shortcut {
     justify-self: start;
   }
 
   .smart-search__hint {
     color: var(--fg-muted, var(--color-content-tertiary));
+  }
+
+  @media (max-width: 640px) {
+    .smart-search__row {
+      flex-direction: column;
+    }
+
+    .smart-search__submit {
+      inline-size: 100%;
+    }
   }
 </style>

--- a/web/src/components/__steps__/publicacoes-search.steps.ts
+++ b/web/src/components/__steps__/publicacoes-search.steps.ts
@@ -53,6 +53,10 @@ async function typeAndSubmit(input: HTMLInputElement, value: string) {
   await fireEvent.keyDown(input, { key: 'Enter' });
 }
 
+async function waitForLocalPreparation() {
+  await new Promise((resolve) => setTimeout(resolve, 350));
+}
+
 describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) => {
   BeforeEachScenario(() => {
     cleanup();
@@ -77,6 +81,35 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
       expect(
         screen.getByText(/Comece digitando um número de OAB, um processo CNJ ou um termo livre/i),
       ).toBeTruthy();
+    });
+  });
+
+
+  Scenario('Typing prepares criteria without submitting to DJEN', ({ Given, When, Then, And }) => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    Given('the DJEN API returns 2 publications for the next request', () => {
+      fetchMock = mockFetchOnce(
+        { items: [samplePublication(1), samplePublication(2)], count: 2 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '29' } },
+      );
+    });
+
+    When('I type "OAB/SP 123456" without submitting', async () => {
+      render(PublicationSearch);
+      const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'OAB/SP 123456' } });
+      await waitForLocalPreparation();
+    });
+
+    Then('I should see the prepared OAB criteria "OAB/SP 123456"', () => {
+      expect(screen.getByText('Critério preparado')).toBeTruthy();
+      expect(screen.getByText('OAB/SP 123456')).toBeTruthy();
+      expect(screen.getByText(/Critério preparado, mas ainda não enviado/i)).toBeTruthy();
+    });
+
+    And('the DJEN API should not have been called', () => {
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 
@@ -105,6 +138,37 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
 
     And('I should see "OAB SP/123456 detectada" as the hint', () => {
       expect(screen.getByText(/OAB SP\/123456 detectada/)).toBeTruthy();
+    });
+  });
+
+
+  Scenario('User submits with the Buscar button', ({ Given, When, Then, And }) => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    Given('the DJEN API returns 1 publication for the next request', () => {
+      fetchMock = mockFetchOnce(
+        { items: [samplePublication(9)], count: 1 },
+        { headers: { 'x-ratelimit-limit': '30', 'x-ratelimit-remaining': '28' } },
+      );
+    });
+
+    When('I type "mandado de segurança" and click Buscar', async () => {
+      render(PublicationSearch);
+      const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'mandado de segurança' } });
+      await fireEvent.click(screen.getByRole('button', { name: /^Buscar$/ }));
+    });
+
+    Then('I should see 1 result card', async () => {
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+        expect(screen.getByText(/1 resultado/)).toBeTruthy();
+      });
+    });
+
+    And('the last DJEN query should include text "mandado de segurança"', () => {
+      const lastUrl = latestFetchUrl(fetchMock);
+      expect(lastUrl.searchParams.get('texto')).toBe('mandado de segurança');
     });
   });
 
@@ -154,14 +218,16 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
       await typeAndSubmit(input, 'contrato');
     });
 
-    Then('I should see a rate-limit banner with a countdown', async () => {
+    Then('I should see a DJEN rate-limit banner with a countdown and historical archive action', async () => {
       await waitFor(() => {
         expect(screen.getByText(/Limite de requisições atingido/i)).toBeTruthy();
+        expect(screen.getByText(/Origem: API DJEN online/i)).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Usar arquivo histórico/i })).toBeTruthy();
       });
     });
   });
 
-  Scenario('Search criteria changes reset pagination', ({ Given, When, Then }) => {
+  Scenario('Search criteria changes reset pagination only after explicit submit', ({ Given, When, Then }) => {
     let fetchMock: ReturnType<typeof vi.fn>;
 
     Given('the DJEN API returns 30 publications out of 60 for each request', () => {
@@ -172,7 +238,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
     });
 
     When(
-      'I search for "contrato", go to page 2, and replace the search with "mandado de segurança"',
+      'I search for "contrato", go to page 2, type "mandado de segurança", and click Buscar',
       async () => {
         render(PublicationSearch);
         const input = screen.getByLabelText('Buscar publicações') as HTMLInputElement;
@@ -189,7 +255,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
           expect(screen.getByText(/Página 2 de 2/)).toBeTruthy();
         });
 
-        await typeAndSubmit(input, 'mandado de segurança');
+        await fireEvent.input(input, { target: { value: 'mandado de segurança' } });
+        expect(latestFetchUrl(fetchMock).searchParams.get('pagina')).toBe('2');
+        await fireEvent.click(screen.getByRole('button', { name: /^Buscar$/ }));
       },
     );
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -25,12 +25,12 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   <header class="hero" aria-labelledby="hero-title">
     <div class="hero__inner">
       <div class="hero__tiles" aria-hidden="true" id="hero-tiles"></div>
-      <span class="kicker">§ Busca pública · sem cadastro · sem rate-limit</span>
+      <span class="kicker">§ Busca pública · sem cadastro · cota DJEN transparente</span>
       <h1 class="mega" id="hero-title">Procure<br/>no <em>DJEN.</em></h1>
       <p class="hero__lede">
         {fmt(totalZips)} documentos preservados desde 2018, vindos de {totalTribunals} tribunais brasileiros.
         Cole um número de processo CNJ, uma inscrição na OAB, o nome de uma parte —
-        ou pesquise por palavra-chave.
+        ou pesquise por palavra-chave. A consulta online respeita a cota pública da API DJEN; quando ela limitar requisições, você ainda pode recorrer ao arquivo histórico preservado.
       </p>
       <form class="hero__search" action={BASE + 'publicacoes'} method="get" role="search">
         <fieldset role="group">


### PR DESCRIPTION
### Motivation
- Remove the inaccurate "sem rate-limit" promise and make the homepage copy reflect the real DJEN quota. 
- Prevent accidental consumption of the shared DJEN quota by stopping debounced API calls while the user types. 
- Give users a clear, reviewable summary of the criteria that will be sent and provide an explicit fallback action when rate limits occur.

### Description
- UI: updated hero copy in `web/src/pages/index.astro` to remove the "sem rate-limit" claim and mention the DJEN quota and historical archive alternative. 
- Input: `web/src/components/SmartSearchInput.svelte` now exposes an explicit submit button and props (`disabled`, `busy`, `submitLabel`) while keeping Enter/Escape keyboard behavior. 
- Search logic: `web/src/components/PublicationSearch.svelte` separates `rawInput` (what user types) from a debounced `preparedInput` used only for local parsing/hints, and only issues DJEN requests on explicit submit (Enter/button) or pagination; added `queryHasIdentity`, `buildCriteriaSummary`, and a visible criteria summary UI. 
- Rate-limit UX: the rate-limit banner now indicates the origin (`DJEN` online) and offers an action to `Usar arquivo histórico` linking to the archived data page. 
- Tests: updated BDD scenarios in `web/features/publicacoes-search.feature` and step implementations in `web/src/components/__steps__/publicacoes-search.steps.ts` to cover prepared-but-not-submitted input, button submission, clarified rate-limit assertions, and pagination reset only after explicit submit.

### Testing
- Ran the publication search BDD steps with `npm test -- src/components/__steps__/publicacoes-search.steps.ts` and the test suite passed (1 test file, 31 tests passed). 
- Ran linter with `npm run lint` and it completed successfully. 
- Ran typecheck with `npm run typecheck` but it could not complete in this environment because Astro requires Node.js `>=22.12.0` while the runner uses `v20.20.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3aa9f878832580e7ee028d53a82d)