### PR TITLE
[codex] Fix FRONTEND.md violations

### DIFF
--- a/web/src/components/BackfillDetailedStatus.svelte
+++ b/web/src/components/BackfillDetailedStatus.svelte
@@ -54,7 +54,7 @@
                 {/if}
               </td>
               <td><small>{t.genesis_date}</small></td>
-              <td><kbd>{t.cursor_date || 'N/A'}</kbd></td>
+              <td><data value={t.cursor_date ?? ''}>{t.cursor_date || 'N/A'}</data></td>
               <td>
                 <progress value={t.completion_pct} max="100" aria-label="{t.tribunal}: {t.completion_pct}%"></progress>
                 <small>{t.completion_pct}%</small>

--- a/web/src/components/CommandPalette.astro
+++ b/web/src/components/CommandPalette.astro
@@ -74,10 +74,11 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
 <script>
   function setupCommandPalette() {
-    const dialog = document.getElementById('command-palette-dialog') as HTMLDialogElement | null;
+    const dialogEl = document.getElementById('command-palette-dialog') as HTMLDialogElement | null;
     const closeBtn = document.getElementById('command-palette-close');
 
-    if (!dialog || dialog.dataset.commandPaletteBound === 'true') return;
+    if (!dialogEl || dialogEl.dataset.commandPaletteBound === 'true') return;
+    const dialog = dialogEl;
     dialog.dataset.commandPaletteBound = 'true';
 
     function isTypingInField() {

--- a/web/src/components/DataSourceIndicator.astro
+++ b/web/src/components/DataSourceIndicator.astro
@@ -6,8 +6,9 @@
 
 <script>
   function setupDataSourceIndicator() {
-    const indicator = document.getElementById('datasource-indicator');
-    if (!indicator) return;
+    const indicatorEl = document.getElementById('datasource-indicator');
+    if (!indicatorEl) return;
+    const indicator = indicatorEl;
 
     const IA_URL = 'https://archive.org/download/causaganha-dashboard/meta.json';
 

--- a/web/src/components/IASearchBar.svelte
+++ b/web/src/components/IASearchBar.svelte
@@ -139,11 +139,10 @@
         aria-label="Buscar no Internet Archive por tribunal ou ano"
         enterkeyhint="search"
       />
-      {#if shortcutEnabled}
-        <kbd>Ctrl</kbd>
-        <kbd>K</kbd>
-      {/if}
     </label>
+    {#if shortcutEnabled}
+      <span class="search-shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd><kbd>K</kbd></span>
+    {/if}
 
     <div>
       <small>Sugestões:</small>

--- a/web/src/components/ManifestStatus.svelte
+++ b/web/src/components/ManifestStatus.svelte
@@ -125,14 +125,14 @@
 
   <small class="meta-text">Atualizado: {new Date(data.generated_at).toLocaleString('pt-BR')}</small>
 
-  <nav aria-label="Visualização">
+  <div class="manifest-status__view-toggle" role="toolbar" aria-label="Visualização">
     <button type="button" aria-pressed={view === 'tribunals'} onclick={() => view = 'tribunals'}>
       Por Tribunal ({data.tribunals.length})
     </button>
     <button type="button" class="secondary" aria-pressed={view === 'years'} onclick={() => view = 'years'}>
       Por Ano ({data.years.length})
     </button>
-  </nav>
+  </div>
 
   {#if view === 'tribunals'}
     <div class="table-wrap">
@@ -214,3 +214,12 @@
     </div>
   {/if}
 {/if}
+
+<style>
+  .manifest-status__view-toggle {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-block: var(--space-3);
+  }
+</style>

--- a/web/src/components/NetworkStatusBanner.astro
+++ b/web/src/components/NetworkStatusBanner.astro
@@ -4,19 +4,19 @@
   id="network-status-banner"
   role="alert"
   aria-live="assertive"
-  style="display: none;">
+  hidden>
 
-  <div id="ns-slow" style="display: none;">
+  <div id="ns-slow" hidden>
     <strong>Rede Lenta Detectada</strong>
     <small>O carregamento pode demorar mais que o normal. Usando dados em cache, se disponíveis.</small>
   </div>
 
-  <div id="ns-retry" style="display: none;">
+  <div id="ns-retry" hidden>
     <strong>Problema de Conexão</strong>
     <small id="ns-retry-text"></small>
   </div>
 
-  <div id="ns-error" style="display: none;">
+  <div id="ns-error" hidden>
     <div>
       <strong>Falha na Rede</strong>
       <small>Não foi possível conectar ao servidor. Mostrando dados offline em cache.</small>
@@ -51,9 +51,9 @@
     const loadedAt = Date.now();
 
     function hideAll() {
-      elSlow!.style.display = 'none';
-      elRetry!.style.display = 'none';
-      elError!.style.display = 'none';
+      elSlow!.hidden = true;
+      elRetry!.hidden = true;
+      elError!.hidden = true;
       if (countdownInterval) {
         clearInterval(countdownInterval);
         countdownInterval = null;
@@ -66,14 +66,14 @@
 
     function updateView() {
       if (status === 'idle') {
-        banner!.style.display = 'none';
+        banner!.hidden = true;
         hideAll();
       } else {
-        banner!.style.display = 'block';
+        banner!.hidden = false;
         hideAll();
-        if (status === 'slow') elSlow!.style.display = 'block';
-        if (status === 'retrying') elRetry!.style.display = 'block';
-        if (status === 'error') elError!.style.display = 'block';
+        if (status === 'slow') elSlow!.hidden = false;
+        if (status === 'retrying') elRetry!.hidden = false;
+        if (status === 'error') elError!.hidden = false;
       }
     }
 

--- a/web/src/components/SearchFilters.svelte
+++ b/web/src/components/SearchFilters.svelte
@@ -122,8 +122,8 @@
     </label>
   </div>
 
-  <div aria-label="Presets de período mais usados">
-    <small>Período:</small>
+  <fieldset class="publication-filters__presets">
+    <legend>Período</legend>
     {#each DATE_PRESETS as preset (preset.value)}
       <button
         type="button"
@@ -135,7 +135,7 @@
       >{preset.label}</button>
     {/each}
     <button type="button" class="outline" onclick={clearDates}>Limpar datas</button>
-  </div>
+  </fieldset>
 
   <details bind:open={showSecondaryFilters}>
     <summary>Mais filtros</summary>

--- a/web/src/components/SystemStatus.svelte
+++ b/web/src/components/SystemStatus.svelte
@@ -91,9 +91,9 @@
       </p>
     </hgroup>
     {#if stats?.timestamp}
-      <div>
+      <div class="system-status__next-run">
         <small>Próxima execução</small>
-        <kbd>{countdown}</kbd>
+        <data class="system-status__countdown" value={countdown}>{countdown}</data>
       </div>
     {/if}
   </header>
@@ -187,3 +187,22 @@
     </a>
   </footer>
 </article>
+
+<style>
+  .system-status__next-run {
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .system-status__countdown {
+    display: inline-flex;
+    width: fit-content;
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--color-border-muted);
+    border-radius: var(--radius-pill);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    font-variant-numeric: tabular-nums;
+    background: var(--color-surface-elevated);
+  }
+</style>

--- a/web/src/components/TribunalCalendar.svelte
+++ b/web/src/components/TribunalCalendar.svelte
@@ -127,7 +127,7 @@
 <div class="cal-control">
   <div class="cal-control__selectors">
     <div class="cal-control__pick">
-      <label class="kicker" for="tribunal-calendar-tribunal" style="margin-bottom: 4px;">Tribunal</label>
+      <label class="kicker cal-control__label" for="tribunal-calendar-tribunal">Tribunal</label>
       <select id="tribunal-calendar-tribunal" class="select cal-control__select" bind:value={selectedTribunal}>
         {#each TRIBUNAL_GROUPS as group}
           <optgroup label={group.name}>
@@ -140,7 +140,7 @@
     </div>
 
     <div class="cal-control__pick">
-      <label class="kicker" for="tribunal-calendar-year" style="margin-bottom: 4px;">Ano</label>
+      <label class="kicker cal-control__label" for="tribunal-calendar-year">Ano</label>
       <select id="tribunal-calendar-year" class="select cal-control__select" bind:value={selectedYear}>
         {#each Array.from({ length: currentYear - 2018 + 1 }, (_, i) => currentYear - i) as y}
           <option value={y}>{y}</option>
@@ -167,8 +167,8 @@
   <a class="btn btn--secondary btn--sm" href={detailHref}>Ver página →</a>
 </div>
 
-<p style="font-family: var(--font-mono); font-size: var(--t-small); color: var(--fg-muted); margin: 0 0 var(--s-5);">
-  Mostrando <b style="color: var(--fg-heading);">{tribunalLabel}</b>.
+<p class="cal-summary">
+  Mostrando <b class="cal-summary__value">{tribunalLabel}</b>.
 </p>
 
 <div class="mini-months" role="img" aria-label="Calendário de 12 meses">
@@ -200,3 +200,21 @@
     </div>
   {/each}
 </div>
+
+<style>
+  .cal-control__label {
+    display: inline-block;
+    margin-bottom: 4px;
+  }
+
+  .cal-summary {
+    margin: 0 0 var(--s-5);
+    color: var(--fg-muted);
+    font-family: var(--font-mono);
+    font-size: var(--t-small);
+  }
+
+  .cal-summary__value {
+    color: var(--fg-heading);
+  }
+</style>

--- a/web/src/components/TribunalCoverageGrid.astro
+++ b/web/src/components/TribunalCoverageGrid.astro
@@ -32,35 +32,60 @@ const missing = totalTribunals - tribunalStats.length;
     <a href={statsHref}>Ver estatísticas →</a>
   </header>
 
-  <div
-    aria-label="Grade de cobertura dos tribunais"
-    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(1.5rem, 1fr)); gap: 0.25rem;"
-  >
+  <div class="tribunal-coverage-grid" aria-label="Grade de cobertura dos tribunais">
     {sorted.map(t => (
       <div
+        class="tribunal-coverage-grid__cell"
         data-tone={getCellTone(t.data_rate_pct) || undefined}
         title={`${t.tribunal}: ${t.data_rate_pct.toFixed(0)}%`}
         aria-label={`${t.tribunal}: ${t.data_rate_pct.toFixed(0)}% de cobertura`}
-        style="aspect-ratio: 1; border-radius: 2px;"
       />
     ))}
     {Array.from({ length: missing }).map(() => (
       <div
+        class="tribunal-coverage-grid__cell"
         data-tone="muted"
         title="Tribunal sem dados ainda"
-        style="aspect-ratio: 1; border-radius: 2px;"
       />
     ))}
   </div>
 
   <footer>
-    <ul class="auto-grid-sm">
-      <li><span data-tone="success" style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:2px;"></span> ≥80%</li>
-      <li><span style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:2px;background:var(--pico-muted-border-color);"></span> 40–79%</li>
-      <li><span data-tone="warning" style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:2px;"></span> 1–39%</li>
-      <li><span data-tone="error" style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:2px;"></span> 0%</li>
-      <li><span data-tone="muted" style="display:inline-block;width:0.75rem;height:0.75rem;border-radius:2px;"></span> Não iniciado</li>
+    <ul class="auto-grid-sm tribunal-coverage-grid__legend">
+      <li><span class="tribunal-coverage-grid__swatch" data-tone="success"></span> ≥80%</li>
+      <li><span class="tribunal-coverage-grid__swatch tribunal-coverage-grid__swatch--partial"></span> 40–79%</li>
+      <li><span class="tribunal-coverage-grid__swatch" data-tone="warning"></span> 1–39%</li>
+      <li><span class="tribunal-coverage-grid__swatch" data-tone="error"></span> 0%</li>
+      <li><span class="tribunal-coverage-grid__swatch" data-tone="muted"></span> Não iniciado</li>
     </ul>
     <small data-tone="muted">{withData} de {totalTribunals} com dados</small>
   </footer>
 </article>
+
+<style>
+  .tribunal-coverage-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(1.5rem, 1fr));
+    gap: 0.25rem;
+  }
+
+  .tribunal-coverage-grid__cell {
+    aspect-ratio: 1;
+    border-radius: 2px;
+  }
+
+  .tribunal-coverage-grid__legend {
+    align-items: center;
+  }
+
+  .tribunal-coverage-grid__swatch {
+    display: inline-block;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 2px;
+  }
+
+  .tribunal-coverage-grid__swatch--partial {
+    background: var(--pico-muted-border-color);
+  }
+</style>

--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -12,7 +12,6 @@ function fmt(n: number): string {
   return n.toLocaleString('pt-BR');
 }
 
-const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <Layout
@@ -50,10 +49,16 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   </section>
 
   <!-- ═══════════ SEARCH ═══════════ -->
-  <section style="padding: var(--s-7) 0 var(--s-9);">
+  <section class="publication-search-section">
     <div class="wrap wrap--wide">
       <PublicationSearch client:load />
     </div>
   </section>
 
 </Layout>
+
+<style>
+  .publication-search-section {
+    padding: var(--s-7) 0 var(--s-9);
+  }
+</style>

--- a/web/src/pages/sobre.astro
+++ b/web/src/pages/sobre.astro
@@ -46,7 +46,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       <h2>Acesso aos Dados</h2>
       <p>Todos os dados coletados são disponibilizados de maneira estruturada:</p>
       <ul>
-        <li><strong>Zips Originais:</strong> Arquivados no Internet Archive (ex: <kbd>djen-tjro-2025</kbd>).</li>
+        <li><strong>Zips Originais:</strong> Arquivados no Internet Archive (ex: <code>djen-tjro-2025</code>).</li>
         <li><strong>Catálogo Parquet:</strong> Um catálogo completo e indexado pode ser baixado e consultado utilizando ferramentas modernas como o DuckDB.</li>
         <li><strong>Dashboard Público:</strong> Interface simplificada para acompanhar a cobertura diária e encontrar os arquivos de cada tribunal.</li>
       </ul>

--- a/web/src/styles/publications.css
+++ b/web/src/styles/publications.css
@@ -119,10 +119,11 @@
   gap: var(--space-modern-2);
   flex-wrap: wrap;
 }
-.publication-filters__presets small {
+.publication-filters__presets legend {
   font-family: var(--font-mono);
   font-size: var(--font-size-micro);
   color: var(--color-text-muted);
+  margin-bottom: 0;
 }
 
 .publication-card {


### PR DESCRIPTION
## What changed

This PR fixes a batch of `FRONTEND.md` violations in the frontend code under `web/`.

It:
- replaces non-keyboard `<kbd>` usage with semantic `<data>` or `<code>` where appropriate
- moves the `Ctrl+K` search shortcut hint outside the search `<label>`
- replaces an action-group `<nav>` with a proper toolbar wrapper
- converts the date preset label from `<small>` to `<fieldset><legend>`
- removes several inline styles by moving them into scoped styles or classes
- fixes Astro nullability issues in `CommandPalette.astro` and `DataSourceIndicator.astro` so typecheck passes cleanly

## Why

`FRONTEND.md` explicitly forbids a few patterns that were still present in the frontend:
- using `<kbd>` for badges or non-keyboard content
- putting `<kbd>` hints inside a `<label>`
- using `<nav>` for action controls instead of navigation landmarks
- using `<small>` instead of `<legend>` for grouped controls
- relying on inline styles where classes or scoped CSS should be used

## Impact

This keeps the UI behavior the same while improving semantic HTML, accessibility, and alignment with the repo's frontend architecture rules.

## Validation

- `npm run lint`
- `npm run typecheck`
