### PR TITLE
refactor: P2/P3 design system and component cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ cd web && npm run dev
 - Cache `has_uploaded_entries` / `counts` in `SyncManifest`; invalidate on mutation.
 - For sampling/debugging absent entries, see patterns in previous audit (sample → `get_caderno_url` live).
 
+### CSS token boundary
+
+Two token systems coexist — keep them in their lanes:
+
+- **Brazilian Modernism** (`--s-*`, `--papel-*`, `--tinta-*`): homepage and marketing sections only (`index.astro`, `sobre.astro`). Do not use inside `container`-layout data pages.
+- **Semantic** (`--color-*`, `--space-*`, `--pico-*`): all functional/data pages (`stats`, `publicacoes`, `explorador`, tribunal pages, etc.).
+
 ### Style
 
 - Ruff is strict. Only formatter-incompatible ignores + accepted-pattern ignores are in `ruff.toml` (see comments).

--- a/web/src/components/LawyerCard.astro
+++ b/web/src/components/LawyerCard.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  index: {
+  stats: {
     tribunal: string;
     dataRatePct: number;
     daysWithData: number;
@@ -8,16 +8,15 @@ interface Props {
   };
 }
 
-const { index } = Astro.props;
-const href = `${import.meta.env.BASE_URL.replace(/\/?$/, '/')}advogados/${index.tribunal.toLowerCase()}`;
+const { stats } = Astro.props;
+const href = `${import.meta.env.BASE_URL.replace(/\/?$/, '/')}advogados/${stats.tribunal.toLowerCase()}`;
 ---
 
 <article>
-  <h3>{index.tribunal}</h3>
-  <p>Base disponível para exploração de OABs neste tribunal</p>
+  <h3>{stats.tribunal}</h3>
   <ul>
-    <li><strong>Dias com dados:</strong> {index.daysWithData.toLocaleString('pt-BR')} de {index.daysTotal.toLocaleString('pt-BR')}</li>
-    <li><strong>Cobertura:</strong> {index.dataRatePct.toFixed(1)}%</li>
+    <li><strong>Dias com dados:</strong> {stats.daysWithData.toLocaleString('pt-BR')} de {stats.daysTotal.toLocaleString('pt-BR')}</li>
+    <li><strong>Cobertura:</strong> {stats.dataRatePct.toFixed(1)}%</li>
   </ul>
   <footer>
     <a href={href} role="button" class="secondary">Ver guia do tribunal</a>

--- a/web/src/components/StatCard.astro
+++ b/web/src/components/StatCard.astro
@@ -10,7 +10,7 @@ const { title, value, subtitle, tone = 'default' } = Astro.props;
 ---
 
 <article>
-  <p class="stat-label">{title}</p>
   <strong class="stat-value" data-tone={tone}>{value}</strong>
+  <p class="stat-label">{title}</p>
   {subtitle && <small>{subtitle}</small>}
 </article>

--- a/web/src/components/TribunalCompareCard.astro
+++ b/web/src/components/TribunalCompareCard.astro
@@ -21,6 +21,6 @@ const dateRange = earliestYear && latestYear
   {dateRange && <p><small>{dateRange}</small></p>}
   <p><small>{zipCount.toLocaleString('pt-BR')} ZIPs arquivados</small></p>
   <footer>
-    <a href={href} role="button" class="secondary">Abrir tribunal</a>
+    <a href={href} role="button" class="secondary">Abrir publicações do {tribunal}</a>
   </footer>
 </article>

--- a/web/src/pages/advogados.astro
+++ b/web/src/pages/advogados.astro
@@ -98,7 +98,7 @@ const leaderboard = readJson<any[]>('data/lawyer_leaderboard.json') ?? [];
 
     <h2 style="margin-top: 3rem;">Cobertura dos Tribunais</h2>
     <section class="auto-grid" style="margin-top: 1rem;">
-      {tribunalStats.map((index: { tribunal: string; dataRatePct: number; daysWithData: number; daysTotal: number }) => <LawyerCard index={index} />)}
+      {tribunalStats.map((stats: { tribunal: string; dataRatePct: number; daysWithData: number; daysTotal: number }) => <LawyerCard stats={stats} />)}
     </section>
   </div>
 </Layout>

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import ManifestStatus from '../components/ManifestStatus.svelte';
+import StatCard from '../components/StatCard.astro';
 import { readJson } from '../lib/readJson';
 
 // All aggregations come from .qmd query contracts rendered against the manifest.
@@ -64,21 +65,23 @@ const base = import.meta.env.BASE_URL;
         <small data-tone="muted">Últimos 30 dias</small>
       </header>
       <div class="auto-grid">
-        <figure>
-          <div class="stat-value">{avgCoverage30Pct.toFixed(1)}<small class="stat-label">%</small></div>
-          <figcaption>Média de Coleta</figcaption>
-          <small data-tone="muted">{avgCoverage30.toFixed(1)} / {totalTribunals} tribunais por dia</small>
-        </figure>
-        <figure>
-          <div class="stat-value" data-tone="success">{bestCount}<small class="stat-label"> / {totalTribunals}</small></div>
-          <figcaption>Melhor Dia</figcaption>
-          <small data-tone="muted">{bestDay ?? '--'}</small>
-        </figure>
-        <figure>
-          <div class="stat-value" data-tone="error">{worstCount}<small class="stat-label"> / {totalTribunals}</small></div>
-          <figcaption>Pior Dia</figcaption>
-          <small data-tone="muted">{worstDay ?? '--'}</small>
-        </figure>
+        <StatCard
+          title="Média de Coleta"
+          value={`${avgCoverage30Pct.toFixed(1)}%`}
+          subtitle={`${avgCoverage30.toFixed(1)} / ${totalTribunals} tribunais por dia`}
+        />
+        <StatCard
+          title="Melhor Dia"
+          value={`${bestCount} / ${totalTribunals}`}
+          subtitle={bestDay ?? '--'}
+          tone="success"
+        />
+        <StatCard
+          title="Pior Dia"
+          value={`${worstCount} / ${totalTribunals}`}
+          subtitle={worstDay ?? '--'}
+          tone="warning"
+        />
       </div>
     </article>
 

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -106,6 +106,10 @@ code, kbd {
   -webkit-overflow-scrolling: touch;
 }
 
+pre {
+  overflow-x: auto;
+}
+
 /* ─── article > header/footer: suppress Pico's sectioning background ─── */
 article > header {
   background: none;


### PR DESCRIPTION
## Summary

Batch of P2 (design system) and P3 (component) fixes from the audit.

### P2 — CSS fixes
- **`base.css`**: add `pre { overflow-x: auto }` — code blocks inside custom card layouts could escape horizontal bounds
- **`CLAUDE.md`**: document the CSS token boundary — Brazilian Modernism tokens (`--s-*`, `--papel-*`) are homepage/marketing only; Semantic tokens (`--color-*`, `--space-*`) are for all functional/data pages

### P3 — Component fixes
- **`StatCard.astro`**: render value before label — universal convention for metric cards; label below value
- **`LawyerCard.astro`**: rename `index` prop → `stats` (was misleading — it holds a stats object); remove hardcoded description "Base disponível para exploração de OABs neste tribunal" that was identical on every card and added zero information
- **`TribunalCompareCard.astro`**: accessible link text "Abrir publicações do {tribunal}" instead of generic "Abrir tribunal"
- **`stats.astro`**: replace 3 raw `<figure>` stat blocks with `StatCard` component — removes the non-standard pattern, uses proper `tone` props

## Test plan
- [ ] Build passes (105 pages)
- [ ] `/stats` shows value-above-label layout in coverage cards
- [ ] `/advogados` renders LawyerCard without the hardcoded description
- [ ] `/comparador` shows tribunal-specific link text on each card

https://claude.ai/code/session_01FAswLmAdCpDk7cbnVkWA7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAswLmAdCpDk7cbnVkWA7W)_