### PR TITLE
fix(consolidate): block incomplete validated exports

### DIFF
--- a/docs/planning/consolidation-plan.md
+++ b/docs/planning/consolidation-plan.md
@@ -1,0 +1,551 @@
+# Plano de consolidação — do backfill ao produto
+
+**Data:** 2026-06-02
+**Contexto:** o backfill está quase completo (~157K entries no manifest). O
+pipeline coleta ZIPs, arquiva no IA e faz consolidação diária em 10 tabelas
+Parquet. A questão agora: como fechar a distância entre "arquivamento funcional"
+e "plataforma de dados judiciais confiável".
+
+**Princípio orientador:** *validar o schema antes de consolidar mais*, porque
+cada Parquet com schema errado é retrabalho caro (re-download + re-process +
+re-upload de itens no IA).
+
+**Referência arquitetural:** padrões extraídos do projeto irmão
+[ficha](https://github.com/franklinbaldo/ficha) — especificamente ADRs 0003
+(schema versioning em três camadas), 0006 (validação pragmática), 0008
+(Parquet-per-access-pattern), 0009 (roundtrip-equivalence como gate), e 0012
+(IA como source-of-truth). Os padrões que se aplicam diretamente ao CausaGanha
+são marcados com `[ficha]` nas seções abaixo.
+
+---
+
+## 1. Por que schema primeiro
+
+O pipeline consolida ZIPs em 10 tabelas Parquet (`comunicacoes`, `textos`,
+`destinatarios`, `partes`, `advogados`, `advogado_nomes`,
+`comunicacao_advogados`, `representacoes`, `processos`, `classificacoes`).
+Cada tabela é definida por um `ibis.Schema` em `transforms.py` (l.376-489).
+
+Riscos atuais:
+
+| Risco | Impacto |
+|---|---|
+| **Schema silently drifts** — DJEN API muda campos, nosso `read_json_auto` aceita qualquer coisa | Parquets no IA com colunas extras ou tipos errados; leitores DuckDB quebram |
+| **Sem versão no schema** — `SCHEMA_VERSION = "3"` existe mas não é validado em leitura | Parquets v2 e v3 coexistem no IA sem como distinguir |
+| **Sem validação pós-consolidação** — o pipeline grava e faz upload sem checar se o Parquet resultante respeita o schema declarado | Erro propagado em silêncio |
+| **`classificacoes` é heurística v1** — keyword matching com confidence fixa 0.3, sem benchmark contínuo | Classificações de baixa qualidade congeladas no IA |
+| **Manifest CSV → Parquet em migração** — decisão doc (manifest-source-of-truth.md) define o caminho mas a Fase 1 ainda não rodou | Risco de drift continua |
+
+### Lições do ficha
+
+O ficha enfrentou o mesmo problema com dumps da RFB (layouts mudam
+silenciosamente) e resolveu com três camadas de versionamento (ADR 0003):
+
+1. **Versão embutida no Parquet** — KV metadata no footer (`ficha.schema_version`).
+2. **Manifest público** — `manifest.json` commitado, single source of truth de
+   snapshots.
+3. **Schemas Zod versionados e imutáveis** — `web/src/schemas/v1/`, nunca
+   editados após publicação; mudanças quebram → criar `v2/`.
+
+E com validação pragmática (ADR 0006): asserts SQL simples sobre DuckDB em vez
+de Great Expectations — 5-10 regras críticas, zero deps extras, ms de execução.
+
+O CausaGanha já tem metade das peças (Ibis schemas em Python, Zod gen via
+orval). O que falta é **colá-las**: stampar a versão no Parquet, validar antes
+de upload, e tornar os schemas imutáveis por versão.
+
+---
+
+## 2. Restrições de design
+
+Estas restrições se aplicam a todo código no pipeline de consolidação e são
+obrigatórias para qualquer novo table builder ou transform.
+
+### 2.1 Ibis — nunca pandas
+
+`pandas` está banido do repo (`ruff.toml` `banned-api`). Todo processamento de
+dados usa **Ibis** com o backend DuckDB. Isso não é preferência de estilo — é
+a garantia de que o DuckDB, não o Python, executa os joins e aggregations.
+
+### 2.2 Transformações vetorizadas — nunca row-by-row
+
+Proibido: `.iterrows()`, loops Python sobre DataFrames, list comprehensions que
+materializam rows. Cada table builder deve ser uma expressão Ibis pura que o
+DuckDB compila e executa como SQL.
+
+**Errado:**
+```python
+rows = []
+for record in ndjson_data:       # Python loop → O(n) overhead
+    rows.append(transform(record))
+```
+
+**Certo:**
+```python
+t = con.read_json(path)          # DuckDB lê e transforma em SQL
+result = (t.select(...).filter(...).mutate(...))  # expressão lazy
+```
+
+### 2.3 Delay de materialização — `.execute()` só no `COPY`
+
+Expressões Ibis são **lazy** (o DuckDB só executa quando chamamos `.execute()`
+ou `COPY`). Manter o plano de execução em SQL até o momento do `COPY TO` é o
+que permite ao DuckDB otimizar joins multi-tabela e usar leitura por colunas.
+
+**Regra:** chamar `.execute()` ou `.to_pyarrow()` fora do `COPY` final é sinal
+de que algo pode ser reestruturado como expressão Ibis. A única exceção
+permitida é `t.count().execute()` para checar se a tabela está vazia antes de
+exportar.
+
+### 2.4 UDFs Python — somente para lógica não expressável em SQL
+
+`@ibis.udf.scalar.python` executa Python por-linha dentro do DuckDB. Usar
+apenas para coisas que o SQL não tem: UUIDv5 determinístico (`djen_uuid5`),
+normalização de strings com `unicodedata` (`normalize_name`). Nunca para
+transformar colunas que SQL nativo expressaria em uma linha.
+
+---
+
+## 3. Fases de execução
+
+### Fase 0 — Validação de schema (gate obrigatório)
+
+**Objetivo:** garantir que nenhum Parquet é gravado/uploaded sem validar contra o
+schema declarado. Impede acúmulo de dados com formato errado.
+
+#### 0.1 Schema versioning em três camadas `[ficha ADR 0003]`
+
+O ficha usa três camadas complementares de versionamento. Adaptamos para o
+CausaGanha:
+
+**Camada 1 — Versão embutida no Parquet (KV metadata no footer)**
+
+Cada Parquet consolidado carrega no footer:
+```
+causaganha.schema_version = "3.1.0"
+causaganha.item_id = "djen-2026-06-01"
+causaganha.consolidated_at = "2026-06-02T07:00:00Z"
+```
+Lido via `parquet_kv_metadata()` do DuckDB. Custo zero, colado ao dado.
+
+**Camada 2 — Registry em Python (ETL side)**
+
+Criar `src/causaganha/consolidate/schema_registry.py`:
+
+```
+SchemaVersion
+  version: str           # semver: "3.1.0"
+  tables: dict[str, ibis.Schema]
+  created_at: datetime
+
+CURRENT_VERSION = "3.1.0"
+SCHEMA_REGISTRY: dict[str, SchemaVersion] = {...}
+```
+
+- Registra cada versão do schema junto com o dict de tabelas.
+- A versão atual (`CURRENT_VERSION`) é a que o pipeline usa para gravar.
+- Versões anteriores ficam no registry para leitura/migração.
+- **Regra do ficha:** nunca editar um schema publicado. Mudanças → nova versão.
+
+**Camada 3 — Schemas Zod versionados no frontend**
+
+O CausaGanha já gera Zod schemas via orval (`djen-zod.gen.ts`) para a API.
+Estender para os Parquets consolidados:
+
+```
+web/src/schemas/
+  v3/            ← schema atual dos 10 Parquets
+    comunicacao.ts
+    advogado.ts
+    classificacao.ts
+    ...
+    index.ts     ← re-exports + VERSION = "3.1.0"
+  registry.ts    ← lookup por versão (como ficha)
+```
+
+Frontend lê `causaganha.schema_version` do Parquet footer via DuckDB WASM e
+seleciona o schema correto. Parquets antigos continuam legíveis.
+
+**SemVer (adaptado do ficha ADR 0009):**
+- *patch*: campo opcional novo, campo computado novo
+- *minor*: campo obrigatório com default, lookup description inline
+- *major*: campo removido, campo renomeado, tipo mudou
+
+#### 0.2 Validação pós-export `[ficha ADR 0006]`
+
+Seguindo a abordagem pragmática do ficha: asserts SQL simples sobre DuckDB, sem
+framework externo (nem Great Expectations, nem Pandera no v1).
+
+**Atenção: dois code paths de consolidação coexistem.** O workflow de produção
+(`consolidate-parquet.yml`) roda `scripts/pipeline/consolidate.py` (monolito
+legado), não o módulo refatorado `src/causaganha/consolidate/exporter.py`. A
+validação precisa cobrir **ambos** para ser um gate real:
+
+- **Opção A (preferida):** extrair `validate_parquet()` para um módulo
+  compartilhado (`src/causaganha/consolidate/validation.py`) e importar em
+  ambos os code paths — o refatorado (`exporter.py`) e o legado
+  (`scripts/pipeline/consolidate.py`).
+- **Opção B:** migrar o workflow para usar o módulo refatorado
+  (`python -m causaganha.consolidate backfill`) antes de implementar a
+  validação. Mais limpo, mas bloqueia o gate na migração do workflow.
+
+Independente da opção, após `COPY TO` e antes do upload:
+
+1. Abrir o Parquet com DuckDB.
+2. Comparar colunas/tipos contra `TABLE_SCHEMAS[table_name]`.
+3. Validar invariantes: `id` não-nulo, `tribunal` em lista conhecida,
+   `data_disponibilizacao` parsável como date.
+4. Se falhar: log + skip upload + não marcar checkpoint. Não falha silenciosamente.
+
+```python
+def validate_parquet(path: Path, table_name: str) -> list[str]:
+    """Pragmatic validation — SQL asserts, zero extra deps."""
+    errors = []
+    con = duckdb.connect()
+    cols = con.execute(f"DESCRIBE SELECT * FROM '{path}'").fetchall()
+    expected = TABLE_SCHEMAS[table_name]
+    # Column count + types match
+    # NOT NULL invariants
+    # Domain checks (tribunal in known list, outcome in enum)
+    # Row count > 0 (WARN level)
+    return errors
+```
+
+**Quando escalar:** se regras passarem de ~15, avaliar Pandera (schema-as-class)
+ou dbt-style SQL tests. Não antes.
+
+#### 0.3 Version stamp nos Parquets
+
+Gravar `schema_version` como metadata do Parquet file (via DuckDB `KV_METADATA`):
+
+```sql
+COPY tbl TO 'x.parquet' (FORMAT PARQUET, COMPRESSION ZSTD,
+  KV_METADATA {'schema_version': '3.1.0'});
+```
+
+Leitores podem checar a versão antes de consumir.
+
+#### 0.4 Validação do NDJSON de entrada
+
+Antes de `load_and_transform`, validar amostra do NDJSON contra os field
+variants (`FIELD_*` em `djen_schema.py`). Se > 10% dos records não têm nenhum
+dos campos esperados → abortar esse ZIP (DJEN mudou a API; alarme).
+
+#### 0.5 CI gate — schema snapshot test
+
+Novo test em `tests/test_schema_registry.py`:
+- Snapshot do schema atual (colunas + tipos) serializado como JSON.
+- Qualquer PR que mude `TABLE_SCHEMAS` ou `djen_schema.py` sem bumpar a versão → falha no CI.
+- Protege contra drift acidental do schema.
+
+#### 0.6 Consolidation manifest `[ficha ADR 0008]`
+
+O ficha usa um `manifest.json` como contrato único entre ETL e frontend: lista
+todos os snapshots, seus arquivos, SHA-256, row counts, e schema version. O
+CausaGanha tem o `sync-manifest` (para ZIPs) mas não tem equivalente para os
+Parquets consolidados.
+
+Criar `web/public/data/consolidation-manifest.json`:
+
+```json
+{
+  "schema_version": "3.1.0",
+  "generated_at": "2026-06-02T07:00:00Z",
+  "items": [
+    {
+      "item_id": "djen-2026-06-01",
+      "date": "2026-06-01",
+      "schema_version": "3.1.0",
+      "tables": {
+        "comunicacoes": { "rows": 12345, "size_bytes": 4567890, "sha256": "..." },
+        "advogados":    { "rows": 890,   "size_bytes": 123456,  "sha256": "..." }
+      }
+    }
+  ]
+}
+```
+
+Benefícios:
+- Frontend descobre quais Parquets existem com **um fetch** no boot.
+- DuckDB WASM sabe qual schema usar antes de abrir o Parquet.
+- Drift detection gratuita: diff de manifests sucessivos mostra row count drops.
+- Schema version coverage visível sem varrer todos os itens no IA.
+
+#### 0.7 Roundtrip-equivalence gate `[ficha ADR 0009]`
+
+O ficha valida que seus Parquets denormalizados retornam os mesmos dados que o
+dump cru original (`assert_roundtrip`). Adaptar para CausaGanha:
+
+Após consolidar um date, sortear N comunicações do NDJSON bruto e verificar que
+cada campo presente no Parquet bate com a extração original:
+
+```python
+def assert_roundtrip(con, ndjson_dir: Path, sample_size: int = 100) -> None:
+    sample = sample_records_from_ndjson(ndjson_dir, n=sample_size)
+    for rec in sample:
+        parquet_row = query_comunicacao_by_id(con, rec["id"])
+        assert_fields_match(rec, parquet_row, ignore=["processed_at", "texto_id"])
+```
+
+Campos computados (`texto_id`, `processed_at`, partition columns) são excluídos.
+Falha → não faz upload, exatamente como no ficha.
+
+**Entregável:** nenhum Parquet chega ao IA sem validação. Schema versionado e rastreável.
+
+---
+
+### Fase 1 — Manifest write-back (da decisão doc, já planejada)
+
+Implementar a Fase 1 do `manifest-source-of-truth.md`:
+
+1. Congelar Parquet atual como base (Fase 0 da decisão doc).
+2. `render_manifest_parquet.py` faz merge dos deltas e **escreve de volta** a
+   nova base Parquet (substitui o CSV como fonte canônica).
+3. Corrigir as ~79K linhas `djen_raw='200'` + `djen_status='available'` →
+   `djen_raw='no_publications'` + `djen_status='absent'`.
+
+Sequência obrigatória: parar engine → rodar write-back → reiniciar engine.
+
+**Entregável:** Parquet passa a ser a fonte autoritativa. CSV mantido como backup.
+
+---
+
+### Fase 2 — Consolidação confiável em escala
+
+Com schema validado e manifest correto:
+
+#### 2.1 Backfill da consolidação
+
+Rodar `causaganha.consolidate backfill` sobre todas as datas com ZIPs mas sem
+Parquets. O `candidates.py` já faz esse diff via `dates_needing_consolidation_from_ia`.
+
+Prioridade: datas mais recentes primeiro (já é o default — `ORDER BY date_str DESC`).
+
+#### 2.2 Consolidação incremental (reprocessamento zero)
+
+Datas já consolidadas com a versão atual do schema não são reprocessadas.
+Se o schema bumpar → pipeline de reconsolidação seletiva:
+
+```
+SELECT date FROM catalog
+WHERE schema_version < CURRENT_VERSION
+  AND has_zips = true
+ORDER BY date DESC
+```
+
+#### 2.3 Monitoramento de qualidade contínuo
+
+- **Contagem de registros por tabela por date**: dashboard widget mostrando
+  `comunicacoes.count`, `advogados.count`, etc. por data. Drop repentino = alarme.
+- **Distribuição de classificações**: `classificacoes.outcome` distribution por
+  semana. Shift grande = keyword heuristic degradou ou API mudou.
+- **Schema version coverage**: % de itens no IA com `schema_version == CURRENT`.
+
+---
+
+### Fase 3 — Classificação robusta (upgrade de `classificacoes`)
+
+A tabela `classificacoes` hoje é keyword-matching v1 (confidence=0.3 fixa).
+O benchmark (`data/benchmark/DESIGN.md`) já define o framework de avaliação
+correto (gate + conditional, invariant winner polo, multi-model oracle).
+
+#### 3.1 Benchmark contínuo
+
+- `scripts/daily_benchmark_update.py` já existe. Integrá-lo ao workflow
+  `consolidate-parquet.yml` para que cada run avalie o classificador contra o
+  gold set.
+- Threshold de deploy: só publicar classificações com accuracy >
+  benchmark-target.
+
+#### 3.2 Classificador ML
+
+O pipeline já tem:
+- `analysis/ml_document_classifier.py` — trained on embeddings
+- `analysis/hybrid_analyzer.py` — keyword + RAG fusion
+- `analysis/bayesian_fusion.py` — combine signals
+- `scoring/openskill.py` — lawyer rating
+
+Roadmap de upgrade:
+1. Substituir `keyword_v1` por `hybrid_v2` na consolidação.
+2. Gravar `metodo='hybrid_v2'` + `confidence` real (não fixa).
+3. Manter `keyword_v1` como fallback para when embeddings are unavailable.
+
+#### 3.3 Schema da `classificacoes` v2
+
+Campos a adicionar (requires schema version bump → 4.0.0):
+
+```
+winner_polo: string         # 'A' | 'P' | 'draw' | 'unknown' (invariant winner)
+recorrente_polo: string     # quem recorreu
+fase_processual: string     # 'conhecimento' | 'execução' | 'recursal'
+classe_processual: string
+assunto_principal: string
+valor_causa: float64
+valor_condenacao: float64
+```
+
+Estes campos já existem em `analysis/models.py:DecisionAnalysis` mas não fluem
+para o Parquet consolidado. A Fase 3 fecha esse gap.
+
+---
+
+### Fase 4 — Scoring e produto
+
+Com classificações confiáveis:
+
+#### 4.1 Lawyer ratings em escala
+
+- `scoring/openskill.py` já implementa PlackettLuce.
+- Hoje roda só para TJRO. Escalar para todos os tribunais consolidados.
+- Gravar ratings como tabela Parquet adicional (`lawyer_ratings.parquet`) no IA.
+- Query contract `lawyer_leaderboard.qmd` já consome; generalizar para
+  multi-tribunal.
+
+#### 4.2 Dashboard v2
+
+Funcionalidades que dependem da consolidação confiável:
+
+| Feature | Dependência |
+|---|---|
+| Busca por advogado (cross-tribunal) | `advogados` + `advogado_nomes` consolidados |
+| Explorador de publicações (DuckDB WASM) | Parquets versionados no IA |
+| Página de advogado com rating + histórico | `lawyer_ratings` + `comunicacao_advogados` |
+| Heatmap de classificações por tribunal | `classificacoes` v2 |
+| Comparador de tribunais por outcome | `classificacoes` v2 + `comunicacoes` |
+
+#### 4.3 API de dados abertos `[ficha ADR 0004, 0012]`
+
+- Manter Parquets no IA como API primária (HTTP Range + DuckDB httpfs).
+- `catalog.duckdb` com views remotas já existe.
+- Documentar o schema versionado como contrato público estável.
+- **IA como source-of-truth** (padrão ficha ADR 0012): os Parquets no IA são
+  o artefato canônico. O dashboard é uma view. Se o repo sumir, os dados
+  continuam acessíveis no IA.
+
+#### 4.4 IA practicality probe `[ficha ia_practicality.py]`
+
+Script de diagnóstico que exercita os Parquets consolidados no IA end-to-end:
+
+1. Descobre itens `djen-*` no IA.
+2. Para cada Parquet: `DESCRIBE` (schema inference), `COUNT(*)` (row group
+   stats), `LIMIT 5` (real data access).
+3. Compara colunas contra `MINIMAL_REQUIRED_COLUMNS` por tabela.
+4. Hard failures (zero rows, missing required columns) → exit non-zero.
+5. Soft warnings (optional column missing, schema drift) → annotations.
+
+Roda como CI job periódico (weekly) e detecta degradação de dados no IA antes
+que usuários reportem.
+
+---
+
+## 4. Schema de validação — especificação detalhada
+
+### 4.1 Invariantes por tabela
+
+| Tabela | Invariante | Severidade |
+|---|---|---|
+| `comunicacoes` | `id` NOT NULL, `tribunal` in KNOWN_TRIBUNALS, `data_disponibilizacao` IS DATE | BLOCK |
+| `comunicacoes` | `texto_id` NOT NULL when `texto` exists in raw | WARN |
+| `textos` | `id` NOT NULL, `texto` NOT EMPTY | BLOCK |
+| `destinatarios` | `comunicacao_id` FK → `comunicacoes.id` | WARN |
+| `advogados` | `id` NOT NULL, at least one of `numero_oab`/`nome` non-empty | BLOCK |
+| `classificacoes` | `outcome` in {'WIN','LOSS','PARTIAL','SETTLEMENT','UNKNOWN'} | BLOCK |
+| `classificacoes` | `confidence` BETWEEN 0 AND 1 | BLOCK |
+| `processos` | `numero_processo` matches `\d{20}` or masked format | WARN |
+| All tables | zero rows → WARN (empty date is possible but suspicious) | WARN |
+| All tables | column count matches schema | BLOCK |
+| All tables | column types match schema | BLOCK |
+
+BLOCK = não faz upload, não marca checkpoint.
+WARN = log + upload procede, mas incrementa contador de warnings.
+
+### 4.2 Validação cruzada entre tabelas
+
+Anti-join containment checks (not just cardinality — `COUNT <=` would miss
+orphaned IDs where child has IDs absent from parent):
+
+```sql
+SELECT comunicacao_id FROM destinatarios
+WHERE comunicacao_id NOT IN (SELECT id FROM comunicacoes)
+
+SELECT advogado_id FROM comunicacao_advogados
+WHERE advogado_id NOT IN (SELECT id FROM advogados)
+
+SELECT texto_id FROM classificacoes
+WHERE texto_id NOT IN (SELECT id FROM textos)
+```
+
+Any rows returned = WARN (possible FK to comunicação from another item/date).
+
+### 4.3 Formato do campo `djen_raw` (manifest)
+
+Valores válidos pós-Fase 1:
+
+```
+'200'              # HTTP 200 com URL (available)
+'no_publications'  # HTTP 200 sem URL ("Sem comunicações")
+'404'              # Not Found (genuinely absent)
+'400'              # Bad Request (holidays)
+'403'              # Forbidden (rate limit → unknown)
+'500'              # Internal Server Error (transient → unknown)
+'502'              # Bad Gateway (transient → unknown)
+'503'              # Service Unavailable (transient → unknown)
+'504'              # Gateway Timeout (transient → unknown)
+'timeout'          # Request timeout (unknown)
+'network'          # Network error (unknown)
+```
+
+Must match `TRANSIENT_CODES` in `src/djen_backup/manifest.py` — the 5xx codes
+are legitimate server failures that the engine records and retries. Validation
+on write-back and checker.
+
+---
+
+## 5. Ordem de implementação e estimativas
+
+| # | Tarefa | Fase | Bloqueia | Estimativa |
+|---|---|---|---|---|
+| 1 | Schema registry 3 camadas (Python + KV metadata + Zod) | 0.1, 0.3 | Tudo | M |
+| 2 | Validação pós-export em `exporter.py` | 0.2 | Upload de novos Parquets | P |
+| 3 | CI snapshot test do schema | 0.5 | PRs que tocam schema | P |
+| 4 | Validação NDJSON de entrada | 0.4 | — | M |
+| 5 | Consolidation manifest JSON | 0.6 | Dashboard v2 | M |
+| 6 | Roundtrip-equivalence gate | 0.7 | — | M |
+| 7 | Manifest write-back (Fase 1 da decisão doc) | 1 | Consolidação correta | M |
+| 8 | Backfill da consolidação em escala | 2.1 | — | G |
+| 9 | Monitoramento de qualidade | 2.3 | — | M |
+| 10 | Benchmark contínuo | 3.1 | Upgrade do classificador | M |
+| 11 | Classificador hybrid_v2 | 3.2 | — | G |
+| 12 | Schema classificacoes v2 | 3.3 | Precisa de 1 | M |
+| 13 | Lawyer ratings multi-tribunal | 4.1 | Precisa de 11 | M |
+| 14 | Dashboard v2 features | 4.2 | Precisa de 8, 12 | G |
+| 15 | IA practicality probe (CI weekly) | 4.4 | — | M |
+
+P = pequeno (< 1 dia), M = médio (1-3 dias), G = grande (> 3 dias).
+
+**Caminho crítico:** 1 → 2 → 7 → 8 → 11 → 12 → 13 → 14
+
+**Quick wins imediatos (Fase 0):** tarefas 1, 2, 3 podem ser feitas hoje e já
+protegem contra retrabalho.
+
+---
+
+## 6. O que NÃO fazer
+
+- **Não reconsolidar sem schema validation.** Cada Parquet errado no IA é um
+  item que precisa ser re-uploaded (IA não suporta update parcial).
+- **Não mudar o schema sem version bump.** Consumidores (DuckDB WASM no
+  dashboard) dependem da estabilidade das colunas.
+- **Não editar um schema publicado `[ficha]`.** Mudanças quebram → criar nova
+  versão. Schemas antigos ficam imutáveis no registry para sempre.
+- **Não confiar no CSV como fonte.** Decisão já tomada: o Parquet é mais correto.
+  O CSV é backup histórico.
+- **Não deploiar classificador novo sem benchmark.** O gold set existe e o
+  framework de avaliação está definido. Usá-lo.
+- **Não adicionar campos ao Parquet consolidado sem atualizar `TABLE_SCHEMAS`.**
+  DuckDB `union_by_name` resolve leitura, mas schemas implícitos viram dívida.
+- **Não adotar Great Expectations / framework pesado para <15 regras `[ficha]`.**
+  Asserts SQL sobre DuckDB. Zero deps extras. Reconsiderar Pandera se regras
+  passarem de ~15-20.
+- **Não separar metadado do dado `[ficha]`.** Schema version vive no footer do
+  Parquet (KV metadata), não em arquivo lateral. Fragiliza se separar.

--- a/ruff.toml
+++ b/ruff.toml
@@ -75,6 +75,7 @@ ignore = [
 # checksums; S108 is a hardcoded tmp path (audit on cleanup); S101 is an
 # assert in archive.py that should become a real check.
 "src/causaganha/consolidate/manifest_reader.py" = ["S608"]
+"src/causaganha/consolidate/validation.py" = ["S608"]
 "src/causaganha/storage/embedding_storage.py" = ["S608"]
 "src/causaganha/catalog/creator.py" = ["S608"]
 "src/causaganha/analysis/ground_truth.py" = ["S608"]
@@ -95,6 +96,7 @@ ignore = [
     "SLF001",           # private member access
     "E402",             # module import not at top (dynamic imports in tests)
     "SIM108",           # ternary expressions not required
+    "S608",             # f-string SQL (DuckDB with tmp_path, no user input)
 ]
 
 # ── Scripts ────────────────────────────────────────────────────────────────

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -60,6 +60,8 @@ from tenacity import (
 )
 
 from causaganha.config import TRIBUNAIS
+from causaganha.consolidate.schema_registry import kv_metadata_sql_fragment
+from causaganha.consolidate.validation import validate_parquet
 from causaganha.storage.connection import get_connection
 from causaganha.storage.djen_schema import (
     FIELD_CODIGO_CLASSE,
@@ -408,7 +410,6 @@ class CheckpointManager:
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = "3"
 NAMESPACE_DJEN = uuid.uuid5(uuid.NAMESPACE_DNS, "djen.causaganha.org")
 
 logger = structlog.get_logger()
@@ -1499,6 +1500,7 @@ def _export_table_sync(
     table_name: str,
     con: ibis.BaseBackend,
     output_dir: Path,
+    item_id: str = "",
 ) -> tuple[Path, float, int] | None:
     """Export a single table to Parquet (blocking DuckDB work).
 
@@ -1511,8 +1513,12 @@ def _export_table_sync(
         if count == 0:
             return None
         output_path = output_dir / f"{table_name}.parquet"
+        kv_clause = kv_metadata_sql_fragment(item_id) if item_id else ""
+        copy_opts = "FORMAT PARQUET, COMPRESSION ZSTD"
+        if kv_clause:
+            copy_opts = f"{copy_opts}, {kv_clause}"
         con.raw_sql(
-            f"COPY {table_name} TO '{output_path}' (FORMAT PARQUET, COMPRESSION ZSTD)",
+            f"COPY {table_name} TO '{output_path}' ({copy_opts})",
         )
         size_mb = output_path.stat().st_size / (1024 * 1024)
         return output_path, size_mb, int(count)
@@ -1536,7 +1542,9 @@ async def _export_and_upload_table(
     behaviour as the previous ThreadPoolExecutor path).
     """
     try:
-        export_result = await asyncio.to_thread(_export_table_sync, table_name, con, output_dir)
+        export_result = await asyncio.to_thread(
+            _export_table_sync, table_name, con, output_dir, item_id
+        )
         if export_result is None:
             return False, 0.0, 0
 
@@ -1547,6 +1555,13 @@ async def _export_and_upload_table(
             rows=count,
             size_mb=f"{size_mb:.1f}",
         )
+
+        vr = await asyncio.to_thread(validate_parquet, output_path, table_name)
+        if not vr.passed:
+            logger.error("validation_blocked_upload", table=table_name, errors=vr.errors)
+            return False, size_mb, 0
+        if vr.warnings:
+            logger.warning("validation_warnings", table=table_name, warnings=vr.warnings)
 
         # Upload if not dry run
         uploaded = 0

--- a/src/causaganha/consolidate/cli.py
+++ b/src/causaganha/consolidate/cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Annotated
 
@@ -28,6 +29,7 @@ import structlog
 import typer
 
 from causaganha.consolidate import checkpoint, manifest_reader
+from causaganha.consolidate.candidates import dates_needing_consolidation_from_ia
 from causaganha.consolidate.exporter import export_and_upload_table, upload_marker
 from causaganha.consolidate.transforms import TABLES, init_tables, load_and_transform
 from causaganha.consolidate.zip_processor import process_zip_entry
@@ -59,6 +61,89 @@ def _get_connection(db_path: Path | None = None, memory_limit: str = "2GB") -> i
     return con
 
 
+def _process_zip_entries(
+    zips: list[dict],
+    tmp_path: Path,
+    ndjson_dir: Path,
+    item_id: str,
+    *,
+    workers: int,
+    local_zips: str | None,
+    stats: dict[str, int | float],
+) -> None:
+    """Download and extract ZIP entries into NDJSON, updating aggregate stats."""
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                process_zip_entry,
+                zip_entry,
+                tmp_path,
+                ndjson_dir,
+                item_id,
+                local_zips=local_zips,
+            ): zip_entry
+            for zip_entry in zips
+        }
+        for future in as_completed(futures):
+            zip_entry = futures[future]
+            try:
+                success_cnt, records_cnt = future.result()
+                stats["zips_processed"] += success_cnt
+                stats["records"] += records_cnt
+            except (OSError, ValueError) as e:
+                log.exception(
+                    "zip_processing_error",
+                    zip=zip_entry.get("filename"),
+                    error=str(e),
+                )
+
+
+def _collect_export_results(
+    results: list[tuple[bool, float, int] | Exception],
+    non_empty_tables: set[str],
+    stats: dict[str, int | float],
+) -> None:
+    """Fold per-table export results into stats and count non-empty failures."""
+    for table_name, result in zip(TABLES, results, strict=True):
+        if isinstance(result, Exception):
+            log.error(
+                "table_export_error",
+                table=table_name,
+                error=str(result),
+            )
+            if table_name in non_empty_tables:
+                stats["export_failures"] += 1
+            continue
+
+        success, size_mb, uploaded = result
+        if success:
+            stats["parquets_created"] += 1
+            stats["uploaded"] += uploaded
+            stats["uploaded_mb"] += size_mb
+        elif table_name in non_empty_tables:
+            stats["export_failures"] += 1
+
+
+def _exports_complete(
+    non_empty_tables: set[str],
+    stats: dict[str, int | float],
+    item_id: str,
+) -> bool:
+    """Return true only when every non-empty table produced a valid Parquet."""
+    expected_parquets = len(non_empty_tables)
+    if stats["parquets_created"] == expected_parquets and stats["export_failures"] == 0:
+        return True
+
+    log.error(
+        "marker_blocked_by_incomplete_exports",
+        item_id=item_id,
+        expected_parquets=expected_parquets,
+        parquets_created=stats["parquets_created"],
+        export_failures=stats["export_failures"],
+    )
+    return False
+
+
 async def _consolidate_zips(
     zips: list[dict],
     item_id: str,
@@ -75,6 +160,8 @@ async def _consolidate_zips(
         "parquets_created": 0,
         "uploaded": 0,
         "uploaded_mb": 0.0,
+        "export_failures": 0,
+        "marker_uploaded": 0,
     }
 
     if not zips:
@@ -92,32 +179,15 @@ async def _consolidate_zips(
         init_tables(con)
 
         # Download + extract in parallel — bounded by workers
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = {
-                executor.submit(
-                    process_zip_entry,
-                    zip_entry,
-                    tmp_path,
-                    ndjson_dir,
-                    item_id,
-                    local_zips=local_zips,
-                ): zip_entry
-                for zip_entry in zips
-            }
-            for future in as_completed(futures):
-                zip_entry = futures[future]
-                try:
-                    success_cnt, records_cnt = future.result()
-                    stats["zips_processed"] += success_cnt
-                    stats["records"] += records_cnt
-                except (OSError, ValueError) as e:
-                    log.exception(
-                        "zip_processing_error",
-                        zip=zip_entry.get("filename"),
-                        error=str(e),
-                    )
+        _process_zip_entries(
+            zips,
+            tmp_path,
+            ndjson_dir,
+            item_id,
+            workers=workers,
+            local_zips=local_zips,
+            stats=stats,
+        )
 
         if stats["records"] == 0:
             log.warning("no_records_extracted", item_id=item_id)
@@ -125,6 +195,9 @@ async def _consolidate_zips(
 
         # Transform NDJSON → 10 DuckDB tables via Ibis
         table_counts = load_and_transform(con, ndjson_dir, item_id)
+        non_empty_tables = {
+            table_name for table_name, row_count in table_counts.items() if int(row_count or 0) > 0
+        }
         log.info("transform_complete", item_id=item_id, tables=table_counts)
 
         output_dir = tmp_path / "output"
@@ -157,25 +230,14 @@ async def _consolidate_zips(
                     results.append(res)
                 except Exception as exc:  # noqa: BLE001 — per-table resilience: capture any failure, report all, keep exporting the rest
                     results.append(exc)
-            for table_name, result in zip(TABLES, results, strict=True):
-                if isinstance(result, Exception):
-                    log.exception(
-                        "table_export_error",
-                        table=table_name,
-                        error=str(result),
-                    )
-                    continue
-                success, size_mb, uploaded = result
-                if success:
-                    stats["parquets_created"] += 1
-                    stats["uploaded"] += uploaded
-                    stats["uploaded_mb"] += size_mb
+            _collect_export_results(results, non_empty_tables, stats)
 
-            if (
+            if _exports_complete(non_empty_tables, stats, item_id) and (
                 stats["parquets_created"] > 0
                 and not dry_run
                 and await upload_marker(client, item_id, date_tag, circuit_breaker=breaker)
             ):
+                stats["marker_uploaded"] = 1
                 log.info("marker_uploaded", item_id=item_id)
 
     return stats
@@ -196,7 +258,7 @@ def _print_stats(stats: dict) -> None:
 def date(
     target_date: Annotated[str, typer.Argument(help="Date to consolidate (YYYY-MM-DD)")],
     *,
-    dry_run: bool = typer.Option(False, "--dry-run", help="Skip IA uploads"),
+    dry_run: bool = typer.Option(default=False, help="Skip IA uploads"),
     workers: int = typer.Option(4, "--workers", help="Parallel ZIP processors"),
 ) -> None:
     """Consolidate all ZIPs for a single date into a per-date IA item."""
@@ -206,7 +268,7 @@ def date(
         _consolidate_zips(zips, item_id, target_date, dry_run=dry_run, workers=workers)
     )
     _print_stats(stats)
-    if not dry_run and stats["parquets_created"] > 0:
+    if not dry_run and stats.get("marker_uploaded", 0) > 0:
         checkpoint.mark_date_complete(target_date)
 
 
@@ -215,7 +277,7 @@ def tribunal_year(
     tribunal: Annotated[str, typer.Argument(help="Tribunal code (e.g. TJSP)")],
     year: Annotated[int, typer.Argument(help="Year (e.g. 2026)")],
     *,
-    dry_run: bool = typer.Option(False, "--dry-run", help="Skip IA uploads"),
+    dry_run: bool = typer.Option(default=False, help="Skip IA uploads"),
     workers: int = typer.Option(4, "--workers", help="Parallel ZIP processors"),
 ) -> None:
     """Consolidate all ZIPs for a (tribunal, year) into a per-tribunal-year IA item."""
@@ -231,14 +293,12 @@ def tribunal_year(
 @app.command()
 def backfill(
     *,
-    dry_run: bool = typer.Option(False, "--dry-run", help="Skip IA uploads"),
+    dry_run: bool = typer.Option(default=False, help="Skip IA uploads"),
     workers: int = typer.Option(4, "--workers", help="Parallel ZIP processors per date"),
     max_dates: int = typer.Option(0, "--max-dates", help="Max dates per run (0 = all)"),
     deadline_seconds: int = typer.Option(600, "--deadline-seconds", help="Stop after N seconds"),
 ) -> None:
     """Find unconsolidated dates (newest first) and consolidate them until deadline."""
-    from causaganha.consolidate.candidates import dates_needing_consolidation_from_ia
-
     start = time.monotonic()
     dates = dates_needing_consolidation_from_ia()
     log.info("backfill_candidates", count=len(dates))
@@ -271,7 +331,7 @@ def backfill(
         for k in total_stats:
             total_stats[k] += stats.get(k, 0)
 
-        if not dry_run and stats["parquets_created"] > 0:
+        if not dry_run and stats.get("marker_uploaded", 0) > 0:
             checkpoint.mark_date_complete(target_date)
         processed += 1
 

--- a/src/causaganha/consolidate/exporter.py
+++ b/src/causaganha/consolidate/exporter.py
@@ -16,6 +16,8 @@ import anyio
 import httpx
 import structlog
 
+from causaganha.consolidate.schema_registry import kv_metadata_sql_fragment
+from causaganha.consolidate.validation import validate_parquet
 from causaganha.pipeline.ia_s3 import upload_to_ia
 
 
@@ -40,8 +42,9 @@ def export_table_sync(
     table_name: str,
     con: ibis.BaseBackend,
     output_dir: Path,
+    item_id: str = "",
 ) -> tuple[Path, float, int] | None:
-    """Export one DuckDB table → Parquet file.
+    """Export one DuckDB table → Parquet file with schema version stamp.
 
     Returns ``(output_path, size_mb, row_count)`` or ``None`` when empty.
     Blocking — call via ``asyncio.to_thread`` from async code.
@@ -51,8 +54,12 @@ def export_table_sync(
     if count == 0:
         return None
     output_path = output_dir / f"{table_name}.parquet"
+    kv_clause = kv_metadata_sql_fragment(item_id) if item_id else ""
+    copy_opts = "FORMAT PARQUET, COMPRESSION ZSTD"
+    if kv_clause:
+        copy_opts = f"{copy_opts}, {kv_clause}"
     con.raw_sql(
-        f"COPY {table_name} TO '{output_path}' (FORMAT PARQUET, COMPRESSION ZSTD)",
+        f"COPY {table_name} TO '{output_path}' ({copy_opts})",
     )
     size_mb = output_path.stat().st_size / (1024 * 1024)
     return output_path, size_mb, count
@@ -93,7 +100,13 @@ async def export_and_upload_table(
     Any exception during export or upload is logged and returns ``(False, 0.0, 0)``.
     """
     try:
-        export_result = await asyncio.to_thread(export_table_sync, table_name, con, output_dir)
+        export_result = await asyncio.to_thread(
+            export_table_sync,
+            table_name,
+            con,
+            output_dir,
+            item_id,
+        )
         if export_result is None:
             return False, 0.0, 0
 
@@ -104,6 +117,13 @@ async def export_and_upload_table(
             rows=count,
             size_mb=f"{size_mb:.1f}",
         )
+
+        vr = await asyncio.to_thread(validate_parquet, output_path, table_name)
+        if not vr.passed:
+            log.error("validation_blocked_upload", table=table_name, errors=vr.errors)
+            return False, size_mb, 0
+        if vr.warnings:
+            log.warning("validation_warnings", table=table_name, warnings=vr.warnings)
 
         uploaded = 0
         if not dry_run and await _upload_consolidated(

--- a/src/causaganha/consolidate/schema_registry.py
+++ b/src/causaganha/consolidate/schema_registry.py
@@ -1,0 +1,209 @@
+"""Schema registry: versioned, immutable table schemas for consolidated Parquets.
+
+Three-layer versioning (inspired by ficha ADR 0003):
+  1. KV metadata embedded in Parquet footer (causaganha.schema_version)
+  2. This Python registry (ETL side) — maps version → table schemas
+  3. Zod schemas in web/src/schemas/vN/ (frontend side, future)
+
+Rules:
+  - Never edit a published schema. Changes → new version.
+  - SemVer: patch = optional field added, minor = required field with default,
+    major = field removed/renamed/type changed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import ibis
+
+
+IBIS_TO_DUCKDB_TYPES: dict[str, set[str]] = {
+    "string": {"VARCHAR", "TEXT", "STRING"},
+    "int32": {"INTEGER", "INT4", "INT32", "INT", "SIGNED"},
+    "int64": {"BIGINT", "INT8", "INT64", "LONG", "HUGEINT"},
+    "float64": {"DOUBLE", "FLOAT8", "NUMERIC", "DECIMAL"},
+    "date": {"DATE"},
+    "timestamp": {"TIMESTAMP", "DATETIME", "TIMESTAMP WITH TIME ZONE"},
+    "boolean": {"BOOLEAN", "BOOL", "LOGICAL"},
+}
+
+
+def _types_compatible(ibis_type: str, duckdb_type: str) -> bool:
+    """Check if a DuckDB column type is compatible with an Ibis schema type."""
+    duckdb_upper = duckdb_type.upper().strip()
+    allowed = IBIS_TO_DUCKDB_TYPES.get(ibis_type)
+    if allowed is None:
+        return ibis_type.upper() in duckdb_upper
+    return duckdb_upper in allowed
+
+
+@dataclass(frozen=True)
+class SchemaVersion:
+    """Immutable snapshot of all table schemas for a given version."""
+
+    version: str
+    tables: dict[str, ibis.Schema]
+    created_at: str = field(default_factory=lambda: datetime.now(tz=UTC).isoformat())
+
+    def get_table_schema(self, table_name: str) -> ibis.Schema:
+        """Look up a table's schema. Raises KeyError if not found."""
+        if table_name not in self.tables:
+            msg = f"Table '{table_name}' not in schema version {self.version}"
+            raise KeyError(msg)
+        return self.tables[table_name]
+
+
+SCHEMA_V3 = SchemaVersion(
+    version="3.0.0",
+    created_at="2026-05-01",
+    tables={
+        "comunicacoes": ibis.schema(
+            {
+                "id": "string",
+                "original_id": "string",
+                "tribunal": "string",
+                "numero_processo": "string",
+                "numero_processo_mascara": "string",
+                "data_disponibilizacao": "date",
+                "tipo_comunicacao": "string",
+                "nome_orgao": "string",
+                "meio": "string",
+                "link": "string",
+                "tipo_documento": "string",
+                "nome_classe": "string",
+                "codigo_classe": "string",
+                "numero_comunicacao": "string",
+                "hash": "string",
+                "processed_at": "timestamp",
+                "texto_id": "string",
+                "p_ano": "int32",
+                "p_mes": "int32",
+                "p_item_ia": "string",
+            },
+        ),
+        "advogados": ibis.schema(
+            {
+                "id": "string",
+                "original_id": "string",
+                "tribunal": "string",
+                "nome": "string",
+                "numero_oab": "string",
+                "uf_oab": "string",
+                "p_ano": "int32",
+                "p_mes": "int32",
+                "p_item_ia": "string",
+            },
+        ),
+        "advogado_nomes": ibis.schema(
+            {
+                "advogado_id": "string",
+                "nome": "string",
+                "tribunal": "string",
+                "first_seen": "date",
+            },
+        ),
+        "destinatarios": ibis.schema(
+            {
+                "comunicacao_id": "string",
+                "tribunal": "string",
+                "nome": "string",
+                "polo": "string",
+                "parte_id": "string",
+                "p_ano": "int32",
+                "p_mes": "int32",
+                "p_item_ia": "string",
+            },
+        ),
+        "comunicacao_advogados": ibis.schema(
+            {
+                "comunicacao_id": "string",
+                "tribunal": "string",
+                "advogado_id": "string",
+            },
+        ),
+        "textos": ibis.schema(
+            {
+                "id": "string",
+                "texto": "string",
+            },
+        ),
+        "representacoes": ibis.schema(
+            {
+                "comunicacao_id": "string",
+                "tribunal": "string",
+                "advogado_id": "string",
+                "parte_id": "string",
+                "polo": "string",
+                "p_ano": "int32",
+                "p_mes": "int32",
+                "p_item_ia": "string",
+            },
+        ),
+        "processos": ibis.schema(
+            {
+                "numero_processo": "string",
+                "tribunal": "string",
+                "data": "date",
+                "comunicacao_id": "string",
+                "p_ano": "int32",
+                "p_mes": "int32",
+                "p_item_ia": "string",
+            },
+        ),
+        "classificacoes": ibis.schema(
+            {
+                "texto_id": "string",
+                "metodo": "string",
+                "outcome": "string",
+                "decision_type": "string",
+                "winner_advogado_id": "string",
+                "loser_advogado_id": "string",
+                "confidence": "float64",
+                "classified_at": "timestamp",
+            },
+        ),
+        "partes": ibis.schema(
+            {
+                "id": "string",
+                "nome_normalizado": "string",
+                "nome_original": "string",
+            },
+        ),
+    },
+)
+
+CURRENT_VERSION = "3.0.0"
+
+SCHEMA_REGISTRY: dict[str, SchemaVersion] = {
+    "3.0.0": SCHEMA_V3,
+}
+
+
+def get_schema(version: str) -> SchemaVersion:
+    """Look up a schema version. Raises KeyError if not found."""
+    if version not in SCHEMA_REGISTRY:
+        msg = f"Schema version '{version}' not found. Available: {list(SCHEMA_REGISTRY.keys())}"
+        raise KeyError(msg)
+    return SCHEMA_REGISTRY[version]
+
+
+def get_current_schema() -> SchemaVersion:
+    """Return the current (latest) schema version."""
+    return SCHEMA_REGISTRY[CURRENT_VERSION]
+
+
+def kv_metadata_for_export(item_id: str) -> dict[str, str]:
+    """Return KV metadata dict to embed in Parquet footer via DuckDB."""
+    return {
+        "causaganha.schema_version": CURRENT_VERSION,
+        "causaganha.item_id": item_id,
+    }
+
+
+def kv_metadata_sql_fragment(item_id: str) -> str:
+    """Return the KV_METADATA clause for a DuckDB COPY statement."""
+    meta = kv_metadata_for_export(item_id)
+    pairs = ", ".join(f"'{k}': '{v}'" for k, v in meta.items())
+    return f"KV_METADATA {{{pairs}}}"

--- a/src/causaganha/consolidate/transforms.py
+++ b/src/causaganha/consolidate/transforms.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-SCHEMA_VERSION = "3"
 NAMESPACE_DJEN = uuid.uuid5(uuid.NAMESPACE_DNS, "djen.causaganha.org")
 
 

--- a/src/causaganha/consolidate/validation.py
+++ b/src/causaganha/consolidate/validation.py
@@ -1,0 +1,286 @@
+"""Pragmatic Parquet validation — SQL asserts over DuckDB, zero extra deps.
+
+Shared by both code paths:
+  - src/causaganha/consolidate/exporter.py (refactored module)
+  - scripts/pipeline/consolidate.py (legacy monolith used by CI workflow)
+
+Severity levels:
+  BLOCK = do not upload, do not mark checkpoint
+  WARN  = log + upload proceeds, increment warning counter
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import duckdb
+import structlog
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from causaganha.config import TRIBUNAIS
+from causaganha.consolidate.schema_registry import (
+    CURRENT_VERSION,
+    SCHEMA_REGISTRY,
+    _types_compatible,
+)
+
+
+log = structlog.get_logger()
+
+KNOWN_TRIBUNALS: frozenset[str] = frozenset(TRIBUNAIS)
+
+VALID_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "WIN",
+        "LOSS",
+        "PARTIAL",
+        "SETTLEMENT",
+        "UNKNOWN",
+    }
+)
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating one Parquet table."""
+
+    table_name: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """True when no blocking errors were found."""
+        return len(self.errors) == 0
+
+
+def validate_parquet(
+    path: Path,
+    table_name: str,
+    *,
+    schema_version: str = CURRENT_VERSION,
+    check_kv_metadata: bool = True,
+) -> ValidationResult:
+    """Validate a Parquet file against the declared schema.
+
+    Returns a ValidationResult with errors (BLOCK) and warnings (WARN).
+    """
+    result = ValidationResult(table_name=table_name)
+
+    if not path.exists():
+        result.errors.append(f"File does not exist: {path}")
+        return result
+
+    schema_entry = SCHEMA_REGISTRY.get(schema_version)
+    if schema_entry is None:
+        result.errors.append(f"Unknown schema version: {schema_version}")
+        return result
+
+    expected_schema = schema_entry.tables.get(table_name)
+    if expected_schema is None:
+        result.errors.append(f"Table '{table_name}' not in schema {schema_version}")
+        return result
+
+    con = duckdb.connect()
+    try:
+        _validate_columns(con, path, table_name, expected_schema, result)
+        if check_kv_metadata:
+            _validate_kv_metadata(con, path, schema_version, result)
+        _validate_row_count(con, path, table_name, result)
+        _validate_invariants(con, path, table_name, result)
+    except duckdb.Error as e:
+        result.errors.append(f"DuckDB error reading {path}: {e}")
+    finally:
+        con.close()
+
+    return result
+
+
+def _validate_columns(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    table_name: str,
+    expected_schema: object,
+    result: ValidationResult,
+) -> None:
+    """Check column names and types match the expected schema."""
+    cols = con.execute(f"DESCRIBE SELECT * FROM '{path}'").fetchall()
+    actual_names = [c[0] for c in cols]
+    actual_types = {c[0]: c[1] for c in cols}
+
+    expected_pairs = list(expected_schema.items())
+    expected_names = [name for name, _ in expected_pairs]
+    expected_types = {name: str(dtype) for name, dtype in expected_pairs}
+
+    missing = set(expected_names) - set(actual_names)
+    if missing:
+        result.errors.append(f"{table_name}: missing columns {sorted(missing)}")
+
+    extra = set(actual_names) - set(expected_names)
+    if extra:
+        result.errors.append(f"{table_name}: unexpected extra columns {sorted(extra)}")
+
+    for col_name in set(expected_names) & set(actual_names):
+        expected_t = expected_types[col_name]
+        actual_t = actual_types[col_name]
+        if not _types_compatible(expected_t, actual_t):
+            result.errors.append(
+                f"{table_name}.{col_name}: expected type '{expected_t}', got '{actual_t}'"
+            )
+
+
+def _validate_kv_metadata(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    expected_version: str,
+    result: ValidationResult,
+) -> None:
+    """Check that the Parquet footer contains the expected schema version stamp."""
+    rows = con.execute(f"SELECT key, value FROM parquet_kv_metadata('{path}')").fetchall()
+    kv = {
+        (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+        for k, v in rows
+    }
+    actual = kv.get("causaganha.schema_version")
+    if actual is None:
+        result.errors.append("Missing causaganha.schema_version in Parquet KV metadata")
+    elif actual != expected_version:
+        result.errors.append(
+            f"Schema version mismatch in KV metadata: expected '{expected_version}', got '{actual}'"
+        )
+
+
+def _validate_row_count(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    table_name: str,
+    result: ValidationResult,
+) -> None:
+    """Warn on zero rows (empty date is possible but suspicious)."""
+    row_count = con.execute(f"SELECT COUNT(*) FROM '{path}'").fetchone()[0]
+    if row_count == 0:
+        result.warnings.append(f"{table_name}: zero rows")
+
+
+def _validate_invariants(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    table_name: str,
+    result: ValidationResult,
+) -> None:
+    """Check domain-specific invariants per table."""
+    if table_name == "comunicacoes":
+        _check_not_null(con, path, "id", table_name, result)
+        _check_tribunal_domain(con, path, "tribunal", table_name, result)
+
+    elif table_name == "textos":
+        _check_not_null(con, path, "id", table_name, result)
+        empty = con.execute(
+            f"SELECT COUNT(*) FROM '{path}' WHERE texto IS NULL OR texto = ''"
+        ).fetchone()[0]
+        if empty > 0:
+            result.errors.append(f"textos: {empty} rows with NULL/empty texto")
+
+    elif table_name == "advogados":
+        _check_not_null(con, path, "id", table_name, result)
+
+    elif table_name == "classificacoes":
+        _check_not_null(con, path, "outcome", table_name, result)
+        _check_not_null(con, path, "confidence", table_name, result)
+
+        invalid_outcomes = con.execute(
+            f"SELECT DISTINCT outcome FROM '{path}' "
+            f"WHERE outcome IS NOT NULL "
+            f"AND outcome NOT IN ({','.join(repr(o) for o in VALID_OUTCOMES)})"
+        ).fetchall()
+        if invalid_outcomes:
+            vals = [r[0] for r in invalid_outcomes]
+            result.errors.append(f"classificacoes: invalid outcomes {vals}")
+
+        bad_confidence = con.execute(
+            f"SELECT COUNT(*) FROM '{path}' "
+            f"WHERE confidence IS NOT NULL AND (confidence < 0 OR confidence > 1)"
+        ).fetchone()[0]
+        if bad_confidence > 0:
+            result.errors.append(
+                f"classificacoes: {bad_confidence} rows with confidence outside [0,1]"
+            )
+
+    elif table_name in ("destinatarios", "comunicacao_advogados", "representacoes"):
+        _check_not_null(con, path, "comunicacao_id", table_name, result)
+
+    elif table_name == "processos":
+        _check_not_null(con, path, "numero_processo", table_name, result)
+        _check_tribunal_domain(con, path, "tribunal", table_name, result)
+
+
+def _check_not_null(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    column: str,
+    table_name: str,
+    result: ValidationResult,
+) -> None:
+    null_count = con.execute(
+        f"SELECT COUNT(*) FROM '{path}' WHERE \"{column}\" IS NULL"
+    ).fetchone()[0]
+    if null_count > 0:
+        result.errors.append(f"{table_name}: {null_count} NULL values in '{column}'")
+
+
+def _check_tribunal_domain(
+    con: duckdb.DuckDBPyConnection,
+    path: Path,
+    column: str,
+    table_name: str,
+    result: ValidationResult,
+) -> None:
+    tribunals = con.execute(
+        f'SELECT DISTINCT "{column}" FROM \'{path}\' WHERE "{column}" IS NOT NULL'
+    ).fetchall()
+    unknown = [r[0] for r in tribunals if r[0] not in KNOWN_TRIBUNALS]
+    if unknown:
+        result.errors.append(f"{table_name}: unknown tribunals in '{column}': {unknown[:5]}")
+
+
+def all_passed(results: dict[str, ValidationResult]) -> bool:
+    """True when every table in the results dict passed validation."""
+    return all(r.passed for r in results.values())
+
+
+def validate_all_tables(
+    output_dir: Path,
+    *,
+    schema_version: str = CURRENT_VERSION,
+    check_kv_metadata: bool = True,
+) -> dict[str, ValidationResult]:
+    """Validate all Parquet files in a directory against the schema.
+
+    Returns a dict of table_name → ValidationResult.
+    Use ``all_passed(results)`` to gate the completion marker.
+    """
+    schema_entry = SCHEMA_REGISTRY.get(schema_version)
+    if schema_entry is None:
+        return {}
+
+    results: dict[str, ValidationResult] = {}
+    for table_name in schema_entry.tables:
+        parquet_path = output_dir / f"{table_name}.parquet"
+        if parquet_path.exists():
+            r = validate_parquet(
+                parquet_path,
+                table_name,
+                schema_version=schema_version,
+                check_kv_metadata=check_kv_metadata,
+            )
+            results[table_name] = r
+            if r.errors:
+                log.error("validation_failed", table=table_name, errors=r.errors)
+            if r.warnings:
+                log.warning("validation_warnings", table=table_name, warnings=r.warnings)
+
+    return results

--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -1,0 +1,267 @@
+"""Schema registry snapshot tests.
+
+Ensures TABLE_SCHEMAS in transforms.py stays in sync with the schema
+registry, and that schema versions are never modified after publication.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from causaganha.consolidate.schema_registry import (
+    CURRENT_VERSION,
+    SCHEMA_REGISTRY,
+    get_current_schema,
+    get_schema,
+    kv_metadata_for_export,
+    kv_metadata_sql_fragment,
+)
+from causaganha.consolidate.transforms import TABLE_SCHEMAS, TABLES
+from causaganha.consolidate.validation import all_passed, validate_parquet
+
+
+class TestSchemaRegistryConsistency:
+    """TABLE_SCHEMAS in transforms.py must match the current registry version."""
+
+    def test_all_tables_present_in_registry(self) -> None:
+        schema = get_current_schema()
+        for table_name in TABLES:
+            assert table_name in schema.tables, (
+                f"Table '{table_name}' in TABLES but missing from registry "
+                f"version {CURRENT_VERSION}"
+            )
+
+    def test_all_registry_tables_present_in_transforms(self) -> None:
+        schema = get_current_schema()
+        for table_name in schema.tables:
+            assert table_name in TABLE_SCHEMAS, (
+                f"Table '{table_name}' in registry but missing from TABLE_SCHEMAS"
+            )
+
+    def test_schemas_match_field_by_field(self) -> None:
+        schema = get_current_schema()
+        for table_name in TABLES:
+            registry_schema = schema.tables[table_name]
+            transforms_schema = TABLE_SCHEMAS[table_name]
+            registry_fields = dict(registry_schema.items())
+            transforms_fields = dict(transforms_schema.items())
+            assert registry_fields == transforms_fields, (
+                f"Schema mismatch for '{table_name}' between registry "
+                f"({CURRENT_VERSION}) and TABLE_SCHEMAS.\n"
+                f"Registry: {registry_fields}\n"
+                f"Transforms: {transforms_fields}"
+            )
+
+
+class TestSchemaVersioning:
+    def test_current_version_exists(self) -> None:
+        assert CURRENT_VERSION in SCHEMA_REGISTRY
+
+    def test_get_schema_returns_correct_version(self) -> None:
+        sv = get_schema(CURRENT_VERSION)
+        assert sv.version == CURRENT_VERSION
+
+    def test_get_schema_unknown_raises(self) -> None:
+        with pytest.raises(KeyError, match="not found"):
+            get_schema("99.99.99")
+
+    def test_schema_version_is_semver(self) -> None:
+        for version in SCHEMA_REGISTRY:
+            parts = version.split(".")
+            assert len(parts) == 3, f"Version '{version}' is not semver"
+            for part in parts:
+                assert part.isdigit(), f"Version '{version}' has non-numeric part"
+
+
+class TestKVMetadata:
+    def test_kv_metadata_contains_version(self) -> None:
+        meta = kv_metadata_for_export("djen-2026-06-01")
+        assert meta["causaganha.schema_version"] == CURRENT_VERSION
+
+    def test_kv_metadata_contains_item_id(self) -> None:
+        meta = kv_metadata_for_export("djen-2026-06-01")
+        assert meta["causaganha.item_id"] == "djen-2026-06-01"
+
+    def test_kv_sql_fragment_parseable(self) -> None:
+        fragment = kv_metadata_sql_fragment("djen-test")
+        assert "KV_METADATA" in fragment
+        assert CURRENT_VERSION in fragment
+
+    def test_kv_metadata_roundtrips_through_duckdb(self) -> None:
+        con = duckdb.connect()
+        con.execute("CREATE TABLE t AS SELECT 1 AS x")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.parquet"
+            fragment = kv_metadata_sql_fragment("djen-roundtrip")
+            con.execute(f"COPY t TO '{path}' (FORMAT PARQUET, COMPRESSION ZSTD, {fragment})")
+            kv = con.execute(f"SELECT key, value FROM parquet_kv_metadata('{path}')").fetchall()
+            kv_dict = {
+                (k.decode() if isinstance(k, bytes) else k): (
+                    v.decode() if isinstance(v, bytes) else v
+                )
+                for k, v in kv
+            }
+            assert kv_dict["causaganha.schema_version"] == CURRENT_VERSION
+            assert kv_dict["causaganha.item_id"] == "djen-roundtrip"
+        con.close()
+
+
+class TestValidation:
+    @pytest.fixture
+    def valid_comunicacoes_parquet(self, tmp_path: Path) -> Path:
+        con = duckdb.connect()
+        fragment = kv_metadata_sql_fragment("djen-2026-06-01")
+        con.execute("""
+            CREATE TABLE comunicacoes AS SELECT
+                'uuid-1' AS id,
+                '12345' AS original_id,
+                'TJRO' AS tribunal,
+                '00012345678901234567' AS numero_processo,
+                '0001234-56.2026.8.26.0100' AS numero_processo_mascara,
+                DATE '2026-06-01' AS data_disponibilizacao,
+                'Intimação' AS tipo_comunicacao,
+                '1ª Vara' AS nome_orgao,
+                'D' AS meio,
+                'https://x' AS link,
+                'Sentença' AS tipo_documento,
+                'Comum' AS nome_classe,
+                '7' AS codigo_classe,
+                '1' AS numero_comunicacao,
+                'abc123' AS hash,
+                CURRENT_TIMESTAMP AS processed_at,
+                'texto-uuid' AS texto_id,
+                2026 AS p_ano,
+                6 AS p_mes,
+                'djen-2026-06-01' AS p_item_ia
+        """)
+        path = tmp_path / "comunicacoes.parquet"
+        con.execute(f"COPY comunicacoes TO '{path}' (FORMAT PARQUET, COMPRESSION ZSTD, {fragment})")
+        con.close()
+        return path
+
+    def test_valid_parquet_passes(self, valid_comunicacoes_parquet: Path) -> None:
+        result = validate_parquet(valid_comunicacoes_parquet, "comunicacoes")
+        assert result.passed, f"Unexpected errors: {result.errors}"
+
+    def test_missing_column_blocks(self, tmp_path: Path) -> None:
+        con = duckdb.connect()
+        con.execute("CREATE TABLE t AS SELECT 'x' AS id, 'TJRO' AS tribunal")
+        path = tmp_path / "comunicacoes.parquet"
+        con.execute(f"COPY t TO '{path}' (FORMAT PARQUET)")
+        con.close()
+        result = validate_parquet(path, "comunicacoes", check_kv_metadata=False)
+        assert not result.passed
+        assert any("missing columns" in e for e in result.errors)
+
+    def test_nonexistent_file_blocks(self, tmp_path: Path) -> None:
+        result = validate_parquet(tmp_path / "nope.parquet", "comunicacoes")
+        assert not result.passed
+
+    def test_classificacoes_validates_outcomes(self, tmp_path: Path) -> None:
+        con = duckdb.connect()
+        con.execute("""
+            CREATE TABLE classificacoes AS SELECT
+                'tid' AS texto_id,
+                'keyword_v1' AS metodo,
+                'INVALID_OUTCOME' AS outcome,
+                'sentença' AS decision_type,
+                NULL AS winner_advogado_id,
+                NULL AS loser_advogado_id,
+                0.5 AS confidence,
+                CURRENT_TIMESTAMP AS classified_at
+        """)
+        path = tmp_path / "classificacoes.parquet"
+        con.execute(f"COPY classificacoes TO '{path}' (FORMAT PARQUET)")
+        con.close()
+        result = validate_parquet(path, "classificacoes", check_kv_metadata=False)
+        assert not result.passed
+        assert any("invalid outcomes" in e for e in result.errors)
+
+    def test_missing_kv_metadata_blocks(self, tmp_path: Path) -> None:
+        con = duckdb.connect()
+        con.execute("CREATE TABLE t AS SELECT 'uuid-1' AS id, 'TJRO' AS tribunal")
+        path = tmp_path / "comunicacoes.parquet"
+        con.execute(f"COPY t TO '{path}' (FORMAT PARQUET)")
+        con.close()
+        result = validate_parquet(path, "comunicacoes", check_kv_metadata=True)
+        assert not result.passed
+        assert any("Missing causaganha.schema_version" in e for e in result.errors)
+
+    def test_extra_columns_block(self, tmp_path: Path) -> None:
+        con = duckdb.connect()
+        fragment = kv_metadata_sql_fragment("djen-test")
+        con.execute("""
+            CREATE TABLE comunicacoes AS SELECT
+                'uuid-1' AS id,
+                '12345' AS original_id,
+                'TJRO' AS tribunal,
+                '00012345678901234567' AS numero_processo,
+                '0001234-56.2026.8.26.0100' AS numero_processo_mascara,
+                DATE '2026-06-01' AS data_disponibilizacao,
+                'Intimação' AS tipo_comunicacao,
+                '1ª Vara' AS nome_orgao,
+                'D' AS meio,
+                'https://x' AS link,
+                'Sentença' AS tipo_documento,
+                'Comum' AS nome_classe,
+                '7' AS codigo_classe,
+                '1' AS numero_comunicacao,
+                'abc123' AS hash,
+                CURRENT_TIMESTAMP AS processed_at,
+                'texto-uuid' AS texto_id,
+                2026 AS p_ano,
+                6 AS p_mes,
+                'djen-2026-06-01' AS p_item_ia,
+                'SURPRISE' AS rogue_column
+        """)
+        path = tmp_path / "comunicacoes.parquet"
+        con.execute(f"COPY comunicacoes TO '{path}' (FORMAT PARQUET, COMPRESSION ZSTD, {fragment})")
+        con.close()
+        result = validate_parquet(path, "comunicacoes")
+        assert not result.passed
+        assert any("extra columns" in e for e in result.errors)
+
+    def test_unknown_tribunal_blocks(self, tmp_path: Path) -> None:
+        con = duckdb.connect()
+        fragment = kv_metadata_sql_fragment("djen-test")
+        con.execute("""
+            CREATE TABLE comunicacoes AS SELECT
+                'uuid-1' AS id,
+                '12345' AS original_id,
+                'BADTRIB' AS tribunal,
+                '00012345678901234567' AS numero_processo,
+                '0001234-56.2026.8.26.0100' AS numero_processo_mascara,
+                DATE '2026-06-01' AS data_disponibilizacao,
+                'Intimação' AS tipo_comunicacao,
+                '1ª Vara' AS nome_orgao,
+                'D' AS meio,
+                'https://x' AS link,
+                'Sentença' AS tipo_documento,
+                'Comum' AS nome_classe,
+                '7' AS codigo_classe,
+                '1' AS numero_comunicacao,
+                'abc123' AS hash,
+                CURRENT_TIMESTAMP AS processed_at,
+                'texto-uuid' AS texto_id,
+                2026 AS p_ano,
+                6 AS p_mes,
+                'djen-2026-06-01' AS p_item_ia
+        """)
+        path = tmp_path / "comunicacoes.parquet"
+        con.execute(f"COPY comunicacoes TO '{path}' (FORMAT PARQUET, COMPRESSION ZSTD, {fragment})")
+        con.close()
+        result = validate_parquet(path, "comunicacoes")
+        assert not result.passed
+        assert any("unknown tribunals" in e for e in result.errors)
+
+    def test_all_passed_helper(self) -> None:
+        from causaganha.consolidate.validation import ValidationResult
+
+        r1 = ValidationResult(table_name="a")
+        r2 = ValidationResult(table_name="b", errors=["bad"])
+        assert all_passed({"a": r1})
+        assert not all_passed({"a": r1, "b": r2})


### PR DESCRIPTION
### Motivation
- Prevent partial or schema-invalid Parquet exports from being treated as a successful consolidation run so markers/checkpoints are not written for incomplete datasets.
- Harden the Phase 0 schema-gate behavior from PR #767 by making malformed tribunal codes and unexpected columns blocking errors.
- Ensure both the refactored exporter and the legacy consolidation script run the same validation logic so the CI/workflow gate is effective for production runs.

### Description
- Export pipeline: `src/causaganha/consolidate/exporter.py` now stamps Parquet KV metadata and runs `validate_parquet` before upload so blocked validations stop uploads.
- CLI/orchestration: `src/causaganha/consolidate/cli.py` now tracks which transformed tables are non-empty, aggregates per-table export/validation results, and only uploads `_consolidated.marker` (and marks a date complete) when every expected non-empty table produced a valid Parquet; added helpers `_process_zip_entries`, `_collect_export_results`, and `_exports_complete` to keep flow readable.
- Validation & schema registry: added `src/causaganha/consolidate/validation.py` (shared pragmatic SQL asserts using DuckDB) and `src/causaganha/consolidate/schema_registry.py` (immutable versioned table schemas + KV metadata helpers) to centralize schema checks and KV stamping.
- Legacy workflow coverage: wired validation and KV stamping into the legacy script `scripts/pipeline/consolidate.py` so the production workflow is covered.
- Behavior changes: unknown `tribunal` values are promoted from warnings to blocking `errors` and unexpected extra columns also block; empty tables remain allowed and don't count as failures.
- Tests & lint: added/updated tests in `tests/test_schema_registry.py` to cover KV metadata roundtrip, validation failures (including unknown tribunal), and registry↔transforms consistency, and updated `ruff.toml` to add S608 exemption for the new validation file.

### Testing
- Unit tests: ran `uv run pytest tests/test_schema_registry.py -q` and `uv run pytest -q`, and targeted tests passed (all green, with one skip in the full suite as expected).
- Lint/format: ran `uv run ruff check src/causaganha/consolidate/validation.py src/causaganha/consolidate/cli.py tests/test_schema_registry.py` and `uv run ruff format --check src/causaganha/consolidate/validation.py src/causaganha/consolidate/cli.py tests/test_schema_registry.py`, and both checks passed for the touched files.
- Note: a repository-wide `uv run ruff check` shows pre-existing lint debt unrelated to these changes, but the focused validation/export files and tests introduced here pass their checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eaadd877083259eae24877e495886)