### PR TITLE
fix(consolidate): let the backfill loop process more than 1 day per run

### DIFF
--- a/.github/workflows/consolidate-parquet.yml
+++ b/.github/workflows/consolidate-parquet.yml
@@ -30,7 +30,7 @@ on:
       deadline_minutes:
         description: 'Deadline in minutes'
         required: false
-        default: '12'
+        default: '165'
 
 permissions:
   contents: read
@@ -44,7 +44,11 @@ jobs:
   consolidate:
     name: Consolidate ZIPs → Parquet
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # A single backfill date already takes ~13-14 min (measured), so the previous
+    # 15min/12min pair left almost no margin — the loop never got past 1 date/run,
+    # and any slowdown killed the job outright (6 of the last 10 scheduled runs were
+    # cancelled by the timeout). Both numbers need headroom over per-date runtime.
+    timeout-minutes: 180
     environment: dev
 
     env:
@@ -106,7 +110,7 @@ jobs:
           DATE="${{ github.event.inputs.date || '' }}"
           DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
           FORCE="${{ github.event.inputs.force || 'false' }}"
-          DEADLINE="${{ github.event.inputs.deadline_minutes || '12' }}"
+          DEADLINE="${{ github.event.inputs.deadline_minutes || '165' }}"
 
           CMD="uv run python scripts/pipeline/consolidate.py"
 

--- a/notebooks/cost_estimate.ipynb
+++ b/notebooks/cost_estimate.ipynb
@@ -88,7 +88,7 @@
    "pygments_lexer": "ipython3"
   },
   "marimo": {
-   "marimo_version": "0.23.13"
+   "marimo_version": "0.23.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/train_decision_segmenter.ipynb
+++ b/notebooks/train_decision_segmenter.ipynb
@@ -644,7 +644,7 @@
   },
   "marimo": {
    "header": "# /// script\n# dependencies = [\"-\", \"accelerate\", \"datasets\", \"scikit-learn\", \"transformers\"]\n# ///\n\n",
-   "marimo_version": "0.23.13"
+   "marimo_version": "0.23.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/train_ml_document_classifier.ipynb
+++ b/notebooks/train_ml_document_classifier.ipynb
@@ -468,7 +468,7 @@
   },
   "marimo": {
    "header": "# /// script\n# dependencies = [\"-\", \"classify\"]\n# ///\n\n",
-   "marimo_version": "0.23.13"
+   "marimo_version": "0.23.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/train_privacy_filter.ipynb
+++ b/notebooks/train_privacy_filter.ipynb
@@ -417,7 +417,7 @@
   },
   "marimo": {
    "header": "# /// script\n# dependencies = [\"datasets\", \"ibis-framework\", \"seqeval\", \"structlog\", \"transformers\"]\n# ///\n\n",
-   "marimo_version": "0.23.13"
+   "marimo_version": "0.23.14"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,11 @@ dev = [
     "mkdocs-minify-plugin>=0.8.0",
     "playwright>=1.58.0",
     # marimo notebooks (notebooks/*.py) + ipynb export used by the
-    # notebook-sync CI check (scripts/check_notebooks_synced.py)
-    "marimo>=0.23.8",
+    # notebook-sync CI check (scripts/check_notebooks_synced.py). uv.lock is
+    # gitignored, so this is the only thing pinning the version anywhere —
+    # exact-pinned because even patch bumps change ipynb export bytes and
+    # break that check (hit twice now: 0.23.11->0.23.13, then ->0.23.14).
+    "marimo==0.23.14",
     "nbformat>=5.10.4",
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -54,7 +54,9 @@ ignore = [
 # PLW2901: loop variable reassignment in CSV parser (strip idiom).
 # PERF401: list.append in CSV serializer — clarity over micro-optimisation.
 # E501: long IA metadata strings; re-wrapping would harm readability.
-"src/stj_acordaos/__main__.py" = ["B008", "PLC0415", "D101", "D102", "D103", "D107", "FBT001", "FBT003"]
+# BLE001: blind except around a single resource's download/extract in a batch
+# CLI loop — one bad ZIP shouldn't abort the whole run.
+"src/stj_acordaos/__main__.py" = ["B008", "PLC0415", "D101", "D102", "D103", "D107", "FBT001", "FBT003", "BLE001"]
 "src/stj_acordaos/manifest.py" = ["D107", "D105", "PLW2901", "PERF401"]
 # S608: f-string SQL with DuckDB — path_list is internal (no user input).
 # E501: long log line; splitting would obscure the structured-logging pattern.
@@ -79,7 +81,8 @@ ignore = [
 # PLC0415: lazy duckdb imports inside CLI helpers — standard pattern.
 # FBT001/FBT002: boolean CLI flags are idiomatic Typer.
 # S608: f-string SQL over internal parquet paths only (no user input).
-"src/datajud/__main__.py" = ["PLC0415", "FBT001", "FBT002", "S608"]
+# S310: urlopen against a fixed archive.org URL constant, not user input.
+"src/datajud/__main__.py" = ["PLC0415", "FBT001", "FBT002", "S608", "S310"]
 
 # ── Lazy / conditional imports in library modules ─────────────────────────
 # These modules defer expensive imports to avoid slowing every process start.
@@ -99,6 +102,8 @@ ignore = [
 "src/causaganha/consolidate/manifest_reader.py" = ["S608"]
 "src/causaganha/consolidate/validation.py" = ["S608"]
 "src/causaganha/consolidate/consolidation_manifest.py" = ["S608"]
+"src/causaganha/consolidate/exporter.py" = ["S608"]
+"src/djen_backup/probe.py" = ["S608"]
 "src/causaganha/analysis/llm_analyzer.py" = ["ANN401", "ARG002", "C901", "E501", "PLR0912", "PLR0915"]
 "src/causaganha/analysis/models.py" = ["E501"]
 "src/causaganha/consolidate/cli.py" = ["C901", "E501", "PLR0912", "PLR0915"]

--- a/src/causaganha/consolidate/exporter.py
+++ b/src/causaganha/consolidate/exporter.py
@@ -82,7 +82,7 @@ def export_table_sync(
         msg = f"unknown table for export: {table_name!r}"
         raise ValueError(msg)
     order_keys = _TABLE_ORDER_KEYS[table_name]
-    copy_source = f"(SELECT * FROM {table_name} ORDER BY {order_keys})"  # noqa: S608
+    copy_source = f"(SELECT * FROM {table_name} ORDER BY {order_keys})"
     con.raw_sql(
         f"COPY {copy_source} TO '{output_path}' ({copy_opts})",
     )

--- a/src/datajud/__main__.py
+++ b/src/datajud/__main__.py
@@ -93,7 +93,7 @@ def _try_download_unificados(sources_dir: Path) -> None:
     typer.echo(f"No local sources — trying {_UNIFICADOS_IA_URL}")
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with urllib.request.urlopen(_UNIFICADOS_IA_URL, timeout=180) as resp:  # noqa: S310 — fixed archive.org URL
+        with urllib.request.urlopen(_UNIFICADOS_IA_URL, timeout=180) as resp:
             dest.write_bytes(resp.read())
     except OSError as exc:
         typer.echo(f"  WARNING: could not download processos_unificados — {exc}", err=True)

--- a/src/djen_backup/probe.py
+++ b/src/djen_backup/probe.py
@@ -66,7 +66,7 @@ def fetch_pending_batch(
           {seen_filter}
         ORDER BY random()
         LIMIT ?
-        """,  # noqa: S608
+        """,
         (parquet_url, batch_size),
     ).fetchall()
     return [(r[0], r[1]) for r in rows]

--- a/src/stj_acordaos/__main__.py
+++ b/src/stj_acordaos/__main__.py
@@ -98,7 +98,7 @@ def download(
         typer.echo(f"→ Downloading {name} ({tipo}) …")
         try:
             download_resource(url, dest)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             typer.echo(f"  ERROR: {exc}", err=True)
             continue
 
@@ -108,7 +108,7 @@ def download(
             try:
                 extracted = extract_zip(dest, extract_dir)
                 n_extracted = len(extracted)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 typer.echo(f"  Extract ERROR: {exc}", err=True)
 
         manifest.upsert(


### PR DESCRIPTION
## Description

While investigating why `reconcile_processos.py` can't make DJEN contribute to `processos_unificados.parquet` (blocks RFC 0010's DataJud enrichment, which sources its CNJs from that file), I traced the actual root cause past the file-not-found symptom into `consolidate-parquet.yml`'s backfill throughput.

**The chain:**
1. `datajud-enrich.yml`'s two scheduled runs so far both failed in ~3s: `processos_unificados.parquet` 404s on IA.
2. That parquet is only ever produced by `reconcile_processos.py`, which isn't wired into any workflow yet (separate follow-up).
3. But even fixing that wiring wouldn't help much today: `reconcile_processos.py`'s DJEN join needs a `comunicacoes.parquet` per consolidated date, and only **~20 days** (2026-01-15 to 2026-02-16) have ever been consolidated, out of a manifest with ~157K tribunal-day entries.
4. Root cause: `consolidate-parquet.yml`'s `--backfill` mode already loops over unconsolidated dates until `--deadline`, but the previous defaults (`deadline_minutes: 12`, job `timeout-minutes: 15`) left less margin than a single date's real runtime (~13-14 min measured on the 2026-07-10 run, 128 ZIPs/~68 tribunals). The loop checks the deadline *before* starting each new date, so it always stopped after exactly one. Worse, 6 of the last 10 scheduled runs were killed by the 15min timeout outright (`conclusion: cancelled`), so even "1 day per day" wasn't reliable — the backlog has been frozen ~150 days behind real time.

## Change

Raise `timeout-minutes` (15 → 180) and the `--deadline` default (12 → 165 min) — both the declared `workflow_dispatch` input and the bash fallback the schedule trigger actually uses (`github.event.inputs.*` is empty on `schedule` events, so the fallback is what governs the daily cron). At ~13-14 min/date this lets one daily run work through roughly a dozen backlog days instead of one, so the backlog actually shrinks over the coming weeks instead of staying frozen.

**Not in scope for this PR** (flagged for follow-up): wiring `reconcile_processos.py` into a workflow so `processos_unificados.parquet` actually gets (re)published, and deciding whether `datajud-enrich.yml`'s cron should stay on while its only CNJ source is empty.

### Also fixed: pre-existing CI failures unrelated to the above (blocking this PR's `lint` check on main already, not caused by this branch)

- **`pyproject.toml`**: `marimo` was `>=0.23.8` (open-ended); `uv.lock` is gitignored so nothing else pins it. A patch bump (0.23.13→0.23.14, published after this branch was cut) changed `.ipynb` export bytes and tripped the notebook-sync CI gate — this already happened once before (0.23.11→0.23.13). Pinned exactly and regenerated the 4 affected notebooks against 0.23.14.
- **`ruff.toml`**: 5 lines had inline `# noqa: S608/S310/BLE001` comments. `test.yml` runs `ruff check` twice with complementary filters — `--select S,BLE001,B904,TRY300` (blocking) and `--ignore` the same set (advisory, `continue-on-error`). Under `--ignore`, those rules are already off, so ruff correctly flagged the noqa as unused (`RUF100`). Moved the 5 suppressions into `ruff.toml`'s `per-file-ignores` (same pattern already used for dozens of other files) — that satisfies the blocking `--select` invocation the same way the noqa did, but isn't an inline noqa comment so `RUF100` has nothing to flag under `--ignore`.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. *(No flag added/removed — `--deadline` already exists in `scripts/pipeline/consolidate.py`; only the default value passed to it changes.)*
