### PR TITLE
fix(stj): não classificar recursos não-JSON do CKAN como json

### DIFF
--- a/src/stj_acordaos/__main__.py
+++ b/src/stj_acordaos/__main__.py
@@ -16,8 +16,7 @@ Show manifest summary::
     uv run stj-acordaos status
 
 In CI, ``.github/workflows/stj-tjro-sync.yml`` runs the same commands with
-secrets injected. It is ``workflow_dispatch`` only (no cron) — trigger it
-manually from the Actions tab.
+secrets injected, hourly plus ``workflow_dispatch``.
 """
 
 from __future__ import annotations
@@ -38,6 +37,24 @@ _DEFAULT_DATA_DIR = Path("data/stj")
 _DEFAULT_MANIFEST = _DEFAULT_DATA_DIR / "stj-manifest.csv"
 _DEFAULT_EXTRACT_DIR = _DEFAULT_DATA_DIR / "extracted"
 _DEFAULT_PARQUET = _DEFAULT_DATA_DIR / "stj-acordaos.parquet"
+
+
+def _classify_resource(fmt: str, url: str) -> str | None:
+    """Classify a CKAN resource as "zip" or "json"; None when neither.
+
+    The STJ dataset carries auxiliary resources (e.g. a "dicionário de
+    dados" CSV) that are not acórdãos data — downloading those as if they
+    were JSON produces a file DuckDB's ``read_json`` chokes on later. Only
+    resources explicitly declared zip/json (by CKAN ``format`` or URL
+    suffix) are downloaded; anything else is skipped.
+    """
+    fmt = fmt.lower()
+    url_lower = url.lower()
+    if fmt == "zip" or url_lower.endswith(".zip"):
+        return "zip"
+    if fmt == "json" or url_lower.endswith(".json"):
+        return "json"
+    return None
 
 
 @app.command()
@@ -72,7 +89,10 @@ def download(
             typer.echo(f"  SKIP {name}: no URL", err=True)
             continue
 
-        tipo = "zip" if fmt == "zip" or url.lower().endswith(".zip") else "json"
+        tipo = _classify_resource(fmt, url)
+        if tipo is None:
+            typer.echo(f"  SKIP {name}: unrecognized format {fmt!r} (not zip/json)", err=True)
+            continue
         dest = zip_dir / f"{name}.{tipo}"
 
         typer.echo(f"→ Downloading {name} ({tipo}) …")

--- a/tests/stj_acordaos/test_stj_main.py
+++ b/tests/stj_acordaos/test_stj_main.py
@@ -1,0 +1,34 @@
+"""Tests for stj_acordaos.__main__ — CKAN resource classification.
+
+Regression: the STJ dataset carries a non-JSON "dicionário de dados"
+resource (format=CSV) that used to be blindly downloaded as ``.json`` and
+later broke DuckDB's ``read_json`` during dedup/upload.
+"""
+
+from __future__ import annotations
+
+from stj_acordaos.__main__ import _classify_resource
+
+
+def test_zip_format_classified_as_zip() -> None:
+    assert _classify_resource("ZIP", "https://example.org/x") == "zip"
+
+
+def test_zip_url_suffix_classified_as_zip_even_without_format() -> None:
+    assert _classify_resource("", "https://example.org/x.ZIP") == "zip"
+
+
+def test_json_format_classified_as_json() -> None:
+    assert _classify_resource("JSON", "https://example.org/x") == "json"
+
+
+def test_json_url_suffix_classified_as_json_even_without_format() -> None:
+    assert _classify_resource("", "https://example.org/x.json") == "json"
+
+
+def test_csv_dictionary_resource_is_skipped_not_treated_as_json() -> None:
+    assert _classify_resource("CSV", "https://example.org/dicionario-espelhodoacordao.csv") is None
+
+
+def test_unknown_format_and_extension_is_skipped() -> None:
+    assert _classify_resource("", "https://example.org/readme") is None


### PR DESCRIPTION
## Description

Corrige a causa raiz do **primeiro run agendado** do cron `stj-tjro-sync.yml` (2026-07-08T22:13:41Z, o primeiro tick após o PR #799 ligar o `schedule`), que falhou no job `stj`.

**Diagnóstico:** o dataset CKAN do STJ inclui um recurso auxiliar "dicionário de dados" (`format=CSV`) além dos ZIPs/JSONs de acórdãos. `stj_acordaos download` classificava **qualquer** recurso não-ZIP como `"json"` incondicionalmente (`src/stj_acordaos/__main__.py:75`, código pré-existente da RFC 0002, não tocado pelos PRs #799/#800), então esse CSV era salvo como `dicionario-espelhodoacordao.csv.json` e quebrava o `read_json()` do DuckDB depois, durante o dedup/upload:

```
InvalidInputException: Malformed JSON in file "data/stj/zips/dicionario-espelhodoacordao.csv.json"
```

Esse bug provavelmente sempre existiu, mas só apareceu agora porque antes o workflow só rodava via `workflow_dispatch` manual (baixa frequência de execução = baixa chance de amostrar esse recurso específico antes).

**Correção:** `_classify_resource(fmt, url)` — nova função pura — só classifica como `"zip"`/`"json"` quando o formato do CKAN ou o sufixo da URL confirma explicitamente; qualquer outro formato é pulado com uma mensagem nominal em vez de ser baixado e mal-processado como dado de acórdão.

## Verificação

- `uv run pytest -q` → **440 passed** (434 + 6 novos), 1 skipped
- `ruff check` / `ruff format --check` → limpos
- `vulture` → limpo

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. *(Nenhum flag de CLI alterado — só a lógica interna de classificação de recursos.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5PcM17FjhJTNBuEnEa6Ah

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5PcM17FjhJTNBuEnEa6Ah)_