### PR TITLE
fix(ci): clear lint/format/vulture/notebook debt surfaced by restored CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Check formatting
         run: uv run ruff format --check
-      - name: Check lint (strict: security + policy)
+      - name: "Check lint (strict: security + policy)"
         # Blocking rules: the full `S` security family (bandit port —
         # SQL injection, URL open, subprocess, shell=True, pickle,
         # TLS verify, hash, asserts, etc.), CLAUDE.md-banned BLE001
@@ -28,7 +28,7 @@ jobs:
         # are locked in via per-file-ignores in ruff.toml so this step
         # passes today while blocking new violations in clean files.
         run: uv run ruff check --select S,BLE001,B904,TRY300
-      - name: Check lint (advisory: style)
+      - name: "Check lint (advisory: style)"
         # Everything else (E501, D10x, FBT003, PLR2004, PLC0415, ANN401,
         # PERF401, etc.) — ~265 pre-existing cosmetic violations that
         # stay visible in CI logs as non-blocking regression signal.

--- a/experiments/show_knn_example.py
+++ b/experiments/show_knn_example.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Mostra exemplo concreto de como k-NN funciona."""
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/analyze_pipeline_performance.py
+++ b/scripts/analyze_pipeline_performance.py
@@ -17,7 +17,6 @@ Measures:
   - Bottlenecks and optimization opportunities
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -11,7 +11,6 @@ Strategy: Append new rows as JSONL lines and push to IA. Append-only keeps write
 Status:   production — invoked by the collect/backfill workflows.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/batch_embed_decisions.py
+++ b/scripts/batch_embed_decisions.py
@@ -12,7 +12,6 @@ Status:   research / experiment — part of the embeddings R&D track (experiment
           scripts/ if yes; archive if no.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/build_gold_benchmark.py
+++ b/scripts/build_gold_benchmark.py
@@ -45,7 +45,9 @@ console = Console()
 DEFAULT_BATCH_SIZE = 20  # ~20x throughput vs single calls (1 RPD per batch)
 
 
-def mock_analysis(intimation_id: int, text: str, keyword_outcome: str) -> tuple[DecisionAnalysis, str]:
+def mock_analysis(
+    intimation_id: int, text: str, keyword_outcome: str
+) -> tuple[DecisionAnalysis, str]:
     """Return a deterministic mock label based on keyword heuristic."""
     outcome = keyword_outcome if keyword_outcome != "unknown" else "improcedente"
     dec_type = "sentença"
@@ -100,13 +102,19 @@ def main() -> int:
     # Load environment variables from .env file
     try:
         from dotenv import load_dotenv
+
         # Try current dir and parent directories
         load_dotenv()
         load_dotenv(Path(__file__).resolve().parents[1] / ".env")
         load_dotenv(Path(__file__).resolve().parents[2] / ".env")
     except ImportError:
         # Fallback to manual parsing if python-dotenv is not installed
-        for p in [Path(), Path(".."), Path(__file__).resolve().parents[1], Path(__file__).resolve().parents[2]]:
+        for p in [
+            Path(),
+            Path(".."),
+            Path(__file__).resolve().parents[1],
+            Path(__file__).resolve().parents[2],
+        ]:
             env_file = p / ".env"
             if env_file.exists():
                 with open(env_file, encoding="utf-8") as f:
@@ -122,10 +130,7 @@ def main() -> int:
                                 os.environ[k] = v
 
     # Check API key
-    api_key = (
-        os.getenv("GEMINI_API_KEY")
-        or os.getenv("GOOGLE_API_KEY")
-    )
+    api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
     if "OPENROUTER_API_KEY" in os.environ:
         del os.environ["OPENROUTER_API_KEY"]
     use_mock = args.mock or not api_key
@@ -186,9 +191,7 @@ def main() -> int:
     """)
 
     # Get already indexed UUIDs in gold_benchmark to avoid re-labeling
-    existing_uuids = {
-        r[0] for r in conn.execute("SELECT text_uuid FROM gold_benchmark").fetchall()
-    }
+    existing_uuids = {r[0] for r in conn.execute("SELECT text_uuid FROM gold_benchmark").fetchall()}
     console.print(f"[blue]Benchmark atual possui {len(existing_uuids)} decisões anotadas.[/blue]\n")
 
     # Fetch candidates from intimations (fetching hash as the text_uuid)
@@ -276,10 +279,7 @@ def main() -> int:
         random.shuffle(shuffled)
 
         # Split into batches
-        batches = [
-            shuffled[i : i + batch_size]
-            for i in range(0, len(shuffled), batch_size)
-        ]
+        batches = [shuffled[i : i + batch_size] for i in range(0, len(shuffled), batch_size)]
         n_batches = len(batches)
         console.print(
             f"  [dim]Batch size: {batch_size} | "
@@ -303,7 +303,9 @@ def main() -> int:
                             analysis, model_used = results[int_id]
                             gold_records.append((text_uuid, int_id, analysis, text, model_used))
                         else:
-                            console.print(f"[yellow]  Sem resultado para ID {int_id} no batch[/yellow]")
+                            console.print(
+                                f"[yellow]  Sem resultado para ID {int_id} no batch[/yellow]"
+                            )
                 except Exception as e:
                     console.print(f"[red]  Falha no batch: {e}[/red]")
 
@@ -414,6 +416,7 @@ def main() -> int:
 
         # Clean numpy/pandas data types so they serialize cleanly to standard YAML
         import numpy as np
+
         for k, v in list(row.items()):
             if isinstance(v, np.ndarray):
                 row[k] = v.tolist()
@@ -422,7 +425,10 @@ def main() -> int:
             elif isinstance(v, list):
                 row[k] = [x.tolist() if isinstance(x, np.ndarray) else x for x in v]
             elif isinstance(v, dict):
-                row[k] = {str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv) for dk, dv in v.items()}
+                row[k] = {
+                    str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv)
+                    for dk, dv in v.items()
+                }
 
         # Build YAML frontmatter
         frontmatter = yaml.dump(row, allow_unicode=True, default_flow_style=False).strip()
@@ -434,7 +440,9 @@ def main() -> int:
         with open(md_path, "w", encoding="utf-8") as f:
             f.write(md_content)
 
-    console.print(f"[green]✓ {len(gold_df)} arquivos .md criados com sucesso em {md_dir}.[/green]\n")
+    console.print(
+        f"[green]✓ {len(gold_df)} arquivos .md criados com sucesso em {md_dir}.[/green]\n"
+    )
 
     # Show final distribution stats
     stats = conn.execute("""

--- a/scripts/check_export_health.py
+++ b/scripts/check_export_health.py
@@ -17,7 +17,6 @@ Exit codes:
     3: UNKNOWN - Cannot determine status
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/check_ia_credentials.py
+++ b/scripts/check_ia_credentials.py
@@ -14,7 +14,6 @@ by making a simple request to the IA S3 API. It exits with 0 on success,
 or 1 if the keys are invalid (e.g. InvalidAccessKeyId).
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/classify_from_batch_embeddings.py
+++ b/scripts/classify_from_batch_embeddings.py
@@ -11,7 +11,6 @@ Status:   research/experiment — pairs with batch_embed_decisions + index_groun
           keeper?
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/continuous_embedding_service.py
+++ b/scripts/continuous_embedding_service.py
@@ -28,7 +28,6 @@ Usage:
         --timeout 3600
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/create_sample_data.py
+++ b/scripts/create_sample_data.py
@@ -8,7 +8,6 @@ Strategy: Write small synthetic datasets in the shapes the export system expects
 Status:   dev/test helper — manual run, not in any workflow.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/daily_benchmark_update.py
+++ b/scripts/daily_benchmark_update.py
@@ -98,16 +98,14 @@ def main() -> int:
     # Load environment variables from .env files
     try:
         from dotenv import load_dotenv
+
         load_dotenv()
         load_dotenv(Path(__file__).resolve().parents[1] / ".env")
         load_dotenv(Path(__file__).resolve().parents[2] / ".env")
     except ImportError:
         pass
 
-    api_key = (
-        os.getenv("GEMINI_API_KEY")
-        or os.getenv("GOOGLE_API_KEY")
-    )
+    api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
     if "OPENROUTER_API_KEY" in os.environ:
         del os.environ["OPENROUTER_API_KEY"]
     use_mock = args.mock or not api_key
@@ -141,9 +139,7 @@ def main() -> int:
         return 1
 
     # Get already labeled IDs/hashes
-    existing_uuids = {
-        r[0] for r in conn.execute("SELECT text_uuid FROM gold_benchmark").fetchall()
-    }
+    existing_uuids = {r[0] for r in conn.execute("SELECT text_uuid FROM gold_benchmark").fetchall()}
     existing_ids = {
         r[0] for r in conn.execute("SELECT intimation_id FROM gold_benchmark").fetchall()
     }
@@ -161,7 +157,9 @@ def main() -> int:
         (args.court,),
     ).fetchall()
 
-    new_candidates = [c for c in candidates if c[0] not in existing_uuids and c[1] not in existing_ids]
+    new_candidates = [
+        c for c in candidates if c[0] not in existing_uuids and c[1] not in existing_ids
+    ]
     if not new_candidates:
         console.print(
             "[green]✓ Não há novas decisões para rotular. Benchmark está 100% atualizado![/green]"
@@ -334,7 +332,10 @@ def main() -> int:
             elif isinstance(v, list):
                 row[k] = [x.tolist() if isinstance(x, np.ndarray) else x for x in v]
             elif isinstance(v, dict):
-                row[k] = {str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv) for dk, dv in v.items()}
+                row[k] = {
+                    str(dk): (dv.tolist() if isinstance(dv, np.ndarray) else dv)
+                    for dk, dv in v.items()
+                }
 
         frontmatter = yaml.dump(row, allow_unicode=True, default_flow_style=False).strip()
         md_filename = f"{court}-{val_date_str}-{int_id}.md"
@@ -343,7 +344,9 @@ def main() -> int:
         with open(md_path, "w", encoding="utf-8") as f:
             f.write(md_content)
 
-    console.print(f"[green]✓ {len(gold_df)} arquivos .md atualizados com sucesso em {md_dir}.[/green]\n")
+    console.print(
+        f"[green]✓ {len(gold_df)} arquivos .md atualizados com sucesso em {md_dir}.[/green]\n"
+    )
 
     conn.close()
     return 0

--- a/scripts/daily_export.py
+++ b/scripts/daily_export.py
@@ -20,7 +20,6 @@ Exit codes:
     3: Configuration error
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/embedding_job.py
+++ b/scripts/embedding_job.py
@@ -30,7 +30,6 @@ Usage:
         --timeout-minutes 50
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/export_daily_embeddings.py
+++ b/scripts/export_daily_embeddings.py
@@ -11,7 +11,6 @@ Status:   experimental/ops — no workflow reference found. RFC: still part of t
 Creates compressed Parquet files optimized for archival storage.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/extract_local_css.py
+++ b/scripts/extract_local_css.py
@@ -9,6 +9,7 @@ Status:   dev/one-off refactor tool — manual run, not in any workflow.
 
 Usage: python scripts/extract_local_css.py [--dry-run]
 """
+
 from __future__ import annotations
 
 import re
@@ -49,9 +50,7 @@ def relative(path: Path) -> str:
 
 
 def main() -> None:
-    files = sorted(
-        [*WEB_SRC.rglob("*.astro"), *WEB_SRC.rglob("*.svelte")]
-    )
+    files = sorted([*WEB_SRC.rglob("*.astro"), *WEB_SRC.rglob("*.svelte")])
 
     extracted: list[tuple[Path, str]] = []
     for f in files:
@@ -68,9 +67,11 @@ def main() -> None:
         print(f"  {relative(f)}")
 
     # Build the appendix
-    sections: list[str] = ["\n\n/* ═══════════════════════════════════════════\n"
-                            "   Component & Page Styles (extracted from source)\n"
-                            "   ═══════════════════════════════════════════ */\n"]
+    sections: list[str] = [
+        "\n\n/* ═══════════════════════════════════════════\n"
+        "   Component & Page Styles (extracted from source)\n"
+        "   ═══════════════════════════════════════════ */\n"
+    ]
     for f, css in extracted:
         label = relative(f)
         sections.append(f"\n/* ── {label} ── */\n{css.strip()}\n")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -23,7 +23,6 @@ Usage:
     python scripts/generate_catalog.py --output ./catalog/
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys
@@ -1159,8 +1158,7 @@ def create_catalog_duckdb(
 
         con.execute("DROP VIEW IF EXISTS backfill_progress;")
         _zip_count_sql = (
-            "SELECT COUNT(DISTINCT date || tribunal)"
-            " FROM manifest WHERE file_type = 'zip'"
+            "SELECT COUNT(DISTINCT date || tribunal) FROM manifest WHERE file_type = 'zip'"
         )
         con.execute(f"""
             CREATE VIEW backfill_progress AS

--- a/scripts/laptop_service.py
+++ b/scripts/laptop_service.py
@@ -1,4 +1,3 @@
-
 """Continuous embedding service for running on a laptop / personal computer.
 
 Purpose:  Run a resilient 24/7 embedding worker on personal hardware.

--- a/scripts/monitor_github_backfill.py
+++ b/scripts/monitor_github_backfill.py
@@ -9,7 +9,6 @@ Status:   ops/monitor — manual run, no workflow reference. RFC: still used, or
           superseded by backfill_probe / the catalog progress JSON?
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/probe_tribunal_start_dates.py
+++ b/scripts/probe_tribunal_start_dates.py
@@ -11,7 +11,6 @@ Status:   ops/data-build — manual run, no workflow reference. RFC: re-run
           periodically as tribunals join, or one-shot?
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/render_manifest_parquet.py
+++ b/scripts/render_manifest_parquet.py
@@ -158,7 +158,6 @@ def render_parquet(csv_path: Path, delta_urls: list[str]) -> Path:
             f"{len(delta_urls)} delta file(s)"
         )
 
-
     con.execute(f"COPY manifest TO '{LOCAL_PARQUET}' (FORMAT PARQUET, COMPRESSION ZSTD)")
     return LOCAL_PARQUET
 

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -143,9 +143,7 @@ def render_all() -> int:
     ratings_path = DEV_RATINGS_DIR / "lawyer_ratings.parquet"
     if ratings_path.exists():
         print(f"Using local lawyer_ratings: {ratings_path}")
-        con.execute(
-            f"CREATE VIEW lawyer_ratings AS SELECT * FROM read_parquet('{ratings_path}')"
-        )
+        con.execute(f"CREATE VIEW lawyer_ratings AS SELECT * FROM read_parquet('{ratings_path}')")
 
     ratings_history_path = DEV_RATINGS_DIR / "ratings_history.parquet"
     if ratings_history_path.exists():

--- a/scripts/stress_test_djen.py
+++ b/scripts/stress_test_djen.py
@@ -298,9 +298,7 @@ def _save_config(safe_concurrency: int, err_threshold: float) -> None:
         )
     )
     rel_path = CONFIG_PATH.relative_to(Path.cwd())
-    console.print(
-        f"   [dim]{SYMBOL_ARROW}[/dim]saved to [cyan]{rel_path}[/cyan]"
-    )
+    console.print(f"   [dim]{SYMBOL_ARROW}[/dim]saved to [cyan]{rel_path}[/cyan]")
 
 
 if __name__ == "__main__":

--- a/scripts/upload_to_ia.py
+++ b/scripts/upload_to_ia.py
@@ -9,7 +9,6 @@ Status:   production — invoked by collect-zips.yml and consolidate-parquet.yml
 Uploads compressed embedding Parquet files to IA for long-term archival.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/validate_api_coverage.py
+++ b/scripts/validate_api_coverage.py
@@ -14,7 +14,6 @@ This script attempts to fetch intimations from a list of courts to determine
 which ones are accessible via the API.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -10,7 +10,6 @@ Strategy: Parse every line as JSON and assert the expected schema/row invariants
 Status:   production — gate step in the manifest publish workflow.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/validate_system_health.py
+++ b/scripts/validate_system_health.py
@@ -17,7 +17,6 @@ Checks:
 4. Basic referential integrity checks (orphaned records).
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/scripts/verify_v2_collection.py
+++ b/scripts/verify_v2_collection.py
@@ -13,7 +13,6 @@ Status:   dev/smoke test — manual run (no workflow reference). RFC: still alig
 Collects metadata from TJRO using V2 components and stores in DuckDB.
 """
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import contextlib
 import sys

--- a/src/causaganha/__init__.py
+++ b/src/causaganha/__init__.py
@@ -10,4 +10,3 @@ for stream in (sys.stdout, sys.stderr):
             stream.reconfigure(errors="replace")
         except AttributeError:
             pass
-

--- a/src/causaganha/analysis/anchor_classifier.py
+++ b/src/causaganha/analysis/anchor_classifier.py
@@ -46,11 +46,11 @@ DEFAULT_NEAR_DUPLICATE_SIM = 0.95
 # Columns expected in anchor_set.parquet
 ANCHOR_SCHEMA = {
     "numero_processo": str,
-    "texto_truncado": str,   # first 1000 chars of decision text
-    "outcome": str,          # one of OUTCOME_KEYS
-    "confidence": float,     # annotation confidence (LLM or manual)
-    "annotation_src": str,   # "llm" | "manual" | "auto"
-    "embedding": object,     # bytes or list[float] — 256-dim EmbeddingGemma
+    "texto_truncado": str,  # first 1000 chars of decision text
+    "outcome": str,  # one of OUTCOME_KEYS
+    "confidence": float,  # annotation confidence (LLM or manual)
+    "annotation_src": str,  # "llm" | "manual" | "auto"
+    "embedding": object,  # bytes or list[float] — 256-dim EmbeddingGemma
 }
 
 
@@ -86,11 +86,11 @@ class AnchorClassifier:
         self.max_anchors_per_class = max_anchors_per_class
         self.near_duplicate_sim = near_duplicate_sim
 
-        self._embeddings: np.ndarray | None = None   # (N, D) float32
-        self._labels: list[str] | None = None         # len N
+        self._embeddings: np.ndarray | None = None  # (N, D) float32
+        self._labels: list[str] | None = None  # len N
         self._confidences: list[float] | None = None  # len N
-        self._loaded_processes: set[str] = set()      # for in-memory dedup
-        self._pending_anchors: list[dict] = []        # batched before flush
+        self._loaded_processes: set[str] = set()  # for in-memory dedup
+        self._pending_anchors: list[dict] = []  # batched before flush
         self._loaded = False
 
     # ------------------------------------------------------------------
@@ -157,6 +157,7 @@ class AnchorClassifier:
 
         # Slow path: mixed or list[float] format — iterate per-row
         import io  # noqa: PLC0415
+
         rows = []
         for val in col:
             if isinstance(val, (list, np.ndarray)):
@@ -209,6 +210,7 @@ class AnchorClassifier:
             )
             # Return uniform distribution when anchor set can't help
             from causaganha.analysis.bayesian_fusion import uniform_prior  # noqa: PLC0415
+
             return uniform_prior()
 
         valid_idx = top_idx[valid_mask]
@@ -327,10 +329,12 @@ class AnchorClassifier:
 
         # Add to in-memory arrays
         if self._loaded and self._embeddings is not None:
-            self._embeddings = np.vstack([
-                self._embeddings,
-                embedding.reshape(1, -1).astype(np.float32),
-            ])
+            self._embeddings = np.vstack(
+                [
+                    self._embeddings,
+                    embedding.reshape(1, -1).astype(np.float32),
+                ]
+            )
             self._labels = self._labels or []
             self._labels.append(outcome)
             self._confidences = self._confidences or []
@@ -342,14 +346,16 @@ class AnchorClassifier:
         self._loaded_processes.add(numero_processo)
 
         # Queue for batched parquet write
-        self._pending_anchors.append({
-            "numero_processo": numero_processo,
-            "texto_truncado": texto_truncado,
-            "embedding": embedding.astype(np.float32).tobytes(),
-            "outcome": outcome,
-            "confidence": confidence,
-            "annotation_src": annotation_src,
-        })
+        self._pending_anchors.append(
+            {
+                "numero_processo": numero_processo,
+                "texto_truncado": texto_truncado,
+                "embedding": embedding.astype(np.float32).tobytes(),
+                "outcome": outcome,
+                "confidence": confidence,
+                "annotation_src": annotation_src,
+            }
+        )
 
         if len(self._pending_anchors) >= _FLUSH_THRESHOLD:
             self.flush()
@@ -386,10 +392,7 @@ class AnchorClassifier:
             existing = ibis.read_parquet(self.anchor_path)
             # Build the full expression lazily; new_ids are small (≤ _FLUSH_THRESHOLD)
             new_ids = [row["numero_processo"] for row in pending]
-            combined = (
-                existing.filter(~existing["numero_processo"].isin(new_ids))
-                .union(new_table)
-            )
+            combined = existing.filter(~existing["numero_processo"].isin(new_ids)).union(new_table)
         else:
             self.anchor_path.parent.mkdir(parents=True, exist_ok=True)
             combined = new_table
@@ -414,4 +417,5 @@ class AnchorClassifier:
         if not self._labels:
             return {}
         from collections import Counter  # noqa: PLC0415
+
         return dict(Counter(self._labels))

--- a/src/causaganha/analysis/bayesian_fusion.py
+++ b/src/causaganha/analysis/bayesian_fusion.py
@@ -122,8 +122,7 @@ def fuse(
 
     # Start with log-prior
     log_posterior: dict[str, float] = {
-        k: math.log(max(prior.get(k, _EPS), _EPS))
-        for k in OUTCOME_KEYS
+        k: math.log(max(prior.get(k, _EPS), _EPS)) for k in OUTCOME_KEYS
     }
 
     # Add each source's weighted log-likelihood

--- a/src/causaganha/analysis/document_classifier.py
+++ b/src/causaganha/analysis/document_classifier.py
@@ -15,6 +15,7 @@ class ClassificationResult(TypedDict):
     confidence: float
     matched_keywords: list[str]
 
+
 class DocumentClassifier:
     """Rule-based classifier for judicial documents."""
 
@@ -163,7 +164,13 @@ class DocumentClassifier:
             best_types = [dt for dt, score in doc_scores.items() if score == max_score]
 
             # Tie breaking priority
-            priority = ["acórdão", "decisão monocrática", "sentença", "decisão interlocutória", "despacho"]
+            priority = [
+                "acórdão",
+                "decisão monocrática",
+                "sentença",
+                "decisão interlocutória",
+                "despacho",
+            ]
             document_type = "outro"
             for p in priority:
                 if p in best_types:
@@ -188,7 +195,7 @@ class DocumentClassifier:
             procedural_class = "outro"
         else:
             # Get the class with the highest score
-            procedural_class = max(class_scores, key=class_scores.get) # type: ignore[arg-type]
+            procedural_class = max(class_scores, key=class_scores.get)  # type: ignore[arg-type]
 
         # Calculate confidence based on the number of matches
         total_matches = len(matched_keywords)

--- a/src/causaganha/analysis/keyword_classifier.py
+++ b/src/causaganha/analysis/keyword_classifier.py
@@ -98,10 +98,13 @@ _OUTCOME_PATTERNS: dict[str, list[tuple[re.Pattern[str], float]]] = {
         (re.compile(r"\bhomologo\s+a\s+transação\b", re.IGNORECASE), 0.92),
         (re.compile(r"\bhomologo\s+a\s+avença\b", re.IGNORECASE), 0.92),
         (re.compile(r"\bhomologo\s+a\s+composi[çc][ãa]o\b", re.IGNORECASE), 0.92),
-        (re.compile(
-            r"\bconcilia[çc][ãa]o\s+(?:entre\s+as\s+partes|realizada|homologada)\b",
-            re.IGNORECASE,
-        ), 0.60),
+        (
+            re.compile(
+                r"\bconcilia[çc][ãa]o\s+(?:entre\s+as\s+partes|realizada|homologada)\b",
+                re.IGNORECASE,
+            ),
+            0.60,
+        ),
         (re.compile(r"\bas\s+partes\s+transigiram\b", re.IGNORECASE), 0.90),
         (re.compile(r"\bas\s+partes\s+chegaram\s+a\s+acordo\b", re.IGNORECASE), 0.88),
         (re.compile(r"\bhomologo\s+o\s+acordo\s+firmado\b", re.IGNORECASE), 0.93),

--- a/src/causaganha/analysis/ml_document_classifier.py
+++ b/src/causaganha/analysis/ml_document_classifier.py
@@ -24,6 +24,7 @@ DEFAULT_PROC_CLASS_PATH = Path("data/ml_procedural_class.joblib")
 # Minimum samples per class needed to train
 MIN_SAMPLES_PER_CLASS = 5
 
+
 def _build_classifiers() -> list[tuple[str, object]]:
     """Build the standard list of classifiers."""
     from sklearn.calibration import CalibratedClassifierCV  # noqa: PLC0415
@@ -88,6 +89,7 @@ def _build_classifiers() -> list[tuple[str, object]]:
             ),
         ),
     ]
+
 
 class MLDocumentEnsemble:
     """Ensemble of scikit-learn classifiers for document type or procedural class classification."""
@@ -161,11 +163,9 @@ class MLDocumentEnsemble:
                 logger.info("training_document_classifier", target=self.target_col, name=name)
                 clf.fit(x_mat, y)
                 n_cv = min(5, *[counts[c] for c in valid_classes])
-                n_cv = max(2, n_cv) # ensure at least 2 folds
+                n_cv = max(2, n_cv)  # ensure at least 2 folds
 
-                scores = cross_val_score(
-                    clf, x_mat, y, cv=n_cv, scoring="f1_macro"
-                )
+                scores = cross_val_score(clf, x_mat, y, cv=n_cv, scoring="f1_macro")
                 cv_results[name] = {
                     "cv_f1_macro_mean": round(float(scores.mean()), 3),
                     "cv_f1_macro_std": round(float(scores.std()), 3),
@@ -182,7 +182,7 @@ class MLDocumentEnsemble:
                     "document_classifier_training_failed",
                     target=self.target_col,
                     name=name,
-                    error=str(exc)
+                    error=str(exc),
                 )
 
         self._classifiers = trained
@@ -222,7 +222,7 @@ class MLDocumentEnsemble:
                     "document_classifier_predict_failed",
                     target=self.target_col,
                     name=name,
-                    error=str(exc)
+                    error=str(exc),
                 )
 
         if not all_probas:
@@ -255,7 +255,7 @@ class MLDocumentEnsemble:
             Top predicted class label (string).
         """
         probas = self.predict_proba(embedding)
-        return max(probas, key=probas.get) # type: ignore[arg-type]
+        return max(probas, key=probas.get)  # type: ignore[arg-type]
 
     def save(self) -> None:
         """Save the trained ensemble to joblib."""

--- a/src/causaganha/analysis/ml_ensemble.py
+++ b/src/causaganha/analysis/ml_ensemble.py
@@ -199,6 +199,7 @@ class EmbeddingEnsemble:
 
         # Filter classes with too few samples
         from collections import Counter  # noqa: PLC0415
+
         counts = Counter(y_raw)
         valid_classes = {cls for cls, cnt in counts.items() if cnt >= MIN_SAMPLES_PER_CLASS}
         final_mask = [label in valid_classes for label in y_raw]
@@ -230,9 +231,7 @@ class EmbeddingEnsemble:
                 logger.info("training_classifier", name=name)
                 clf.fit(x_mat, y)
                 n_cv = min(5, *counts.values())
-                scores = cross_val_score(
-                    clf, x_mat, y, cv=n_cv, scoring="f1_macro"
-                )
+                scores = cross_val_score(clf, x_mat, y, cv=n_cv, scoring="f1_macro")
                 cv_results[name] = {
                     "cv_f1_macro_mean": round(float(scores.mean()), 3),
                     "cv_f1_macro_std": round(float(scores.std()), 3),
@@ -297,6 +296,7 @@ class EmbeddingEnsemble:
 
         if not all_probas:
             from causaganha.analysis.bayesian_fusion import uniform_prior  # noqa: PLC0415
+
             return uniform_prior()
 
         # Soft vote: average probabilities across classifiers
@@ -338,6 +338,7 @@ class EmbeddingEnsemble:
         """
         if not self._is_trained or not self._classifiers:
             from causaganha.analysis.bayesian_fusion import uniform_prior  # noqa: PLC0415
+
             return uniform_prior(), 0.0
 
         x = embedding.reshape(1, -1)
@@ -355,10 +356,12 @@ class EmbeddingEnsemble:
 
         if not all_probas:
             from causaganha.analysis.bayesian_fusion import uniform_prior  # noqa: PLC0415
+
             return uniform_prior(), 0.0
 
         # Agreement: fraction of classifiers picking the same top outcome
         from collections import Counter  # noqa: PLC0415
+
         top_counter = Counter(individual_tops)
         majority_outcome, majority_count = top_counter.most_common(1)[0]
         agreement = majority_count / len(individual_tops)

--- a/src/causaganha/analysis/ner_pipeline.py
+++ b/src/causaganha/analysis/ner_pipeline.py
@@ -83,10 +83,7 @@ class JudicialNER:
         try:
             from transformers import pipeline as hf_pipeline  # noqa: PLC0415
         except ImportError as exc:
-            msg = (
-                "transformers is required for JudicialNER. "
-                "Install with: uv sync --group ner"
-            )
+            msg = "transformers is required for JudicialNER. Install with: uv sync --group ner"
             raise ImportError(msg) from exc
 
         logger.info("loading_ner_model", model=self.model_name)

--- a/src/causaganha/analysis/recurso_resolver.py
+++ b/src/causaganha/analysis/recurso_resolver.py
@@ -22,13 +22,15 @@ if TYPE_CHECKING:
     from causaganha.analysis.bayesian_fusion import WinnerPolo
 
 # Outcomes that indicate an appeal decision (as opposed to a first-instance ruling)
-RECURSO_OUTCOMES: frozenset[str] = frozenset({
-    "provido",
-    "não provido",
-    "parcialmente provido",
-    "não conhecido",
-    "prejudicado",
-})
+RECURSO_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "provido",
+        "não provido",
+        "parcialmente provido",
+        "não conhecido",
+        "prejudicado",
+    }
+)
 
 # First-instance outcome -> winning polo (no polarity inversion)
 _FIRST_INSTANCE_MAP: dict[str, str] = {

--- a/src/causaganha/cli/__init__.py
+++ b/src/causaganha/cli/__init__.py
@@ -1,4 +1,3 @@
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import sys
 

--- a/src/causaganha/consolidate/cli.py
+++ b/src/causaganha/consolidate/cli.py
@@ -155,7 +155,7 @@ async def _consolidate_zips(
                         circuit_breaker=breaker,
                     )
                     results.append(res)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001 — per-table resilience: capture any failure, report all, keep exporting the rest
                     results.append(exc)
             for table_name, result in zip(TABLES, results, strict=True):
                 if isinstance(result, Exception):

--- a/src/djen_backup/__init__.py
+++ b/src/djen_backup/__init__.py
@@ -1,6 +1,5 @@
 """djen-backup: Complete backup of Brazil's DJEN to the Internet Archive."""
 
-
 # Safely reconfigure standard output and standard error encoding error handling on Windows
 import sys
 

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -452,7 +452,6 @@ def upload(
             start_date=date(2020, 1, 1),
             end_date=datetime.now(UTC).date(),
             lower_bound=None,
-
             tribunal=tribunal,
             deadline_minutes=deadline_minutes,
             max_items=max_items,
@@ -555,7 +554,6 @@ def probe(
         )
     )
 
-
     confirmed, absent = asyncio.run(
         _probe(
             workers=workers,
@@ -579,7 +577,6 @@ def reset(
     tribunal: str | None = typer.Option(None, "--tribunal", help="Tribunal code to reset."),
     *,
     reset_all: bool = typer.Option(False, "--all", help="Reset all entries for the tribunal."),  # noqa: FBT003
-
     manifest_file: Path = typer.Option(
         Path("data/sync-manifest.csv"), "--manifest-file", help="Path to manifest CSV."
     ),
@@ -599,7 +596,6 @@ def reset(
     # Reset entries by rebuilding without the targeted entries
     count = 0
     for _k, entry in list(manifest._entries.items()):  # noqa: SLF001
-
         if reset_all or (tribunal and entry.tribunal == tribunal.upper()):
             entry.ia_status = ""
             entry.djen_status = ""

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -311,7 +311,7 @@ def _run_pipeline(c: PipelineRunConfig) -> int:
     config_table.add_row("Deadline:", f"{c.deadline_minutes} min")
     config_table.add_row("Max Items:", str(c.max_items) if c.max_items else "Unlimited")
     config_table.add_row("Workers:", str(c.workers))
-    config_table.add_row("Dry Run:", "Yes" if False else "No")
+    config_table.add_row("Dry Run:", "No")
     config_table.add_row("Fail Fast:", "Yes" if c.fail_fast else "No")
     config_table.add_row("Manifest:", "data/sync-manifest.csv")
     config_table.add_row("DJEN Mode:", "Proxy" if c.use_proxy else "Direct")

--- a/src/djen_backup/archive.py
+++ b/src/djen_backup/archive.py
@@ -215,7 +215,9 @@ async def put_ia_bytes(
             continue
         break
 
-    assert last_resp is not None
+    if last_resp is None:
+        msg = "retry loop exited without recording a response"
+        raise RuntimeError(msg)
     return last_resp
 
 

--- a/tests/djen_backup/test_deadline_timeout.py
+++ b/tests/djen_backup/test_deadline_timeout.py
@@ -30,6 +30,7 @@ async def test_run_sync_deadline_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
 
     async def _get_caderno_url(client, base_url, tribunal, d):
         from djen_backup.djen import DJENNotFoundError
+
         raise DJENNotFoundError(status_code=404, reason="Not Found")
 
     async def _upload_to_ia(self: SyncManifest, auth: str) -> bool:
@@ -49,7 +50,7 @@ async def test_run_sync_deadline_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
             lower_bound=date(2024, 1, 1),
             tribunal="TJSP",
             deadline_minutes=-1,  # Set deadline to negative so it times
-                                  # out in the past
+            # out in the past
             max_items=0,
             workers=1,
             manifest_file=manifest_path,

--- a/tests/djen_backup/test_discover_ia.py
+++ b/tests/djen_backup/test_discover_ia.py
@@ -63,9 +63,7 @@ async def test_discover_falls_back_to_manifest_on_http_error() -> None:
     await m.mark_uploaded("TJSP", date(2024, 1, 2))  # not in fallback
 
     with respx.mock(assert_all_called=False) as router:
-        router.get(url__startswith=_IA_SEARCH_URL).mock(
-            side_effect=httpx.ConnectError("boom")
-        )
+        router.get(url__startswith=_IA_SEARCH_URL).mock(side_effect=httpx.ConnectError("boom"))
         existing = await _discover_ia_items(m)
 
     # Fallback returns (tribunal, year) for entries still pending upload —

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -141,3 +141,6 @@ textos
 
 # State
 State.is_done
+
+# Kept-for-API-compat params explicitly documented as ignored
+max_chars_per_doc


### PR DESCRIPTION
Empilha sobre #765 (fix do YAML). Depois que #765 mergear, o diff aqui mostra só a limpeza.

Ao restaurar o `test.yml` (#765), o CI voltou a rodar e expôs **débito pré-existente** do apagão. Esta PR zera o do job **lint** (determinístico):

- **`ruff format`** — 41 arquivos com formatação divergente (commit isolado, mecânico).
- **Gate estrito** (`S,BLE001,B904,TRY300`):
  - `archive.py`: `assert last_resp is not None` (S101) → guard explícito com `RuntimeError`.
  - `consolidate/cli.py`: justifica o broad-except por-tabela (BLE001) — padrão de resiliência tipo `gather`.
  - `__main__.py`: **bug** — "Dry Run" era `"Yes" if False else "No"` (ternário morto, sempre "No"); este path não tem dry_run → vira `"No"` honesto.
- **vulture**: `max_chars_per_doc` (param mantido por compat, documentado como ignorado) → whitelist.

## Estado dos jobs após esta PR
- `tests (tjro)` ✅ · `lint` ✅ (com esta PR) · `web` ❌ **ainda falha** por **bug de teste de frontend** pré-existente (`expected 'STF' to contain '150'` em `publicacoes.steps.ts:120`) — domínio separado, PR próprio.

Nota: o check de notebooks **não** é débito real — a "staleness" local era só CRLF (Windows); no CI (Linux, marimo→LF) está sincronizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)