### PR TITLE
Remove placeholder classificacoes table from consolidation

### DIFF
--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -82,7 +82,6 @@ KNOWN_TABLE_NAMES = {
     "advogado_nomes",
     "processos",
     "representacoes",
-    "classificacoes",
 }
 
 # Cache for tribunal stopped checks (tribunal -> date -> bool)

--- a/scripts/ia_practicality_probe.py
+++ b/scripts/ia_practicality_probe.py
@@ -33,7 +33,6 @@ MINIMAL_REQUIRED_COLUMNS: dict[str, list[str]] = {
     "advogados": ["id"],
     "destinatarios": ["comunicacao_id"],
     "processos": ["numero_processo", "tribunal"],
-    "classificacoes": ["outcome", "confidence"],
 }
 
 

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -864,58 +864,6 @@ def _build_processos(raw: ibis.Table, item_id: str) -> ibis.Table:
     )
 
 
-def _build_classificacoes(raw: ibis.Table, _item_id: str) -> ibis.Table:
-    """Build classificacoes table — keyword-based outcome classification.
-
-    Uses text patterns to classify judicial communications into outcome
-    categories (procedente, improcedente, parcialmente procedente, etc.).
-    This provides a baseline; LLM-based analysis can refine later.
-    """
-    txt = _safe(raw.texto)
-    txt_lower = txt.lower()
-    texto_id = djen_uuid5(txt)
-
-    # Only classify non-empty texts
-    has_text = txt != ""
-
-    # Keyword-based outcome detection
-    # Order matters: check "parcialmente procedente" before "procedente"
-    outcome = ibis.cases(
-        (txt_lower.contains("parcialmente procedente"), "PARTIAL"),
-        (txt_lower.contains("improcedente"), "LOSS"),
-        (txt_lower.contains("procedente"), "WIN"),
-        (txt_lower.contains("acordo") | txt_lower.contains("transação"), "SETTLEMENT"),
-        else_="UNKNOWN",
-    )
-
-    # Decision type detection
-    decision_type = ibis.cases(
-        (txt_lower.contains("acórdão") | txt_lower.contains("acordão"), "acórdão"),
-        (txt_lower.contains("sentença"), "sentença"),
-        (txt_lower.contains("decisão interlocutória"), "decisão interlocutória"),
-        else_="outro",
-    )
-
-    # Low confidence for keyword-based classification
-    confidence = ibis.literal(0.3).cast("float64")
-
-    return (
-        raw.filter(has_text)
-        .filter(outcome != "UNKNOWN")
-        .select(
-            texto_id=texto_id,
-            metodo=ibis.literal("keyword_v1"),
-            outcome=outcome,
-            decision_type=decision_type,
-            winner_advogado_id=ibis.null().cast("string"),
-            loser_advogado_id=ibis.null().cast("string"),
-            confidence=confidence,
-            classified_at=ibis.now(),
-        )
-        .distinct(on=["texto_id"])
-    )
-
-
 # Ordered list: tables with FK dependencies come after their parents.
 _TABLE_BUILDERS: tuple[tuple[str, Any], ...] = (
     ("comunicacoes", _build_comunicacoes),
@@ -927,7 +875,6 @@ _TABLE_BUILDERS: tuple[tuple[str, Any], ...] = (
     ("advogado_nomes", _build_advogado_nomes),
     ("representacoes", _build_representacoes),
     ("processos", _build_processos),
-    ("classificacoes", _build_classificacoes),
 )
 
 
@@ -936,7 +883,7 @@ def _load_and_transform(
     ndjson_dir: Path,
     item_id: str,
 ) -> dict[str, int]:
-    """Load raw per-tribunal NDJSON into DuckDB, produce all 10 tables via Ibis.
+    """Load raw per-tribunal NDJSON into DuckDB, produce all consolidated tables via Ibis.
 
     The only raw SQL is ``read_json_auto`` (DuckDB-specific loader).  Everything
     else — UUIDs, name normalization, unnesting, deduplication — is expressed

--- a/src/causaganha/consolidate/cli.py
+++ b/src/causaganha/consolidate/cli.py
@@ -156,7 +156,7 @@ async def _export_upload_and_manifest(
                 output_dir,
                 item_id,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — per-table resilience
             log.error("table_export_error", table=table_name, error=str(exc))
             if table_name in non_empty_tables:
                 stats["export_failures"] += 1

--- a/src/causaganha/consolidate/schema_registry.py
+++ b/src/causaganha/consolidate/schema_registry.py
@@ -152,18 +152,6 @@ SCHEMA_V3 = SchemaVersion(
                 "p_item_ia": "string",
             },
         ),
-        "classificacoes": ibis.schema(
-            {
-                "texto_id": "string",
-                "metodo": "string",
-                "outcome": "string",
-                "decision_type": "string",
-                "winner_advogado_id": "string",
-                "loser_advogado_id": "string",
-                "confidence": "float64",
-                "classified_at": "timestamp",
-            },
-        ),
         "partes": ibis.schema(
             {
                 "id": "string",

--- a/src/causaganha/consolidate/transforms.py
+++ b/src/causaganha/consolidate/transforms.py
@@ -312,49 +312,6 @@ def _build_processos(raw: ibis.Table, item_id: str) -> ibis.Table:
     )
 
 
-def _build_classificacoes(raw: ibis.Table, _item_id: str) -> ibis.Table:
-    """Build classificacoes table — keyword-based outcome classification."""
-    txt = _safe(raw.texto)
-    txt_lower = txt.lower()
-    texto_id = djen_uuid5(txt)
-
-    has_text = txt != ""
-
-    # Order matters: check "parcialmente procedente" before "procedente"
-    outcome = ibis.cases(
-        (txt_lower.contains("parcialmente procedente"), "PARTIAL"),
-        (txt_lower.contains("improcedente"), "LOSS"),
-        (txt_lower.contains("procedente"), "WIN"),
-        (txt_lower.contains("acordo") | txt_lower.contains("transação"), "SETTLEMENT"),
-        else_="UNKNOWN",
-    )
-
-    decision_type = ibis.cases(
-        (txt_lower.contains("acórdão") | txt_lower.contains("acordão"), "acórdão"),
-        (txt_lower.contains("sentença"), "sentença"),
-        (txt_lower.contains("decisão interlocutória"), "decisão interlocutória"),
-        else_="outro",
-    )
-
-    confidence = ibis.literal(0.3).cast("float64")
-
-    return (
-        raw.filter(has_text)
-        .filter(outcome != "UNKNOWN")
-        .select(
-            texto_id=texto_id,
-            metodo=ibis.literal("keyword_v1"),
-            outcome=outcome,
-            decision_type=decision_type,
-            winner_advogado_id=ibis.null().cast("string"),
-            loser_advogado_id=ibis.null().cast("string"),
-            confidence=confidence,
-            classified_at=ibis.now(),
-        )
-        .distinct(on=["texto_id"])
-    )
-
-
 # Ordered list: tables with FK dependencies come after their parents.
 _TABLE_BUILDERS: tuple[tuple[str, Any], ...] = (
     ("comunicacoes", _build_comunicacoes),
@@ -366,14 +323,13 @@ _TABLE_BUILDERS: tuple[tuple[str, Any], ...] = (
     ("advogado_nomes", _build_advogado_nomes),
     ("representacoes", _build_representacoes),
     ("processos", _build_processos),
-    ("classificacoes", _build_classificacoes),
 )
 
 
 # ── Schemas ─────────────────────────────────────────────────────────
 
 
-# The 10 table schemas are owned by the schema registry (single source of
+# The table schemas are owned by the schema registry (single source of
 # truth). Deriving them here keeps the ETL builders, the legacy consolidation
 # script, and the KV-stamped Parquet footer all on one definition — bump the
 # version in schema_registry.py and every code path follows.
@@ -392,7 +348,7 @@ def load_and_transform(
     ndjson_dir: Path,
     item_id: str,
 ) -> dict[str, int]:
-    """Load raw per-tribunal NDJSON into DuckDB, produce all 10 tables via Ibis.
+    """Load raw per-tribunal NDJSON into DuckDB, produce all consolidated tables via Ibis.
 
     The only raw SQL is ``read_json_auto`` (DuckDB-specific loader). Everything
     else — UUIDs, name normalization, unnesting, deduplication — is expressed

--- a/src/causaganha/consolidate/validation.py
+++ b/src/causaganha/consolidate/validation.py
@@ -34,16 +34,6 @@ log = structlog.get_logger()
 
 KNOWN_TRIBUNALS: frozenset[str] = frozenset(t.upper() for t in TRIBUNAIS)
 
-VALID_OUTCOMES: frozenset[str] = frozenset(
-    {
-        "WIN",
-        "LOSS",
-        "PARTIAL",
-        "SETTLEMENT",
-        "UNKNOWN",
-    }
-)
-
 
 @dataclass
 class ValidationResult:
@@ -188,28 +178,6 @@ def _validate_invariants(
 
     elif table_name == "advogados":
         _check_not_null(con, path, "id", table_name, result)
-
-    elif table_name == "classificacoes":
-        _check_not_null(con, path, "outcome", table_name, result)
-        _check_not_null(con, path, "confidence", table_name, result)
-
-        invalid_outcomes = con.execute(
-            f"SELECT DISTINCT outcome FROM '{path}' "
-            f"WHERE outcome IS NOT NULL "
-            f"AND outcome NOT IN ({','.join(repr(o) for o in VALID_OUTCOMES)})"
-        ).fetchall()
-        if invalid_outcomes:
-            vals = [r[0] for r in invalid_outcomes]
-            result.errors.append(f"classificacoes: invalid outcomes {vals}")
-
-        bad_confidence = con.execute(
-            f"SELECT COUNT(*) FROM '{path}' "
-            f"WHERE confidence IS NOT NULL AND (confidence < 0 OR confidence > 1)"
-        ).fetchone()[0]
-        if bad_confidence > 0:
-            result.errors.append(
-                f"classificacoes: {bad_confidence} rows with confidence outside [0,1]"
-            )
 
     elif table_name in ("destinatarios", "comunicacao_advogados", "representacoes"):
         _check_not_null(con, path, "comunicacao_id", table_name, result)

--- a/tests/consolidate/features/transform.feature
+++ b/tests/consolidate/features/transform.feature
@@ -1,4 +1,4 @@
-Feature: Transform DJEN records into 10 normalized Parquet tables
+Feature: Transform DJEN records into normalized Parquet tables
   As the consolidation pipeline
   I want to parse DJEN ZIP contents into well-typed tables
   So analytics can query uniform facts across all tribunals
@@ -11,10 +11,3 @@ Feature: Transform DJEN records into 10 normalized Parquet tables
     And destinatarios has 2 rows
     And advogados has 2 rows
     And textos has 1 row
-    And classificacoes has 1 row
-    And the classificacoes outcome is WIN
-
-  Scenario: Record with IMPROCEDENTE classifies as LOSS
-    Given a synthetic NDJSON record with an improcedente verdict
-    When I run the transform for item_id djen-tjrs-2026
-    Then the classificacoes outcome is LOSS

--- a/tests/consolidate/test_schema_snapshot.py
+++ b/tests/consolidate/test_schema_snapshot.py
@@ -227,7 +227,7 @@ def test_ts_schema_snapshot_parity():
 
     assert 'export const CONSOLIDATED_SCHEMA_VERSION = "3";' in content
 
-    # Assert that all 10 tables have schemas defined in TS
+    # Assert that all consolidated tables have schemas defined in TS
     for table in TABLES:
         expected_schema_name = f"{table}Schema"
         if "_" in table:

--- a/tests/consolidate/test_transform_bdd.py
+++ b/tests/consolidate/test_transform_bdd.py
@@ -41,13 +41,6 @@ SAMPLE_WIN = {
     ],
 }
 
-SAMPLE_LOSS = {
-    **SAMPLE_WIN,
-    "id": "L1",
-    "texto": "JULGO IMPROCEDENTE o pedido formulado pelo autor.",
-    "hash": "abcloss",
-}
-
 
 def _write_ndjson(ndjson_dir: Path, tribunal: str, records: list[dict[str, Any]]) -> None:
     ndjson_path = ndjson_dir / f"{tribunal}__synthetic.ndjson"
@@ -82,14 +75,6 @@ def _noop_two_each() -> None:
     pass
 
 
-@given("a synthetic NDJSON record with an improcedente verdict")
-def given_loss(tmpdir: Path, context: dict[str, Any]) -> None:
-    ndjson_dir = tmpdir / "ndjson"
-    ndjson_dir.mkdir()
-    _write_ndjson(ndjson_dir, "TJRS", [SAMPLE_LOSS])
-    context["ndjson_dir"] = ndjson_dir
-
-
 @when(parsers.parse("I run the transform for item_id {item_id}"))
 def run_transform(context: dict[str, Any], item_id: str) -> None:
     con = ibis.duckdb.connect(":memory:")
@@ -109,10 +94,3 @@ def check_rows_singular(context: dict[str, Any], table_name: str, n: int) -> Non
 def check_rows_plural(context: dict[str, Any], table_name: str, n: int) -> None:
     count = int(context["con"].table(table_name).count().execute())
     assert count == n, f"{table_name}: expected {n}, got {count}"
-
-
-@then(parsers.parse("the classificacoes outcome is {outcome}"))
-def check_outcome(context: dict[str, Any], outcome: str) -> None:
-    result = context["con"].raw_sql("SELECT outcome FROM classificacoes").fetchall()
-    assert len(result) == 1, f"Expected 1 classificacao row, got {len(result)}"
-    assert result[0][0] == outcome, f"Expected {outcome}, got {result[0][0]}"

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -82,7 +82,7 @@ def _create_synthetic_ndjson(ndjson_dir: Path) -> None:
 
 
 def test_all_tables_populated_from_synthetic_data():
-    """Verify all 10 tables are produced from synthetic data, including classificacoes."""
+    """Verify all consolidated tables are produced from synthetic data."""
     con = ibis.duckdb.connect()
     init_tables(con)
 
@@ -93,7 +93,7 @@ def test_all_tables_populated_from_synthetic_data():
         counts = _load_and_transform(con, ndjson_dir, item_id="djen-tjsp-2026")
 
     # All tables should exist
-    assert len(TABLES) == 10, f"Expected 10 tables, got {len(TABLES)}"
+    assert len(TABLES) == 9, f"Expected 9 tables, got {len(TABLES)}"
 
     # Core tables must have rows
     assert counts.get("comunicacoes", 0) > 0, "comunicacoes should have rows"
@@ -102,48 +102,11 @@ def test_all_tables_populated_from_synthetic_data():
     assert counts.get("destinatarios", 0) > 0, "destinatarios should have rows"
     assert counts.get("processos", 0) > 0, "processos should have rows"
 
-    # classificacoes should be populated (keyword match on "procedente" / "improcedente")
-    assert counts.get("classificacoes", 0) > 0, (
-        "classificacoes should have rows from keyword classification"
-    )
 
-
-def test_classificacoes_schema_correct():
-    """Verify classificacoes table has the correct schema columns."""
-    expected_cols = {
-        "texto_id",
-        "metodo",
-        "outcome",
-        "decision_type",
-        "winner_advogado_id",
-        "loser_advogado_id",
-        "confidence",
-        "classified_at",
-    }
-    schema = TABLE_SCHEMAS["classificacoes"]
-    actual_cols = set(schema.names)
-    assert actual_cols == expected_cols, f"Schema mismatch: {actual_cols} != {expected_cols}"
-
-
-def test_classificacoes_outcomes():
-    """Verify keyword classifier produces correct outcomes."""
-    con = ibis.duckdb.connect()
-    init_tables(con)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        ndjson_dir = Path(tmpdir)
-        _create_synthetic_ndjson(ndjson_dir)
-        _load_and_transform(con, ndjson_dir, item_id="djen-tjsp-2026")
-
-    df = con.table("classificacoes").to_pandas()
-    outcomes = set(df["outcome"].tolist())
-
-    # Our sample data has "procedente" (WIN) and "improcedente" (LOSS)
-    assert "WIN" in outcomes or "LOSS" in outcomes, (
-        f"Expected WIN or LOSS in outcomes, got {outcomes}"
-    )
-    assert all(df["metodo"] == "keyword_v1"), "All classifications should use keyword_v1 method"
-    assert all(df["confidence"] == 0.3), "Keyword classifier confidence should be 0.3"
+def test_classificacoes_removed_from_schema():
+    """Classification is still under development — it must not be a consolidated table."""
+    assert "classificacoes" not in TABLES
+    assert "classificacoes" not in TABLE_SCHEMAS
 
 
 def test_parquet_export_roundtrip():

--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -161,26 +161,6 @@ class TestValidation:
         result = validate_parquet(tmp_path / "nope.parquet", "comunicacoes")
         assert not result.passed
 
-    def test_classificacoes_validates_outcomes(self, tmp_path: Path) -> None:
-        con = duckdb.connect()
-        con.execute("""
-            CREATE TABLE classificacoes AS SELECT
-                'tid' AS texto_id,
-                'keyword_v1' AS metodo,
-                'INVALID_OUTCOME' AS outcome,
-                'sentença' AS decision_type,
-                NULL AS winner_advogado_id,
-                NULL AS loser_advogado_id,
-                0.5 AS confidence,
-                CURRENT_TIMESTAMP AS classified_at
-        """)
-        path = tmp_path / "classificacoes.parquet"
-        con.execute(f"COPY classificacoes TO '{path}' (FORMAT PARQUET)")
-        con.close()
-        result = validate_parquet(path, "classificacoes", check_kv_metadata=False)
-        assert not result.passed
-        assert any("invalid outcomes" in e for e in result.errors)
-
     def test_missing_kv_metadata_blocks(self, tmp_path: Path) -> None:
         con = duckdb.connect()
         con.execute("CREATE TABLE t AS SELECT 'uuid-1' AS id, 'TJRO' AS tribunal")

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -25,12 +25,6 @@
       label: 'vínculos',
       description: 'Relações entre comunicações, advogados, partes e representações.',
     },
-    {
-      key: 'classificacoes',
-      file: 'classificacoes.parquet',
-      label: 'classificações',
-      description: 'Classificações de resultado e tipo de decisão geradas pelo pipeline.',
-    },
   ];
 
   const TEMPLATE_DEFINITIONS = [
@@ -53,14 +47,6 @@ JOIN read_parquet('${path('comunicacao_advogados.parquet')}') ca
 GROUP BY nome, numero_oab, uf_oab
 ORDER BY comunicacoes DESC
 LIMIT 20`,
-    },
-    {
-      label: 'Classificações de resultado',
-      description: 'Agrupa resultados classificados e exibe confiança média.',
-      sql: (path) => `SELECT outcome, decision_type, COUNT(*) as total, ROUND(AVG(confidence), 2) as avg_confidence
-FROM read_parquet('${path('classificacoes.parquet')}')
-GROUP BY outcome, decision_type
-ORDER BY total DESC`,
     },
     {
       label: 'Processos distintos',

--- a/web/src/lib/consolidated-schemas.ts
+++ b/web/src/lib/consolidated-schemas.ts
@@ -87,17 +87,6 @@ export const processosSchema = z.object({
   p_item_ia: z.string(),
 });
 
-export const classificacoesSchema = z.object({
-  texto_id: z.string(),
-  metodo: z.string(),
-  outcome: z.string(),
-  decision_type: z.string(),
-  winner_advogado_id: z.string().nullable(),
-  loser_advogado_id: z.string().nullable(),
-  confidence: z.number(),
-  classified_at: z.string(), // ISO Timestamp
-});
-
 export const partesSchema = z.object({
   id: z.string(),
   nome_normalizado: z.string(),
@@ -113,6 +102,5 @@ export const consolidatedSchemas = {
   textos: textosSchema,
   representacoes: representacoesSchema,
   processos: processosSchema,
-  classificacoes: classificacoesSchema,
   partes: partesSchema,
 };

--- a/web/src/pages/explorador.astro
+++ b/web/src/pages/explorador.astro
@@ -33,7 +33,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         <ul>
           <li>Escolha um tribunal e ano antes de editar a consulta SQL.</li>
           <li>Use os templates para gerar automaticamente caminhos <code>read_parquet(...)</code> no formato <code>djen-&lt;tribunal&gt;-&lt;ano&gt;</code>.</li>
-          <li>Consulte rapidamente as tabelas principais: comunicações, advogados, vínculos e classificações.</li>
+          <li>Consulte rapidamente as tabelas principais: comunicações, advogados, vínculos e processos.</li>
         </ul>
       </article>
     </section>


### PR DESCRIPTION
## Why

Classification is still being designed. The `classificacoes` table currently produced by the consolidation pipeline is a **keyword-v1 placeholder**: hardcoded `confidence = 0.3`, `winner_advogado_id`/`loser_advogado_id` always null, and naive `.contains()` outcome matching. Freezing that into the published consolidated schema commits us to a contract we're about to change. This removes it from the consolidation until the real classifier design lands.

The consolidated schema goes from **10 → 9 tables**.

## Versioning decision

Per discussion, the schema `3.0.0` is **edited in place** (treating the consolidated schema as still in development) rather than bumping the version. Rationale: every version bump forces a re-upload of *all* IA items — too heavy a cost to pull a placeholder table. Old items keep a harmless extra `classificacoes.parquet`; new consolidation runs simply don't produce one.

## Changes

- **`schema_registry.py`** — drop the `classificacoes` table from `SCHEMA_V3` (single source of truth; `TABLES`/`TABLE_SCHEMAS` follow automatically in both code paths).
- **`transforms.py`** + **`scripts/pipeline/consolidate.py`** — remove `_build_classificacoes` and its `_TABLE_BUILDERS` entry in both consolidation code paths.
- **`validation.py`** — remove the `classificacoes` validation block and the now-unused `VALID_OUTCOMES`.
- **Tests** — 9-table assertions, drop the classificacoes-specific tests, add a guard that `classificacoes` is absent from the schema, and trim the BDD feature/steps.
- **Web** — remove `classificacoesSchema` (Zod) + its map entry, the explorer table entry + "Classificações de resultado" query template, and the explorador help-text mention.
- **Catalog/probe scripts** — drop `classificacoes` from the consolidated-table lists.
- **`cli.py`** — suppress the pre-existing `BLE001` on the per-table export loop (justified `# noqa`, matching the existing pattern) so the repo-wide lint gate passes. This is a main breakage, not introduced here.

## Intentionally left untouched (out of scope — the classifier work itself)

- ML/training scripts that read the consolidated `classificacoes.parquet` (e.g. `scripts/train_ml_from_parquets.py`) — part of the in-development classifier; they'll need updating when classification is reintroduced.
- The separate **analysis-storage** `classificacoes` table (`storage/schema.sql`, `migrations.py`) — a different database (ratings/analysis), not the consolidation output.

## Verification

- `ruff check --select S,BLE001,B904,TRY300` + `ruff format --check` — clean repo-wide.
- `pytest tests/test_consolidation.py tests/test_schema_registry.py tests/consolidate/` — 37 passed, 1 skipped.
- Broader `-k 'consolid or transform or schema or validation'` — 47 passed, 1 skipped.
- No dangling references to removed symbols (`VALID_OUTCOMES`, `classificacoesSchema`, `_build_classificacoes`).

https://claude.ai/code/session_01NZDxobkMsTDc3S8aZ9aDhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZDxobkMsTDc3S8aZ9aDhc)_