### PR TITLE
feat(datajud): ligar cron diário do datajud-enrich.yml

### DIFF
--- a/.github/workflows/datajud-enrich.yml
+++ b/.github/workflows/datajud-enrich.yml
@@ -1,10 +1,11 @@
 # ============================================================================
-# DATAJUD ENRICH — Manual enrichment of known CNJs with official metadata
+# DATAJUD ENRICH — Enrichment of known CNJs with official metadata
 # ============================================================================
 #
-# workflow_dispatch ONLY (no cron): the CNJ's rate limit is the dominant
-# constraint (RFC 0010 §3.4) — trigger runs manually from the Actions tab.
-# Cron is an owner decision after manual rounds.
+# Daily cron (RFC 0010 §3.4 — owner decision after manual rounds) plus
+# workflow_dispatch for ad-hoc runs. The CNJ's rate limit is the dominant
+# constraint, so the schedule stays daily with a per-run CNJ limit rather
+# than hourly like stj-tjro-sync.yml.
 #
 # One job:
 #   enrich — `datajud enrich` (source CNJs → DataJud capa+movimentos → IA)
@@ -13,6 +14,8 @@
 name: DataJud Enrich
 
 on:
+  schedule:
+    - cron: '13 5 * * *'
   workflow_dispatch:
     inputs:
       tribunal:

--- a/docs/rfc/0010-datajud-metadados-processuais.md
+++ b/docs/rfc/0010-datajud-metadados-processuais.md
@@ -80,9 +80,11 @@ DataJud. Tipos correspondentes em `web/src/lib/data/contracts.ts` (RFC 0009).
 
 ### 3.4 Operação (padrão RFC 0008)
 
-Workflow `datajud-enrich.yml` **workflow_dispatch apenas** (inputs: tribunal, limite de
-CNJs, janela de re-consulta). Cron é decisão do owner após rodadas manuais — o rate
-limit do CNJ é a restrição dominante.
+Workflow `datajud-enrich.yml` roda em cron diário (`13 5 * * *`, ligado pelo owner após
+rodadas manuais) mais `workflow_dispatch` para runs ad-hoc (inputs: tribunal, limite de
+CNJs, janela de re-consulta). A cadência ficou diária — não horária como o
+`stj-tjro-sync.yml` — porque o rate limit do CNJ é a restrição dominante; o limite de
+CNJs por run controla o volume de cada execução.
 
 ## 4. O que NÃO fazer
 


### PR DESCRIPTION
## Description

Liga o cron do workflow `datajud-enrich.yml`, que até agora era `workflow_dispatch` apenas (RFC 0010 §3.4 deixava isso como "decisão do owner após rodadas manuais").

**Cadência:** diária (`13 5 * * *`), não horária como o `stj-tjro-sync.yml` — o rate limit do CNJ (RFC 0010 §3.4) é a restrição dominante, então o limite de CNJs por run (input `limite`, default 500) controla o volume de cada execução em vez da frequência.

`workflow_dispatch` continua disponível para runs ad-hoc com os mesmos inputs (`tribunal`, `limite`, `skip_upload`). A lógica do step já usa fallback bash (`${TRIBUNAL:-tjro}`, `${LIMITE:-500}`) para quando `inputs.*` vem vazio em eventos `schedule` — não precisou de gate adicional.

Atualizado RFC 0010 §3.4 para refletir a cadência ligada.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. *(Nenhum flag de CLI alterado — só o trigger `schedule` do workflow.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5PcM17FjhJTNBuEnEa6Ah)_