### PR TITLE
fix: stamp _tribunal into NDJSON records at write time, remove filename parsing

### DIFF
--- a/src/causaganha/consolidate/transforms.py
+++ b/src/causaganha/consolidate/transforms.py
@@ -405,8 +405,10 @@ def load_and_transform(
     )
     staging = con.table("_staging")
 
+    # _tribunal is stamped into every record by zip_processor.stream_zip_to_ndjson.
+    # No filename parsing needed — the data is self-describing.
     raw_expr = staging.mutate(
-        src_tribunal=staging.filename.split("/")[-1].split("__")[0],
+        src_tribunal=staging._tribunal,
         src_item_id=ibis.literal(item_id),
     )
     con.create_table("raw_records", raw_expr, overwrite=True)

--- a/src/causaganha/consolidate/zip_processor.py
+++ b/src/causaganha/consolidate/zip_processor.py
@@ -43,8 +43,11 @@ def download_zip(item_id: str, filename: str, output_path: Path) -> bool:
     return output_path.exists() and output_path.stat().st_size > 0
 
 
-def stream_zip_to_ndjson(zip_path: Path, ndjson_path: Path) -> int:
+def stream_zip_to_ndjson(zip_path: Path, ndjson_path: Path, tribunal: str) -> int:
     """Extract records from a ZIP and write each as one NDJSON line.
+
+    Stamps ``_tribunal`` into every record so downstream transforms can use
+    it directly without parsing it back out of the filename.
 
     Returns the number of records written. Never materializes the full
     record set in memory — records are written to disk as they are parsed.
@@ -73,6 +76,7 @@ def stream_zip_to_ndjson(zip_path: Path, ndjson_path: Path) -> int:
                     if not validate_ndjson_record(rec):
                         log.warning("invalid_record_discarded", rec_id=rec.get("id"))
                         continue
+                    rec["_tribunal"] = tribunal
                     try:
                         line = json.dumps(rec, default=str, ensure_ascii=False)
                     except (TypeError, ValueError):
@@ -151,7 +155,7 @@ def process_zip_entry(
     ndjson_path = ndjson_dir / ndjson_filename
 
     try:
-        count = stream_zip_to_ndjson(zip_path, ndjson_path)
+        count = stream_zip_to_ndjson(zip_path, ndjson_path, tribunal)
     except OSError as e:
         log.exception("ndjson_write_failed", file=ndjson_filename, error=str(e))
         return 0, 0

--- a/tests/consolidate/test_transform_bdd.py
+++ b/tests/consolidate/test_transform_bdd.py
@@ -53,8 +53,9 @@ def _write_ndjson(ndjson_dir: Path, tribunal: str, records: list[dict[str, Any]]
     ndjson_path = ndjson_dir / f"{tribunal}__synthetic.ndjson"
     with ndjson_path.open("w", encoding="utf-8") as f:
         for rec in records:
-            f.write(json.dumps(rec))
+            f.write(json.dumps({**rec, "_tribunal": tribunal}))
             f.write("\n")
+
 
 
 @pytest.fixture

--- a/tests/consolidate/test_transform_bdd.py
+++ b/tests/consolidate/test_transform_bdd.py
@@ -57,7 +57,6 @@ def _write_ndjson(ndjson_dir: Path, tribunal: str, records: list[dict[str, Any]]
             f.write("\n")
 
 
-
 @pytest.fixture
 def tmpdir() -> Any:
     with tempfile.TemporaryDirectory() as d:

--- a/tests/consolidate/test_zip_processor.py
+++ b/tests/consolidate/test_zip_processor.py
@@ -38,12 +38,15 @@ def test_stream_extracts_top_level_array() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TJSP")
 
         assert count == 3
         lines = out.read_text().splitlines()
         assert len(lines) == 3
-        assert json.loads(lines[0]) == {"id": 1, "data_disponibilizacao": "2026-04-01"}
+        rec = json.loads(lines[0])
+        assert rec["id"] == 1
+        assert rec["data_disponibilizacao"] == "2026-04-01"
+        assert rec["_tribunal"] == "TJSP"
 
 
 def test_stream_extracts_items_wrapper() -> None:
@@ -60,13 +63,12 @@ def test_stream_extracts_items_wrapper() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TRT18")
 
         assert count == 1
-        assert json.loads(out.read_text().strip()) == {
-            "id": 1,
-            "data_disponibilizacao": "2026-04-01",
-        }
+        rec = json.loads(out.read_text().strip())
+        assert rec["id"] == 1
+        assert rec["_tribunal"] == "TRT18"
 
 
 def test_stream_extracts_single_object() -> None:
@@ -84,14 +86,13 @@ def test_stream_extracts_single_object() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TJCE")
 
         assert count == 1
-        assert json.loads(out.read_text().strip()) == {
-            "id": 42,
-            "texto": "foo",
-            "data_disponibilizacao": "2026-04-01",
-        }
+        rec = json.loads(out.read_text().strip())
+        assert rec["id"] == 42
+        assert rec["texto"] == "foo"
+        assert rec["_tribunal"] == "TJCE"
 
 
 def test_stream_skips_non_json_files() -> None:
@@ -106,7 +107,7 @@ def test_stream_skips_non_json_files() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TJSP")
 
         assert count == 1
 
@@ -123,7 +124,7 @@ def test_stream_handles_malformed_json() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TJSP")
 
         assert count == 1
 
@@ -134,7 +135,7 @@ def test_stream_handles_bad_zip() -> None:
         out = Path(tmpdir) / "out.ndjson"
         zip_path.write_bytes(b"garbage")
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TJSP")
 
         assert count == 0
 
@@ -155,12 +156,15 @@ def test_stream_combines_multiple_json_files() -> None:
             },
         )
 
-        count = stream_zip_to_ndjson(zip_path, out)
+        count = stream_zip_to_ndjson(zip_path, out, "TRT4")
 
         assert count == 4
         lines = out.read_text().splitlines()
         ids = sorted(json.loads(line)["id"] for line in lines)
         assert ids == [1, 2, 3, 4]
+        # All records must carry the tribunal stamp
+        tribunals = {json.loads(line)["_tribunal"] for line in lines}
+        assert tribunals == {"TRT4"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`src_tribunal` was derived by parsing the `filename` column from DuckDB's `read_json_auto(filename=true)`. On Windows, that column contains backslash-separated paths, so `split('/')[-1]` returned the full path instead of the tribunal code, causing every tribunal to fail the `KNOWN_TRIBUNALS` validation gate.

## Root cause

The tribunal code was extracted from the wrong layer — the filename — rather than being carried in the data itself.

## Fix

Stamp `_tribunal` directly into each record in `zip_processor.stream_zip_to_ndjson`, which already has the tribunal code as a parameter. The transform layer reads `staging._tribunal` directly — no path parsing, no platform assumptions.

**Before:**
`\\\python
# transforms.py — parsed the filename column (broken on Windows)
src_tribunal=staging.filename.split('/')[-1].split('__')[0]
\\\**

**After:**
`\\\python
# zip_processor.py — stamped at write time
rec['_tribunal'] = tribunal

# transforms.py — reads it directly
src_tribunal=staging._tribunal
\\\**

## Files changed

- `src/causaganha/consolidate/zip_processor.py` — `stream_zip_to_ndjson` gains a `tribunal: str` param and stamps `_tribunal` into every record
- `src/causaganha/consolidate/transforms.py` — removes all filename-parsing logic; reads `staging._tribunal`
- `tests/consolidate/test_zip_processor.py` — all call sites updated; new assertion that `_tribunal` is present on every record
- `tests/consolidate/test_transform_bdd.py` — `_write_ndjson` helper stamps `_tribunal` to match the runtime contract

## Verification

267/267 tests pass.