### PR TITLE
feat(segmenter-v7): pipeline de inferência ponta-a-ponta + ensemble de verificação versionado

### DIFF
--- a/data/segmenter_splits/verification_ensemble_v7.md
+++ b/data/segmenter_splits/verification_ensemble_v7.md
@@ -1,0 +1,92 @@
+# Verification Ensemble v7 — val+test gold verification protocol
+
+This is the executable specification of the four-role verification ensemble
+declared in `manifest.json` (`test_verified_by =
+prompt_ensemble:strict+disambig+blind+adversarial`). It exists so the
+verification that blessed the seed gold can be **reproduced exactly** when
+scaling annotation (ADR 0010, Phase 2). Mechanical comparison of role
+outputs is done by `scripts/ensemble_compare.py`.
+
+## When to run
+
+Over **val + test splits only** (low volume, high leverage). Train relies on
+the labeler + `opf_annotate.py validate` mechanical checks.
+
+## Model assignment
+
+- All four roles run on a **strong model (Sonnet or better)** — never the
+  same tier as the bulk labeler (Haiku). Model heterogeneity is the point:
+  labeler and verifier errors must decorrelate.
+- Each role runs as an **independent subagent with a fresh context**. Never
+  share one conversation across roles — that correlates their errors.
+
+## The four roles
+
+Every role receives the document text. Roles 1, 2, and 4 also receive the
+candidate annotations; role 3 does not (blind). Each role returns spans as
+`{category, match, nth}` (shortest *unique* match preferred), resolved to
+offsets with `opf_annotate.py from-spans` and checked with `validate`.
+
+### Role 1 — strict-boundary
+
+> You are verifying span BOUNDARIES only. For each annotated span, check:
+> (a) `text[start:end]` is the shortest surface that uniquely identifies the
+> anchor cue; (b) no leading/trailing whitespace; (c) single-anchor spans are
+> ≤120 chars and 1–5 words typical; (d) paired `_inicio`/`_fim` marks the
+> CUE, not the region. Do not question the category choice. Output: for each
+> span, either CONFIRM or a corrected `{category, match, nth}`.
+
+### Role 2 — category-disambiguation
+
+> You are verifying span CATEGORIES only, taking boundaries as given. Apply
+> the guideline's contrast rules: `dispositivo_abertura` vs interlocutory
+> "Decido"; `resultado` only on the operative verb after the dispositivo;
+> `fundamentacao_legal` vs (unlabeled) `ref_normativa`; in acórdãos, the
+> collegiate result is `acordao_decisorio_*`, never a `dispositivo_abertura`
+> inside a `voto`. Output: for each span, CONFIRM or the corrected category.
+
+### Role 3 — blind-relabel
+
+> Annotate this document from scratch following
+> `annotation_guideline_v7.md`. You have NOT seen any existing annotation.
+> Return all spans as `{category, match, nth}`. Do not annotate
+> `ref_normativa`.
+
+The blind output is compared against the candidate set with
+`ensemble_compare.py`; disagreements (missing, extra, boundary, category)
+become adjudication items.
+
+### Role 4 — adversarial
+
+> Your job is to FIND ERRORS in this annotation. Actively hunt for: a second
+> operative `dispositivo_abertura`; `resultado` on a reasoning or quoted
+> verb; a missed `preliminar`/`custas`/`honorarios` section; an `_inicio`
+> without its real `_fim` when one exists in the text; acórdão categories in
+> a sentença or vice versa. Report each suspected error with the evidence
+> quote. Finding nothing is an acceptable outcome — do not invent errors.
+
+## Adjudication
+
+1. Run all four roles; collect role outputs as JSONL (same record order as
+   the split under verification).
+2. Run `scripts/ensemble_compare.py reference.jsonl role1.jsonl
+   role3.jsonl ...` — it reports per-document, per-category disagreement and
+   exits non-zero while any remain.
+3. Every disagreement is adjudicated by a strong model (or human) with the
+   guideline open; the adjudicated decision is applied to the gold and the
+   compare is re-run until clean.
+4. Any document the **bulk labeler flagged as ambiguous** during annotation
+   is adjudicated by the strong model even if the ensemble agrees (ADR 0010
+   tiered-assignment rule).
+
+## Recording the result
+
+On success update `manifest.json`:
+
+```json
+"test_verified_by": "prompt_ensemble:strict+disambig+blind+adversarial",
+"verifier_model": "<model used>"
+```
+
+Never set `test_verified_by` to the ensemble value without actually running
+all four roles — `same_as_train_labeler` is the honest placeholder.

--- a/scripts/ensemble_compare.py
+++ b/scripts/ensemble_compare.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""ensemble_compare.py — mechanical diff for verification-ensemble outputs.
+
+Compares a reference annotation JSONL (the candidate gold) against one or
+more role-output JSONLs (see data/segmenter_splits/verification_ensemble_v7.md)
+and reports disagreements per document and per category:
+
+    missing   — span in reference, absent from role output
+    extra     — span in role output, absent from reference
+    boundary  — same category overlapping region, different offsets
+    category  — same offsets, different category
+
+Exit code is non-zero while any disagreement remains, so this can gate the
+"verified" status mechanically.
+
+Usage:
+    uv run python scripts/ensemble_compare.py reference.jsonl role_blind.jsonl
+    uv run python scripts/ensemble_compare.py ref.jsonl r1.jsonl r2.jsonl r3.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: Path) -> list[dict]:
+    records: list[dict] = []
+    with path.open(encoding="utf-8") as fh:
+        for ln, raw in enumerate(fh, 1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                records.append(json.loads(stripped))
+            except json.JSONDecodeError as e:
+                print(f"ERROR {path}:L{ln}: invalid JSON ({e})", file=sys.stderr)
+                sys.exit(2)
+    return records
+
+
+def _spans_of(rec: dict) -> list[dict]:
+    for field in ("label", "spans"):
+        if field in rec:
+            return rec[field] or []
+    return []
+
+
+def _key(sp: dict) -> tuple[str, int, int]:
+    return (sp["category"], sp["start"], sp["end"])
+
+
+def _overlaps(a: dict, b: dict) -> bool:
+    return a["start"] < b["end"] and b["start"] < a["end"]
+
+
+def compare_record(ref_spans: list[dict], role_spans: list[dict]) -> list[dict]:
+    """Return the list of disagreements between reference and one role output."""
+    ref_keys = {_key(sp) for sp in ref_spans}
+    role_keys = {_key(sp) for sp in role_spans}
+    disagreements: list[dict] = []
+
+    for sp in ref_spans:
+        if _key(sp) in role_keys:
+            continue
+        # exact offsets, different category?
+        cat_clash = next(
+            (r for r in role_spans if r["start"] == sp["start"] and r["end"] == sp["end"]),
+            None,
+        )
+        if cat_clash is not None:
+            disagreements.append(
+                {
+                    "kind": "category",
+                    "category": sp["category"],
+                    "other_category": cat_clash["category"],
+                    "start": sp["start"],
+                    "end": sp["end"],
+                }
+            )
+            continue
+        # same category, overlapping but shifted?
+        boundary = next(
+            (r for r in role_spans if r["category"] == sp["category"] and _overlaps(r, sp)),
+            None,
+        )
+        if boundary is not None:
+            disagreements.append(
+                {
+                    "kind": "boundary",
+                    "category": sp["category"],
+                    "start": sp["start"],
+                    "end": sp["end"],
+                    "other_start": boundary["start"],
+                    "other_end": boundary["end"],
+                }
+            )
+            continue
+        disagreements.append(
+            {
+                "kind": "missing",
+                "category": sp["category"],
+                "start": sp["start"],
+                "end": sp["end"],
+            }
+        )
+
+    matched_in_ref = {
+        _key(sp)
+        for sp in role_spans
+        if _key(sp) in ref_keys
+        or any(r["start"] == sp["start"] and r["end"] == sp["end"] for r in ref_spans)
+        or any(r["category"] == sp["category"] and _overlaps(r, sp) for r in ref_spans)
+    }
+    disagreements.extend(
+        {
+            "kind": "extra",
+            "category": sp["category"],
+            "start": sp["start"],
+            "end": sp["end"],
+        }
+        for sp in role_spans
+        if _key(sp) not in matched_in_ref
+    )
+    return disagreements
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("reference", help="Candidate gold JSONL")
+    parser.add_argument("roles", nargs="+", help="Role output JSONL file(s)")
+    parser.add_argument(
+        "--context",
+        type=int,
+        default=40,
+        help="Chars of text context to print around each disagreement",
+    )
+    args = parser.parse_args()
+
+    ref = _load(Path(args.reference))
+    total = 0
+    per_category: dict[str, int] = {}
+
+    for role_path_s in args.roles:
+        role_path = Path(role_path_s)
+        role = _load(role_path)
+        if len(role) != len(ref):
+            print(
+                f"ERROR {role_path}: {len(role)} records, reference has {len(ref)} "
+                f"(role outputs must keep record order)",
+                file=sys.stderr,
+            )
+            return 2
+        role_total = 0
+        for i, (ref_rec, role_rec) in enumerate(zip(ref, role, strict=True)):
+            text = ref_rec.get("text", "")
+            disagreements = compare_record(_spans_of(ref_rec), _spans_of(role_rec))
+            for d in disagreements:
+                role_total += 1
+                per_category[d["category"]] = per_category.get(d["category"], 0) + 1
+                s, e = d["start"], d["end"]
+                ctx_s = max(0, s - args.context)
+                snippet = text[ctx_s : e + args.context].replace("\n", " ")
+                doc_id = (ref_rec.get("info") or {}).get("id", f"doc{i}")
+                detail = ""
+                if d["kind"] == "category":
+                    detail = f" role says [{d['other_category']}]"
+                elif d["kind"] == "boundary":
+                    detail = f" role says ({d['other_start']}:{d['other_end']})"
+                print(
+                    f"{role_path.name} {doc_id} {d['kind']:8s} "
+                    f"[{d['category']}]({s}:{e}){detail}  ...{snippet}..."
+                )
+        print(f"-- {role_path.name}: {role_total} disagreement(s)", file=sys.stderr)
+        total += role_total
+
+    if per_category:
+        print("\nper-category disagreements:", file=sys.stderr)
+        for cat in sorted(per_category):
+            print(f"  {cat}: {per_category[cat]}", file=sys.stderr)
+    if total:
+        print(f"\nFAILED: {total} disagreement(s) need adjudication", file=sys.stderr)
+        return 1
+    print("\nOK: ensemble agrees with reference", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/segment_decision.py
+++ b/scripts/segment_decision.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""segment_decision.py — end-to-end inference for the v7 decision segmenter.
+
+Chains the three pieces that were built separately but never wired together:
+
+    1. OPF anchor-span prediction  (``opf predict`` subprocess, needs GPU)
+    2. ref_normativa regex pre-pass + merge  (scripts/ref_normativa_prepass.py)
+    3. Region reconstruction  (scripts/reconstruct_regions.py)
+
+Input is JSONL with one ``{"text": ..., "info": {...}}`` record per line
+(the same shape as the gold splits; an existing ``label`` field is ignored
+unless ``--spans-from-label`` is set). Output is JSONL where each record
+gains:
+
+    "spans"   — final anchor spans (OPF + ref_normativa merged, no overlaps)
+    "regions" — reconstructed regions [{category, start, end, matched}]
+
+For development and testing without a GPU, ``--spans-from-label`` skips the
+OPF call and uses each record's gold ``label`` as the model output. This
+exercises the merge + reconstruction stages against real data — which is
+exactly what the integration tests do.
+
+Usage:
+    # Full inference (needs trained checkpoint + GPU):
+    uv run python scripts/segment_decision.py input.jsonl \
+        --checkpoint models/decision_segmenter/best --output out.jsonl
+
+    # GPU-less: run merge+reconstruction over gold spans:
+    uv run python scripts/segment_decision.py data/segmenter_splits/test.jsonl \
+        --spans-from-label --output out.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+
+import structlog
+
+from scripts.reconstruct_regions import reconstruct_regions, validate_anchor_lengths
+from scripts.ref_normativa_prepass import extract_ref_normativa, merge_with_opf_spans
+
+
+logger = structlog.get_logger()
+
+
+def run_opf_predict(input_jsonl: Path, checkpoint: Path, device: str) -> list[list[dict]]:
+    """Run ``opf predict`` and return one span list per input record.
+
+    Mirrors the ``opf train`` / ``opf eval`` subprocess contract used by
+    train_decision_segmenter.py: the output JSONL carries a ``label`` field
+    with ``{category, start, end}`` spans per record.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as tmp:
+        out_path = Path(tmp.name)
+    cmd = [
+        sys.executable,
+        "-m",
+        "opf",
+        "predict",
+        str(input_jsonl),
+        "--checkpoint",
+        str(checkpoint),
+        "--device",
+        device,
+        "--output",
+        str(out_path),
+    ]
+    logger.info("opf_predict_start", cmd=" ".join(cmd))
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        msg = f"opf predict failed with code {result.returncode}"
+        raise RuntimeError(msg)
+    predictions: list[list[dict]] = []
+    with out_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            rec = json.loads(stripped)
+            predictions.append(rec.get("label", []))
+    out_path.unlink(missing_ok=True)
+    return predictions
+
+
+def segment_text(text: str, model_spans: list[dict]) -> dict:
+    """Run the post-model pipeline: ref_normativa merge + region reconstruction.
+
+    This is the pure, GPU-free core — model_spans can come from OPF or from
+    gold labels. Returns {"spans": [...], "regions": [...], "warnings": [...]}.
+    """
+    ref_spans = extract_ref_normativa(text)
+    merged = merge_with_opf_spans(model_spans, ref_spans)
+    warnings = validate_anchor_lengths(merged, text)
+    regions = reconstruct_regions(merged, len(text))
+    return {
+        "spans": merged,
+        "regions": [asdict(r) for r in regions],
+        "warnings": warnings,
+    }
+
+
+def _iter_records(path: Path):
+    with path.open(encoding="utf-8") as fh:
+        for ln, raw in enumerate(fh, 1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            yield ln, json.loads(stripped)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("input", help="JSONL with {text, info} records")
+    parser.add_argument("--output", help="Output JSONL path (default: stdout)")
+    parser.add_argument("--checkpoint", help="OPF model checkpoint dir")
+    parser.add_argument("--device", default="cpu", choices=["cpu", "cuda"])
+    parser.add_argument(
+        "--spans-from-label",
+        action="store_true",
+        help="Skip OPF; use each record's gold `label` as model spans (dev/test)",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        logger.error("input_not_found", path=str(input_path))
+        return 1
+    if not args.spans_from_label and not args.checkpoint:
+        print(
+            "Error: either --checkpoint (real inference) or "
+            "--spans-from-label (dev mode) is required.",
+            file=sys.stderr,
+        )
+        return 1
+
+    records = list(_iter_records(input_path))
+
+    if args.spans_from_label:
+        predictions = [rec.get("label", []) for _, rec in records]
+    else:
+        predictions = run_opf_predict(input_path, Path(args.checkpoint), args.device)
+        if len(predictions) != len(records):
+            logger.error(
+                "prediction_count_mismatch",
+                records=len(records),
+                predictions=len(predictions),
+            )
+            return 1
+
+    n_regions = 0
+    n_warnings = 0
+    with contextlib.ExitStack() as stack:
+        out_fh = (
+            stack.enter_context(Path(args.output).open("w", encoding="utf-8"))
+            if args.output
+            else sys.stdout
+        )
+        for (ln, rec), model_spans in zip(records, predictions, strict=True):
+            text = rec.get("text")
+            if not isinstance(text, str):
+                logger.error("missing_text", line=ln)
+                continue
+            result = segment_text(text, model_spans)
+            n_regions += len(result["regions"])
+            n_warnings += len(result["warnings"])
+            for w in result["warnings"]:
+                print(f"WARN L{ln}: {w}", file=sys.stderr)
+            out = {
+                "text": text,
+                "spans": result["spans"],
+                "regions": result["regions"],
+            }
+            if "info" in rec:
+                out["info"] = rec["info"]
+            out_fh.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+    logger.info(
+        "segmentation_done",
+        records=len(records),
+        regions=n_regions,
+        warnings=n_warnings,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ensemble_compare.py
+++ b/tests/test_ensemble_compare.py
@@ -1,0 +1,50 @@
+"""Tests for the verification-ensemble mechanical comparator."""
+
+from __future__ import annotations
+
+from scripts.ensemble_compare import compare_record
+
+
+def _sp(cat: str, start: int, end: int) -> dict:
+    return {"category": cat, "start": start, "end": end}
+
+
+class TestCompareRecord:
+    def test_identical_sets_agree(self) -> None:
+        spans = [_sp("resultado", 10, 25), _sp("dispositivo_abertura", 0, 14)]
+        assert compare_record(spans, list(spans)) == []
+
+    def test_missing_span(self) -> None:
+        ref = [_sp("resultado", 10, 25)]
+        out = compare_record(ref, [])
+        assert len(out) == 1
+        assert out[0]["kind"] == "missing"
+        assert out[0]["category"] == "resultado"
+
+    def test_extra_span(self) -> None:
+        role = [_sp("resultado", 10, 25)]
+        out = compare_record([], role)
+        assert len(out) == 1
+        assert out[0]["kind"] == "extra"
+
+    def test_category_disagreement_same_offsets(self) -> None:
+        ref = [_sp("fundamentacao_legal", 5, 20)]
+        role = [_sp("resultado", 5, 20)]
+        out = compare_record(ref, role)
+        kinds = {d["kind"] for d in out}
+        assert kinds == {"category"}
+        assert out[0]["other_category"] == "resultado"
+
+    def test_boundary_disagreement_same_category(self) -> None:
+        ref = [_sp("resultado", 10, 25)]
+        role = [_sp("resultado", 10, 30)]
+        out = compare_record(ref, role)
+        assert len(out) == 1
+        assert out[0]["kind"] == "boundary"
+        assert out[0]["other_end"] == 30
+
+    def test_disjoint_same_category_is_missing_plus_extra(self) -> None:
+        ref = [_sp("resultado", 10, 25)]
+        role = [_sp("resultado", 50, 65)]
+        kinds = sorted(d["kind"] for d in compare_record(ref, role))
+        assert kinds == ["extra", "missing"]

--- a/tests/test_segment_decision.py
+++ b/tests/test_segment_decision.py
@@ -1,0 +1,134 @@
+"""Integration tests for the end-to-end inference pipeline (segment_decision).
+
+These run the GPU-free stages — ref_normativa regex merge + region
+reconstruction — over the committed gold splits, asserting the invariants
+that matter for the product output (regions), not just the anchor spans.
+"""
+
+from __future__ import annotations
+
+import json
+from itertools import pairwise
+from pathlib import Path
+
+import pytest
+
+from scripts.prepare_privacy_filter_dataset import (
+    _PAIRED_REGION_BASES,
+    SINGLE_ANCHOR_CATEGORIES,
+)
+from scripts.ref_normativa_prepass import extract_ref_normativa, merge_with_opf_spans
+from scripts.segment_decision import segment_text
+
+
+GOLD_DIR = Path("data/segmenter_splits")
+
+_REGION_CATEGORIES = frozenset(SINGLE_ANCHOR_CATEGORIES) | frozenset(_PAIRED_REGION_BASES)
+
+
+def _gold_records() -> list[dict]:
+    records: list[dict] = []
+    for split in ("train", "val", "test"):
+        path = GOLD_DIR / f"{split}.jsonl"
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped:
+                    records.append(json.loads(stripped))
+    return records
+
+
+GOLD = _gold_records()
+
+pytestmark = pytest.mark.skipif(not GOLD, reason="gold splits not present")
+
+
+class TestSegmentTextOnGold:
+    def test_merged_spans_have_no_overlaps(self) -> None:
+        for rec in GOLD:
+            result = segment_text(rec["text"], rec["label"])
+            spans = sorted(result["spans"], key=lambda s: s["start"])
+            for a, b in pairwise(spans):
+                assert b["start"] >= a["end"], (
+                    f"overlap after merge: [{a['category']}]({a['start']}:{a['end']}) "
+                    f"vs [{b['category']}]({b['start']}:{b['end']})"
+                )
+
+    def test_gold_spans_survive_ref_normativa_merge(self) -> None:
+        # The regex pre-pass must never displace a model/gold span — gold
+        # spans sort first at equal starts and ref spans overlapping them
+        # are dropped by the merge.
+        for rec in GOLD:
+            result = segment_text(rec["text"], rec["label"])
+            kept = {(s["category"], s["start"], s["end"]) for s in result["spans"]}
+            gold_set = {(s["category"], s["start"], s["end"]) for s in rec["label"]}
+            dropped = gold_set - kept
+            # A gold span may only be dropped if another gold span overlapped
+            # it (already prevented by opf_annotate validate), never by a
+            # ref_normativa regex span.
+            assert not dropped, f"gold spans dropped by merge: {dropped}"
+
+    def test_regions_are_within_bounds_and_ordered(self) -> None:
+        for rec in GOLD:
+            text = rec["text"]
+            result = segment_text(text, rec["label"])
+            for region in result["regions"]:
+                assert 0 <= region["start"] < region["end"] <= len(text), (
+                    f"bad region bounds: {region}"
+                )
+                assert region["category"] in _REGION_CATEGORIES, (
+                    f"unexpected region category: {region['category']}"
+                )
+
+    def test_every_paired_inicio_yields_a_region(self) -> None:
+        for rec in GOLD:
+            result = segment_text(rec["text"], rec["label"])
+            inicio_counts: dict[str, int] = {}
+            for sp in rec["label"]:
+                cat = sp["category"]
+                if cat.endswith("_inicio"):
+                    base = cat.removesuffix("_inicio")
+                    inicio_counts[base] = inicio_counts.get(base, 0) + 1
+            region_counts: dict[str, int] = {}
+            for region in result["regions"]:
+                if region["category"] in _PAIRED_REGION_BASES:
+                    region_counts[region["category"]] = region_counts.get(region["category"], 0) + 1
+            for base, n in inicio_counts.items():
+                assert region_counts.get(base, 0) == n, (
+                    f"{base}: {n} _inicio anchors but {region_counts.get(base, 0)} regions"
+                )
+
+    def test_ref_normativa_appears_in_output_not_gold(self) -> None:
+        # Gold never labels ref_normativa (regex pre-pass owns it); after the
+        # pipeline it must be present whenever the text cites statutes.
+        found_any = False
+        for rec in GOLD:
+            assert all(s["category"] != "ref_normativa" for s in rec["label"])
+            result = segment_text(rec["text"], rec["label"])
+            if any(s["category"] == "ref_normativa" for s in result["spans"]):
+                found_any = True
+        assert found_any, (
+            "no ref_normativa span produced over the entire gold corpus — "
+            "regex pre-pass is likely broken"
+        )
+
+
+class TestMergeSemantics:
+    def test_ref_span_overlapping_model_span_is_dropped(self) -> None:
+        text = "Nos termos do art. 927 do CPC, julgo procedente."
+        s = text.find("art. 927")
+        model = [{"category": "fundamentacao_legal", "start": s, "end": s + len("art. 927")}]
+        ref = extract_ref_normativa(text)
+        assert ref, "regex should find art. 927 / CPC"
+        merged = merge_with_opf_spans(model, ref)
+        fund = [sp for sp in merged if sp["category"] == "fundamentacao_legal"]
+        assert len(fund) == 1
+        for a, b in pairwise(sorted(merged, key=lambda x: x["start"])):
+            assert b["start"] >= a["end"]
+
+    def test_ref_span_in_clear_text_is_kept(self) -> None:
+        text = "Aplica-se a Súmula 331 do TST ao caso."
+        merged = merge_with_opf_spans([], extract_ref_normativa(text))
+        assert any(sp["category"] == "ref_normativa" for sp in merged)


### PR DESCRIPTION
## O que é

Implementa as duas peças do RFC 0001 (mergeado em #788) que não dependiam de dados novos nem de GPU:

### Etapa C — pipeline de inferência ponta-a-ponta

- **`scripts/segment_decision.py`**: encadeia OPF predict (subprocess, espelhando o contrato de `train`/`eval`) → merge do pre-pass regex de `ref_normativa` → reconstrução de regiões → JSONL com `spans` + `regions`. O modo `--spans-from-label` roda os estágios pós-modelo (GPU-free) sobre os labels gold — usado pelos testes e para desenvolvimento.
- **`tests/test_segment_decision.py`**: testes de integração sobre os splits gold commitados — sem overlap após o merge, spans gold nunca deslocados por spans regex, bounds de região válidos, todo `_inicio` vira região, `ref_normativa` presente na saída (e nunca no gold).

Smoke test: `test.jsonl` (3 docs) → 37 regiões reconstruídas, incluindo `voto`, `acordao_decisorio` e `ref_normativa` via regex.

### Etapa A — ensemble de verificação versionado

- **`data/segmenter_splits/verification_ensemble_v7.md`**: o protocolo 4-papéis (strict-boundary, category-disambiguation, blind-relabel, adversarial) que o `manifest.json` declarava mas não existia como artefato reproduzível — prompts, atribuição de modelos, regra de re-adjudicação de ambíguos e registro do resultado.
- **`scripts/ensemble_compare.py`**: diff mecânico entre gold candidato e saídas dos papéis (`missing`/`extra`/`boundary`/`category`), exit não-zero enquanto houver desacordo — torna "verified" um estado checável, não uma afirmação.
- **`tests/test_ensemble_compare.py`**: testes unitários do comparador.

## Verificação

- 13 testes novos + suíte completa (158) passando
- `ruff check` (escopo estrito da CI) e `ruff format` limpos; vulture limpo
- CLI smoke-testado: pipeline sobre gold e comparador auto-validando o test split

https://claude.ai/code/session_01JGVQfsPHVdr3AeuwaYVR2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGVQfsPHVdr3AeuwaYVR2W)_