### PR TITLE
feat(reconcile): make DJEN contribute to processos_unificados, wire into automation

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -56,6 +56,16 @@ jobs:
           uv run python scripts/generate_catalog.py --upload
           echo "Catalog updated."
 
+      - name: Reconcile processos (DJEN x JURIS x STJ x DataJud)
+        if: steps.append.outputs.has_new_uploads == 'true'
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          echo "Reconciling processos_unificados..."
+          uv run python scripts/reconcile_processos.py
+          echo "processos_unificados.parquet uploaded."
+
       - name: Render query contracts and generate cache
         if: steps.append.outputs.has_new_uploads == 'true'
         run: |

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -2,7 +2,8 @@
 """Reconcile DJEN x TJRO JURIS x STJ into processos_unificados.
 
 Pipeline:
-  1. Load DJEN from sync-manifest parquet — GROUP BY nr_processo
+  1. Load DJEN from every consolidated comunicacoes.parquet (discovered via the
+     causaganha-catalog manifest) — GROUP BY nr_processo
   2. Load JURIS from tjro-juris-<year>.parquet files — GROUP BY nr_processo
   3. Load STJ from stj-acordaos.parquet — filter to CNJ numbers only
   4. Full outer join the three aggregations in DuckDB
@@ -35,8 +36,7 @@ _PARQUET_DOCUMENTOS = DATA_DIR / "processo_documentos.parquet"
 
 _IA_BASE = "https://archive.org/download"
 _IA_ITEM_DASHBOARD = "causaganha-dashboard"
-_IA_MANIFEST_PARQUET_URL = f"{_IA_BASE}/{_IA_ITEM_DASHBOARD}/sync-manifest.parquet"
-_LOCAL_MANIFEST_PARQUET = DATA_DIR / "sync-manifest.parquet"
+_IA_CATALOG_MANIFEST_URL = f"{_IA_BASE}/causaganha-catalog/manifest.parquet"
 
 _STJ_PARQUET = DATA_DIR / "stj" / "stj-acordaos.parquet"
 _STJ_IA_URL = f"{_IA_BASE}/stj-acordaos-primeira-secao/stj-acordaos.parquet"
@@ -73,11 +73,25 @@ def _download(url: str, dest: Path, label: str) -> Path:
     return dest
 
 
-def ensure_manifest() -> Path:
-    if _LOCAL_MANIFEST_PARQUET.exists():
-        print(f"Using local manifest: {_LOCAL_MANIFEST_PARQUET}")
-        return _LOCAL_MANIFEST_PARQUET
-    return _download(_IA_MANIFEST_PARQUET_URL, _LOCAL_MANIFEST_PARQUET, "sync-manifest.parquet")
+def comunicacoes_parquet_urls(con: duckdb.DuckDBPyConnection) -> list[str]:
+    """URLs of every consolidated comunicacoes.parquet, from the IA catalog.
+
+    consolidate-parquet.yml uploads one comunicacoes.parquet per consolidated
+    date (item djen-YYYY-MM-DD); causaganha-catalog/manifest.parquet is the
+    index of every such file across every item, kept fresh by
+    update-catalog.yml. Querying it (instead of e.g. listing IA items
+    directly) keeps this in sync with whatever has actually been consolidated
+    without hand-enumerating dates.
+    """
+    try:
+        rows = con.execute(
+            "SELECT DISTINCT ia_url FROM read_parquet(?) WHERE table_name = 'comunicacoes'",
+            [_IA_CATALOG_MANIFEST_URL],
+        ).fetchall()
+    except duckdb.Error as exc:
+        print(f"  WARNING: could not read IA catalog manifest — {exc}", file=sys.stderr)
+        return []
+    return sorted(r[0] for r in rows)
 
 
 def ensure_stj_parquet() -> Path | None:
@@ -141,11 +155,11 @@ def _ia_credentials() -> str | None:
 _DJEN_AGG_SQL = """
 SELECT
     regexp_replace(numero_processo, '[^0-9]', '', 'g') AS nr_processo,
-    MIN(data_publicacao)::DATE  AS djen_primeira_pub,
-    MAX(data_publicacao)::DATE  AS djen_ultima_pub,
-    COUNT(*)::INTEGER           AS djen_n_publicacoes,
-    list(DISTINCT tribunal)     AS djen_tribunais
-FROM manifest
+    MIN(data_disponibilizacao)::DATE  AS djen_primeira_pub,
+    MAX(data_disponibilizacao)::DATE  AS djen_ultima_pub,
+    COUNT(*)::INTEGER                 AS djen_n_publicacoes,
+    list(DISTINCT tribunal)           AS djen_tribunais
+FROM comunicacoes
 WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
 GROUP BY nr_processo
 """
@@ -362,14 +376,33 @@ ORDER BY nr_processo, data DESC NULLS LAST
 
 
 def reconcile(*, upload: bool = True) -> dict[str, Any]:
-    manifest_path = ensure_manifest()
     stj_path = ensure_stj_parquet()
     juris_files = juris_parquet_files()
 
     con = duckdb.connect()
+    con.execute("INSTALL httpfs; LOAD httpfs;")
 
-    # Register manifest view
-    con.execute(f"CREATE VIEW manifest AS SELECT * FROM read_parquet('{manifest_path}')")
+    # Register DJEN comunicacoes view (union of every consolidated date, read
+    # straight off IA — there's no single local cache file for this, unlike
+    # STJ/JURIS, since it's one small parquet per consolidated date).
+    comunicacoes_urls = comunicacoes_parquet_urls(con)
+    if comunicacoes_urls:
+        url_list = ", ".join(f"'{u}'" for u in comunicacoes_urls)
+        print(f"Registering DJEN comunicacoes view: {len(comunicacoes_urls)} parquet file(s)")
+        con.execute(
+            f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], "
+            "union_by_name=true)"
+        )
+    else:
+        print(
+            "WARNING: no comunicacoes.parquet in the IA catalog — DJEN contribution will be empty",
+            file=sys.stderr,
+        )
+        con.execute(
+            "CREATE VIEW comunicacoes AS "
+            "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
+            "NULL::VARCHAR AS tribunal WHERE FALSE"
+        )
 
     # Register JURIS view (union of consolidated yearly parquets)
     if juris_files:
@@ -408,26 +441,8 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
         )
 
     # Build aggregation CTEs
-    # DJEN: the sync-manifest is a caderno-level index (tribunal x date); it has no
-    # numero_processo column. A future "comunicacoes" parquet (individual publication
-    # records) would enable the DJEN contribution. Skip gracefully when absent.
     print("Building DJEN aggregation…")
-    manifest_cols = {row[0] for row in con.execute("DESCRIBE manifest").fetchall()}
-    if "numero_processo" in manifest_cols and "data_publicacao" in manifest_cols:
-        con.execute(f"CREATE TEMP TABLE djen_agg AS {_DJEN_AGG_SQL}")
-    else:
-        print(
-            "  SKIP: manifest lacks numero_processo/data_publicacao — "
-            "DJEN contribution requires a comunicacoes parquet (not yet generated)",
-            file=sys.stderr,
-        )
-        con.execute(
-            "CREATE TEMP TABLE djen_agg AS "
-            "SELECT NULL::VARCHAR AS nr_processo, NULL::DATE AS djen_primeira_pub, "
-            "NULL::DATE AS djen_ultima_pub, NULL::INTEGER AS djen_n_publicacoes, "
-            "NULL::VARCHAR[] AS djen_tribunais "
-            "WHERE FALSE"
-        )
+    con.execute(f"CREATE TEMP TABLE djen_agg AS {_DJEN_AGG_SQL}")
     djen_count = con.execute("SELECT COUNT(*) FROM djen_agg").fetchone()[0]
     print(f"  {djen_count:,} DJEN processes")
 
@@ -498,7 +513,9 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
         f"COPY processos_unificados TO '{_PARQUET_UNIFICADOS}' (FORMAT PARQUET, COMPRESSION ZSTD)"
     )
 
-    # Build processo_documentos (JURIS + STJ only; DJEN requires a future comunicacoes parquet)
+    # Build processo_documentos (JURIS + STJ only — DJEN's per-process rollup
+    # already lives in processos_unificados via djen_agg; adding individual
+    # DJEN communications here would need a join through textos for a resumo)
     print("Writing processo_documentos.parquet…")
     con.execute(
         f"COPY ({_DOCUMENTOS_SQL}) TO '{_PARQUET_DOCUMENTOS}' (FORMAT PARQUET, COMPRESSION ZSTD)"

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -346,10 +346,11 @@ def _reconcile_sources_connection() -> duckdb.DuckDBPyConnection:
     so --check can never drift from what the reconcile pipeline actually writes.
     """
     scratch = duckdb.connect()
-    # The reconcile pipeline reads a publication-level manifest (one row per
-    # numero_processo/publication) — distinct from the sync-manifest CSV view.
+    # The reconcile pipeline reads every consolidated comunicacoes.parquet
+    # (one row per DJEN publication) — distinct from the sync-manifest view.
     scratch.execute(
-        "CREATE TABLE manifest (numero_processo VARCHAR, data_publicacao DATE, tribunal VARCHAR)"
+        "CREATE TABLE comunicacoes "
+        "(numero_processo VARCHAR, data_disponibilizacao DATE, tribunal VARCHAR)"
     )
     _synthetic_tjro_juris(scratch)
     _synthetic_acordaos(scratch)


### PR DESCRIPTION
## Description

Follow-up to #803, closing the two items flagged there as out of scope: wiring `reconcile_processos.py` into automation, and the fate of `datajud-enrich.yml`'s cron.

### 1. `reconcile_processos.py`'s DJEN join was structurally dead code

It read `sync-manifest.parquet` (a `tribunal × date` index) and checked for a `numero_processo` column that table can **never** have — so it always hit the `SKIP` branch, no matter how much data existed. This wasn't a wiring problem, it was reading the wrong source entirely.

Fixed it to read every consolidated `comunicacoes.parquet` instead — discovered via `causaganha-catalog/manifest.parquet`, which already indexes every such file by `table_name` (kept fresh by `update-catalog.yml`), unioned over IA via DuckDB httpfs. No new artifact, no new pipeline — just querying data that already exists.

**Verified live against production IA data:**

```
Registering DJEN comunicacoes view: 19 parquet file(s)
Building DJEN aggregation…
  5,539,302 DJEN processes
...
Done. 5,539,302 processos_unificados (0 multi-fonte).
```

(was 0 before this fix, every time, regardless of how many days get consolidated.)

`render_queries.py`'s synthetic schema for `--check` (it imports and runs `reconcile_processos.py`'s own SQL constants against empty tables, so `--check` can't drift from what reconcile actually writes) is updated to match the new `comunicacoes` shape. `--check` and the full test suite both pass.

### 2. Wired into `update-catalog.yml`

New step, right after the catalog regenerates (so the `comunicacoes` lookup sees current data) and before `render_queries` (so `processos_multi_fonte.qmd` reads a fresh `processos_unificados.parquet`). Gated on the same `has_new_uploads` check as its neighboring steps. A catalog-read failure degrades to an empty DJEN contribution (`WARNING`, same fallback pattern already used for the STJ download) instead of crashing the step — IA has shown real transient 503s during this investigation.

### 3. `datajud-enrich.yml` needs no change

Its CI cold-start already falls back to downloading `processos_unificados.parquet` from IA — which will now actually exist once `update-catalog.yml` runs once post-merge. Its `05:13 UTC` cron fires before `consolidate-parquet`'s `07:00 UTC` run, so on any given day it'll pick up the *previous* day's reconciled file — acceptable staleness for CNJ sourcing, this isn't a freshness-sensitive read.

### Not addressed here

JURIS and DataJud capa parquets have no IA download fallback in `reconcile_processos.py` (only local-directory globs), so they'll stay empty in every automated run until someone adds one — same class of gap DJEN had, but already loudly `WARNING`'d today rather than silent, and a reasonably self-contained follow-up (STJ's existing fallback is the template).

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. *(No CLI flags changed — `reconcile_processos.py`'s `--no-upload` already existed; the workflow just calls it without that flag to upload for real.)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzJ76CcgiNrcccvuVMcsCd)_