### PR TITLE
style(scripts): apply ruff safe autofixes (item c)

### DIFF
--- a/scripts/build_gold_benchmark.py
+++ b/scripts/build_gold_benchmark.py
@@ -106,7 +106,7 @@ def main() -> int:
         load_dotenv(Path(__file__).resolve().parents[2] / ".env")
     except ImportError:
         # Fallback to manual parsing if python-dotenv is not installed
-        for p in [Path("."), Path(".."), Path(__file__).resolve().parents[1], Path(__file__).resolve().parents[2]]:
+        for p in [Path(), Path(".."), Path(__file__).resolve().parents[1], Path(__file__).resolve().parents[2]]:
             env_file = p / ".env"
             if env_file.exists():
                 with open(env_file, encoding="utf-8") as f:
@@ -114,8 +114,7 @@ def main() -> int:
                         line = line.strip()
                         if line and not line.startswith("#"):
                             # Handle export GEMINI_API_KEY="..." or GEMINI_API_KEY="..."
-                            if line.startswith("export "):
-                                line = line[7:]
+                            line = line.removeprefix("export ")
                             if "=" in line:
                                 k, v = line.split("=", 1)
                                 k = k.strip()
@@ -307,7 +306,7 @@ def main() -> int:
                             console.print(f"[yellow]  Sem resultado para ID {int_id} no batch[/yellow]")
                 except Exception as e:
                     console.print(f"[red]  Falha no batch: {e}[/red]")
-                
+
                 # Sleep to avoid hitting Gemini's strict 15 RPM (requests per minute) rate limit
                 await asyncio.sleep(5)
 
@@ -383,7 +382,7 @@ def main() -> int:
     # Export each decision as a .md file with frontmatter metadata
     console.print("\n[yellow]Exportando decisões para arquivos Markdown (.md)...[/yellow]")
     import yaml
-    
+
     # Ensure markdown output directory exists in the workspace
     md_dir = Path("data/benchmark/decisions")
     md_dir.mkdir(parents=True, exist_ok=True)
@@ -409,10 +408,10 @@ def main() -> int:
                 val_date_str = dt.strftime("%Y-%m-%d")
             except ValueError:
                 val_date_str = "2026-05-27"
-        
+
         # Add schema version for dataset versioning tracking
         row["schema_version"] = "1.2.0"
-        
+
         # Clean numpy/pandas data types so they serialize cleanly to standard YAML
         import numpy as np
         for k, v in list(row.items()):
@@ -424,10 +423,10 @@ def main() -> int:
                 row[k] = [x.tolist() if isinstance(x, np.ndarray) else x for x in v]
             elif isinstance(v, dict):
                 row[k] = {str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv) for dk, dv in v.items()}
-        
+
         # Build YAML frontmatter
         frontmatter = yaml.dump(row, allow_unicode=True, default_flow_style=False).strip()
-        
+
         # filename format: court-date-intimation_id.md
         md_filename = f"{court}-{val_date_str}-{int_id}.md"
         md_content = f"---\n{frontmatter}\n---\n\n{texto}\n"

--- a/scripts/check_notebooks_synced.py
+++ b/scripts/check_notebooks_synced.py
@@ -60,7 +60,7 @@ def export_ipynb(notebook: Path, out: Path) -> None:
     with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
         raw = Path(tmp.name)
     try:
-        subprocess.run(  # noqa: S603
+        subprocess.run(
             [
                 "marimo",
                 "export",

--- a/scripts/daily_benchmark_update.py
+++ b/scripts/daily_benchmark_update.py
@@ -296,8 +296,8 @@ def main() -> int:
 
     # Export each decision as a .md file with frontmatter metadata
     console.print("[yellow]Exportando decisões para arquivos Markdown (.md)...[/yellow]")
-    import yaml
     import numpy as np
+    import yaml
 
     md_dir = Path("data/benchmark/decisions")
     md_dir.mkdir(parents=True, exist_ok=True)
@@ -311,7 +311,7 @@ def main() -> int:
         int_id = row["intimation_id"]
         court = row["court"]
         texto = row.pop("texto", "")
-        
+
         val_date_str = "2026-05-27"
         if isinstance(row.get("validated_at"), datetime):
             val_date_str = row["validated_at"].strftime("%Y-%m-%d")
@@ -322,9 +322,9 @@ def main() -> int:
                 val_date_str = dt.strftime("%Y-%m-%d")
             except ValueError:
                 pass
-        
+
         row["schema_version"] = "1.2.0"
-        
+
         # Clean numpy types
         for k, v in list(row.items()):
             if isinstance(v, np.ndarray):
@@ -335,7 +335,7 @@ def main() -> int:
                 row[k] = [x.tolist() if isinstance(x, np.ndarray) else x for x in v]
             elif isinstance(v, dict):
                 row[k] = {str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv) for dk, dv in v.items()}
-        
+
         frontmatter = yaml.dump(row, allow_unicode=True, default_flow_style=False).strip()
         md_filename = f"{court}-{val_date_str}-{int_id}.md"
         md_content = f"---\n{frontmatter}\n---\n\n{texto}\n"


### PR DESCRIPTION
## What

Item (c) of the cleanup plan, scoped to **safe autofixes only** (per your choice). Applies `ruff check --fix` (no `--unsafe-fixes`) to three benchmark scripts — purely cosmetic, **no behaviour change**:

- `Path(".")` → `Path()`
- `line[7:]` → `str.removeprefix("export ")`
- drop trailing whitespace on blank lines (W293)
- remove an unused `# noqa: S603` (RUF100 — verified it does **not** make the strict `--select S` gate fail)
- import-order normalization

## Scope & deliberate exclusions
- Limited to `scripts/build_gold_benchmark.py`, `scripts/check_notebooks_synced.py`, `scripts/daily_benchmark_update.py`.
- **`tested_with_real_data.py` left untouched** — it carries `# ruff: noqa` (its author opted it out of ruff), and the autofix there would have stripped its `sys.path` bootstrap.
- The repo's ~250 other violations are **pre-existing, intentionally non-blocking** style debt — `test.yml` runs them under `ruff check --ignore … ` with `continue-on-error: true` and a comment calling them a "non-blocking regression signal." Not touched.

## Verification
- `ruff format --check` ✅ · `py_compile` ✅ · `check_notebooks_synced.py` ✅
- The blocking CI lint gate (`ruff check --select S,BLE001,B904,TRY300`) is unaffected by these changes.

### Heads-up (separate, pre-existing)
While here I noticed the repo-wide strict gate already reports **2 pre-existing violations** in files I didn't touch — `BLE001` in `src/causaganha/consolidate/cli.py` and `S101` in `src/djen_backup/archive.py`. They're not introduced here; flagging for a possible follow-up.

https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vew5mUoSBxWAwdXEb8ksC6)_