### PR TITLE
fix(ci): quote step names with colons so test.yml parses again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Check formatting
         run: uv run ruff format --check
-      - name: Check lint (strict: security + policy)
+      - name: "Check lint (strict: security + policy)"
         # Blocking rules: the full `S` security family (bandit port —
         # SQL injection, URL open, subprocess, shell=True, pickle,
         # TLS verify, hash, asserts, etc.), CLAUDE.md-banned BLE001
@@ -28,7 +28,7 @@ jobs:
         # are locked in via per-file-ignores in ruff.toml so this step
         # passes today while blocking new violations in clean files.
         run: uv run ruff check --select S,BLE001,B904,TRY300
-      - name: Check lint (advisory: style)
+      - name: "Check lint (advisory: style)"
         # Everything else (E501, D10x, FBT003, PLR2004, PLC0415, ANN401,
         # PERF401, etc.) — ~265 pre-existing cosmetic violations that
         # stay visible in CI logs as non-blocking regression signal.


### PR DESCRIPTION
## Problema
O workflow `test.yml` (lint + tests + web) **falha em 0s em todo push, inclusive na main, há dias** — *"This run likely failed because of a workflow file issue."* Resultado: o repo está **sem gate automático de teste/lint**.

## Causa
Dois `name:` de step têm um `: ` (dois-pontos + espaço) **sem aspas**, que o YAML lê como separador chave-valor → arquivo inteiro inválido (`yaml.safe_load` falha em L20):

```yaml
- name: Check lint (strict: security + policy)
- name: Check lint (advisory: style)
```

## Fix
Aspas nos dois `name:`. `test.yml` volta a parsear (jobs `lint`, `tests`, `web`) e todos os workflows do repo ficam válidos.

Descoberto ao acompanhar o CI do #763 (cujos checks reportados estão verdes; este workflow não aparecia no rollup justamente porque falhava antes de iniciar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)