### PR TITLE
feat(reconcile): fall back to Internet Archive for JURIS and STJ contribution

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -61,6 +61,14 @@ jobs:
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+          # Sources whose UNAVAILABILITY (not loaded at all, local or IA)
+          # fails this step. JURIS and DataJud are deliberately excluded for
+          # now: no tjro-juris-*/datajud-* IA items exist yet (their upload
+          # pipelines have never landed data on IA), so requiring them would
+          # hard-fail every catalog run. Their absence still surfaces as
+          # ::warning annotations on every run. Add juris,datajud here as
+          # soon as those uploads produce real IA items.
+          RECONCILE_EXPECTED_SOURCES: djen,stj
         run: |
           echo "Reconciling processos_unificados..."
           uv run python scripts/reconcile_processos.py

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -4,28 +4,51 @@
 Pipeline:
   1. Load DJEN from every consolidated comunicacoes.parquet (discovered via the
      causaganha-catalog manifest) — GROUP BY nr_processo
-  2. Load JURIS from tjro-juris-<year>.parquet files — GROUP BY nr_processo
+  2. Load JURIS from tjro-juris-<year>.parquet files (local, or fetched from
+     the tjro-juris-{year} IA items when absent locally) — GROUP BY nr_processo
   3. Load STJ from stj-acordaos.parquet — filter to CNJ numbers only
   4. Full outer join the three aggregations in DuckDB
   5. Optional DataJud enrichment (RFC 0010): LEFT JOIN the official capa
      (classe_oficial, assuntos, orgao_julgador, grau, data_ajuizamento,
-     ultima_atualizacao, tem_datajud) when datajud-capa-*.parquet exists —
-     without it the columns are NULL/false and behaviour is unchanged
+     ultima_atualizacao, tem_datajud) when datajud-capa-*.parquet exists
+     (local, or fetched from the datajud-{tribunal} IA items) — without it
+     the columns are NULL/false and behaviour is unchanged
   6. Write processos_unificados.parquet + processo_documentos.parquet
-  7. Upload both to IA item causaganha-dashboard
+  7. Write a source-coverage report (per-source counts + load status +
+     fontes intersection matrix) next to the output as
+     processos_unificados.report.json, and fail loudly when an expected
+     source ended up with zero rows because it could not be loaded at all
+  8. Upload both parquets to IA item causaganha-dashboard
+
+Environment knobs:
+  RECONCILE_CACHE_DIR          — where IA-fetched source parquets are cached
+                                 (default: data/reconcile-cache)
+  RECONCILE_DATAJUD_TRIBUNAIS  — comma list of datajud-{tribunal} IA items to
+                                 probe for capa parquets (default: tjro)
+  RECONCILE_EXPECTED_SOURCES   — comma list of sources whose *unavailability*
+                                 is fatal (default: djen,juris,stj,datajud)
+  RECONCILE_STRICT             — set to 0/false to never exit non-zero on
+                                 unavailable expected sources (same as
+                                 --no-strict)
 """
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import sys
-import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import duckdb
+import httpx
 
 from datajud.archive import CAPA_SCHEMA as _DATAJUD_CAPA_SCHEMA
+from datajud.archive import capa_parquet_name as _datajud_capa_name
+from datajud.archive import item_id as _datajud_item_id
 
 
 ROOT = Path(__file__).parent.parent
@@ -33,8 +56,11 @@ DATA_DIR = ROOT / "data"
 
 _PARQUET_UNIFICADOS = DATA_DIR / "processos_unificados.parquet"
 _PARQUET_DOCUMENTOS = DATA_DIR / "processo_documentos.parquet"
+_REPORT_NAME = "processos_unificados.report.json"
 
 _IA_BASE = "https://archive.org/download"
+_IA_METADATA_BASE = "https://archive.org/metadata"
+_IA_SEARCH_URL = "https://archive.org/advancedsearch.php"
 _IA_ITEM_DASHBOARD = "causaganha-dashboard"
 _IA_CATALOG_MANIFEST_URL = f"{_IA_BASE}/causaganha-catalog/manifest.parquet"
 
@@ -43,6 +69,51 @@ _STJ_IA_URL = f"{_IA_BASE}/stj-acordaos-primeira-secao/stj-acordaos.parquet"
 
 # DataJud capa parquets (datajud enrich CLI, RFC 0010) — optional enrichment.
 _DATAJUD_DIR = DATA_DIR / "datajud"
+_DEFAULT_DATAJUD_TRIBUNAIS = ("tjro",)
+
+# TJRO JURIS yearly items on IA (see src/tjro_juris/archive.py). Both local
+# glob spellings are honoured: the CLI/workflows write data/tjro-juris/,
+# older docs said data/tjro_juris/.
+_JURIS_ITEM_PREFIX = "tjro-juris"
+_JURIS_ITEM_RE = re.compile(r"^tjro-juris-\d{4}$")
+_JURIS_LOCAL_GLOBS = (
+    "data/tjro_juris/*/tjro-juris-*.parquet",
+    "data/tjro-juris/*/tjro-juris-*.parquet",
+)
+
+# ── Source load tracking ───────────────────────────────────────────────────────
+
+SOURCE_NAMES = ("djen", "juris", "stj", "datajud")
+
+STATUS_LOADED_LOCAL = "loaded_local"
+STATUS_LOADED_REMOTE = "loaded_remote"
+STATUS_UNAVAILABLE = "unavailable"
+
+
+@dataclass
+class SourceLoad:
+    """How a reconciliation source was (or wasn't) loaded."""
+
+    name: str
+    status: str
+    detail: str = ""
+    rows: int = 0
+
+
+def _cache_dir() -> Path:
+    return Path(os.environ.get("RECONCILE_CACHE_DIR", "") or str(DATA_DIR / "reconcile-cache"))
+
+
+def _datajud_tribunais() -> tuple[str, ...]:
+    raw = os.environ.get("RECONCILE_DATAJUD_TRIBUNAIS", "")
+    tribs = tuple(t.strip().lower() for t in raw.split(",") if t.strip())
+    return tribs or _DEFAULT_DATAJUD_TRIBUNAIS
+
+
+def _expected_sources() -> tuple[str, ...]:
+    raw = os.environ.get("RECONCILE_EXPECTED_SOURCES", "")
+    names = tuple(s.strip().lower() for s in raw.split(",") if s.strip())
+    return names or SOURCE_NAMES
 
 
 # ── CNJ normalisation ──────────────────────────────────────────────────────────
@@ -67,13 +138,37 @@ def formatar_cnj(n: str) -> str:
 def _download(url: str, dest: Path, label: str) -> Path:
     print(f"Downloading {label} from {url}")
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(url, timeout=180) as resp:
-        dest.write_bytes(resp.read())
+    with httpx.Client(timeout=180, follow_redirects=True) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        dest.write_bytes(resp.content)
     print(f"  saved to {dest} ({dest.stat().st_size:,} bytes)")
     return dest
 
 
-def comunicacoes_parquet_urls(con: duckdb.DuckDBPyConnection) -> list[str]:
+def _fetch_cached(client: httpx.Client, url: str, dest: Path, label: str) -> Path:
+    """Download url to dest unless a previous run already cached it."""
+    if dest.exists() and dest.stat().st_size > 0:
+        print(f"  cached: {dest}")
+        return dest
+    print(f"Downloading {label} from {url}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    resp = client.get(url)
+    resp.raise_for_status()
+    dest.write_bytes(resp.content)
+    print(f"  saved to {dest} ({dest.stat().st_size:,} bytes)")
+    return dest
+
+
+def _ia_item_files(client: httpx.Client, item_id: str) -> list[str]:
+    """File names inside an IA item ([] when the item does not exist)."""
+    resp = client.get(f"{_IA_METADATA_BASE}/{item_id}")
+    resp.raise_for_status()
+    files = resp.json().get("files", [])
+    return [f["name"] for f in files if isinstance(f, dict) and "name" in f]
+
+
+def comunicacoes_parquet_urls(con: duckdb.DuckDBPyConnection) -> list[str] | None:
     """URLs of every consolidated comunicacoes.parquet, from the IA catalog.
 
     consolidate-parquet.yml uploads one comunicacoes.parquet per consolidated
@@ -82,6 +177,10 @@ def comunicacoes_parquet_urls(con: duckdb.DuckDBPyConnection) -> list[str]:
     update-catalog.yml. Querying it (instead of e.g. listing IA items
     directly) keeps this in sync with whatever has actually been consolidated
     without hand-enumerating dates.
+
+    Returns None when the catalog itself could not be read (source
+    *unavailable*), as opposed to [] (catalog readable, genuinely lists no
+    comunicacoes parquets).
     """
     try:
         rows = con.execute(
@@ -90,27 +189,150 @@ def comunicacoes_parquet_urls(con: duckdb.DuckDBPyConnection) -> list[str]:
         ).fetchall()
     except duckdb.Error as exc:
         print(f"  WARNING: could not read IA catalog manifest — {exc}", file=sys.stderr)
-        return []
+        return None
     return sorted(r[0] for r in rows)
 
 
-def ensure_stj_parquet() -> Path | None:
+def ensure_stj_parquet() -> tuple[Path | None, SourceLoad]:
     if _STJ_PARQUET.exists():
         print(f"Using local STJ parquet: {_STJ_PARQUET}")
-        return _STJ_PARQUET
+        return _STJ_PARQUET, SourceLoad("stj", STATUS_LOADED_LOCAL, str(_STJ_PARQUET))
     try:
-        return _download(_STJ_IA_URL, _STJ_PARQUET, "STJ parquet")
-    except OSError as exc:
+        path = _download(_STJ_IA_URL, _STJ_PARQUET, "STJ parquet")
+    except (httpx.HTTPError, OSError) as exc:
         print(f"  WARNING: could not download STJ parquet — {exc}", file=sys.stderr)
-        return None
+        return None, SourceLoad("stj", STATUS_UNAVAILABLE, f"IA download failed: {exc}")
+    return path, SourceLoad("stj", STATUS_LOADED_REMOTE, _STJ_IA_URL)
 
 
 def juris_parquet_files() -> list[Path]:
-    return sorted(ROOT.glob("data/tjro_juris/*/tjro-juris-*.parquet"))
+    files: set[Path] = set()
+    for pattern in _JURIS_LOCAL_GLOBS:
+        files.update(ROOT.glob(pattern))
+    return sorted(files)
+
+
+def _discover_juris_items(client: httpx.Client) -> list[str]:
+    """tjro-juris-{year} item identifiers that actually exist on IA."""
+    resp = client.get(
+        _IA_SEARCH_URL,
+        params={
+            "q": f"identifier:{_JURIS_ITEM_PREFIX}-*",
+            "fl[]": "identifier",
+            "rows": "500",
+            "output": "json",
+        },
+    )
+    resp.raise_for_status()
+    docs = resp.json().get("response", {}).get("docs", [])
+    return sorted(
+        d["identifier"]
+        for d in docs
+        if isinstance(d, dict) and _JURIS_ITEM_RE.match(d.get("identifier", ""))
+    )
+
+
+def fetch_juris_from_ia() -> tuple[list[Path], bool]:
+    """Download JURIS parquets from the tjro-juris-{year} IA items.
+
+    Prefers the consolidated tjro-juris-{year}.parquet when the item has one;
+    otherwise falls back to the monthly shards the sync uploads. Returns
+    (paths, needs_dedup) — monthly shards can overlap between crawls, so they
+    must be deduplicated by id_documento before aggregation.
+    """
+    cache = _cache_dir() / "juris"
+    paths: list[Path] = []
+    needs_dedup = False
+    with httpx.Client(timeout=180, follow_redirects=True) as client:
+        items = _discover_juris_items(client)
+        if not items:
+            print(f"  no {_JURIS_ITEM_PREFIX}-* items found on IA", file=sys.stderr)
+            return [], False
+        for item in items:
+            names = _ia_item_files(client, item)
+            consolidated = f"{item}.parquet"
+            if consolidated in names:
+                wanted = [consolidated]
+            else:
+                wanted = sorted(n for n in names if n.endswith(".parquet"))
+                if wanted:
+                    needs_dedup = True
+            if not wanted:
+                print(f"  IA item {item}: no parquet files", file=sys.stderr)
+            paths.extend(
+                _fetch_cached(
+                    client, f"{_IA_BASE}/{item}/{name}", cache / item / name, f"JURIS {item}/{name}"
+                )
+                for name in wanted
+            )
+    return paths, needs_dedup
+
+
+def ensure_juris_parquets() -> tuple[list[Path], bool, SourceLoad]:
+    """JURIS parquets: local files first, IA fallback otherwise.
+
+    Returns (paths, needs_dedup, load_status).
+    """
+    local = juris_parquet_files()
+    if local:
+        detail = f"{len(local)} local parquet file(s)"
+        return local, False, SourceLoad("juris", STATUS_LOADED_LOCAL, detail)
+    print(f"No local JURIS parquets — trying IA items {_JURIS_ITEM_PREFIX}-{{year}}")
+    try:
+        remote, needs_dedup = fetch_juris_from_ia()
+    except (httpx.HTTPError, OSError) as exc:
+        return [], False, SourceLoad("juris", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
+    if remote:
+        detail = f"{len(remote)} parquet file(s) from IA {_JURIS_ITEM_PREFIX}-* items"
+        return remote, needs_dedup, SourceLoad("juris", STATUS_LOADED_REMOTE, detail)
+    detail = f"no local parquets and no parquets in IA {_JURIS_ITEM_PREFIX}-* items"
+    return [], False, SourceLoad("juris", STATUS_UNAVAILABLE, detail)
 
 
 def datajud_parquet_files() -> list[Path]:
     return sorted(_DATAJUD_DIR.glob("datajud-capa-*.parquet"))
+
+
+def fetch_datajud_from_ia() -> list[Path]:
+    """Download DataJud capa parquets from the datajud-{tribunal} IA items."""
+    cache = _cache_dir() / "datajud"
+    paths: list[Path] = []
+    with httpx.Client(timeout=180, follow_redirects=True) as client:
+        for tribunal in _datajud_tribunais():
+            item = _datajud_item_id(tribunal)
+            filename = _datajud_capa_name(tribunal)
+            names = _ia_item_files(client, item)
+            if filename not in names:
+                print(f"  IA item {item}: no {filename} (item missing or empty)", file=sys.stderr)
+                continue
+            paths.append(
+                _fetch_cached(
+                    client,
+                    f"{_IA_BASE}/{item}/{filename}",
+                    cache / filename,
+                    f"DataJud {item}/{filename}",
+                )
+            )
+    return paths
+
+
+def ensure_datajud_parquets() -> tuple[list[Path], SourceLoad]:
+    """DataJud capa parquets: local files first, IA fallback otherwise."""
+    local = datajud_parquet_files()
+    if local:
+        detail = f"{len(local)} local parquet file(s)"
+        return local, SourceLoad("datajud", STATUS_LOADED_LOCAL, detail)
+    tribs = ", ".join(_datajud_item_id(t) for t in _datajud_tribunais())
+    print(f"No local DataJud capa parquets — trying IA item(s) {tribs}")
+    try:
+        remote = fetch_datajud_from_ia()
+    except (httpx.HTTPError, OSError) as exc:
+        return [], SourceLoad("datajud", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
+    if remote:
+        detail = f"{len(remote)} parquet file(s) from IA ({tribs})"
+        return remote, SourceLoad("datajud", STATUS_LOADED_REMOTE, detail)
+    detail = f"no local parquets and no capa parquet in IA item(s) {tribs}"
+    return [], SourceLoad("datajud", STATUS_UNAVAILABLE, detail)
 
 
 # ── IA upload ──────────────────────────────────────────────────────────────────
@@ -118,8 +340,6 @@ def datajud_parquet_files() -> list[Path]:
 
 def upload_to_ia(path: Path, remote_name: str) -> None:
     """PUT a file to the causaganha-dashboard IA item via httpx."""
-    import httpx
-
     ia_key = _ia_credentials()
     if not ia_key:
         print(f"  SKIP upload (no IA credentials): {remote_name}", file=sys.stderr)
@@ -141,8 +361,6 @@ def upload_to_ia(path: Path, remote_name: str) -> None:
 
 
 def _ia_credentials() -> str | None:
-    import os
-
     access = os.environ.get("IA_ACCESS_KEY", "")
     secret = os.environ.get("IA_SECRET_KEY", "")
     if access and secret:
@@ -372,19 +590,91 @@ ORDER BY nr_processo, data DESC NULLS LAST
 """
 
 
+# ── Source coverage report & validation ───────────────────────────────────────
+
+
+def validate_coverage(
+    sources: dict[str, SourceLoad],
+    expected: tuple[str, ...],
+) -> tuple[list[str], list[str]]:
+    """Distinguish "couldn't load the source" from "source genuinely empty".
+
+    Returns (errors, warnings):
+      - error   — an *expected* source ended with zero rows because it was
+                  never loaded (status=unavailable): the reconciliation ran
+                  blind on that source and the output silently degrades.
+      - warning — a source loaded fine but contributed zero rows (legitimate
+                  empty/zero-overlap), or a non-expected source unavailable.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    for name, load in sources.items():
+        if load.status == STATUS_UNAVAILABLE and load.rows == 0:
+            msg = f"source '{name}' has zero rows because it was NOT loaded — {load.detail}"
+            (errors if name in expected else warnings).append(msg)
+        elif load.rows == 0:
+            warnings.append(
+                f"source '{name}' loaded ({load.status}) but contributed zero processos"
+                f" — {load.detail}"
+            )
+    return errors, warnings
+
+
+def _emit_validation(errors: list[str], warnings: list[str]) -> None:
+    in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+    for msg in warnings:
+        prefix = "::warning title=reconcile source coverage::" if in_ci else "WARNING: "
+        print(f"{prefix}{msg}", file=sys.stderr)
+    for msg in errors:
+        prefix = "::error title=reconcile source coverage::" if in_ci else "ERROR: "
+        print(f"{prefix}{msg}", file=sys.stderr)
+
+
+def _print_report(report: dict[str, Any]) -> None:
+    print("\n── Source coverage ──────────────────────────────────────────")
+    for name, src in report["sources"].items():
+        print(f"  {name:<8} {src['rows']:>12,} processos  {src['status']:<14} {src['detail']}")
+    print("  Intersections (fontes → processos):")
+    for combo, n in sorted(report["combinations"].items()):
+        print(f"    {combo:<32} {n:>12,}")
+    print(f"  total={report['total']:,}  multi_fonte={report['multi_fonte']:,}")
+
+
+def _build_report(
+    sources: dict[str, SourceLoad],
+    combinations: dict[str, int],
+    total: int,
+    multi: int,
+) -> dict[str, Any]:
+    expected = _expected_sources()
+    errors, warnings = validate_coverage(sources, expected)
+    return {
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "total": total,
+        "multi_fonte": multi,
+        "sources": {
+            name: {"rows": load.rows, "status": load.status, "detail": load.detail}
+            for name, load in sources.items()
+        },
+        "combinations": combinations,
+        "validation": {
+            "expected_sources": list(expected),
+            "errors": errors,
+            "warnings": warnings,
+        },
+    }
+
+
 # ── Main pipeline ──────────────────────────────────────────────────────────────
 
 
-def reconcile(*, upload: bool = True) -> dict[str, Any]:
-    stj_path = ensure_stj_parquet()
-    juris_files = juris_parquet_files()
+def _register_djen(con: duckdb.DuckDBPyConnection) -> SourceLoad:
+    """Register the DJEN comunicacoes view.
 
-    con = duckdb.connect()
-    con.execute("INSTALL httpfs; LOAD httpfs;")
-
-    # Register DJEN comunicacoes view (union of every consolidated date, read
-    # straight off IA — there's no single local cache file for this, unlike
-    # STJ/JURIS, since it's one small parquet per consolidated date).
+    Union of every consolidated date, read straight off IA — there's no single
+    local cache file for this, unlike STJ/JURIS, since it's one small parquet
+    per consolidated date.
+    """
     comunicacoes_urls = comunicacoes_parquet_urls(con)
     if comunicacoes_urls:
         url_list = ", ".join(f"'{u}'" for u in comunicacoes_urls)
@@ -393,76 +683,96 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
             f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], "
             "union_by_name=true)"
         )
-    else:
-        print(
-            "WARNING: no comunicacoes.parquet in the IA catalog — DJEN contribution will be empty",
-            file=sys.stderr,
-        )
-        con.execute(
-            "CREATE VIEW comunicacoes AS "
-            "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
-            "NULL::VARCHAR AS tribunal WHERE FALSE"
-        )
+        detail = f"{len(comunicacoes_urls)} comunicacoes parquet(s) via IA catalog"
+        return SourceLoad("djen", STATUS_LOADED_REMOTE, detail)
 
-    # Register JURIS view (union of consolidated yearly parquets)
+    if comunicacoes_urls is None:
+        load = SourceLoad("djen", STATUS_UNAVAILABLE, "IA catalog manifest unreadable")
+    else:
+        load = SourceLoad(
+            "djen", STATUS_LOADED_REMOTE, "IA catalog readable but lists no comunicacoes parquets"
+        )
+    print(
+        "WARNING: no comunicacoes.parquet available — DJEN contribution will be empty",
+        file=sys.stderr,
+    )
+    con.execute(
+        "CREATE VIEW comunicacoes AS "
+        "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
+        "NULL::VARCHAR AS tribunal WHERE FALSE"
+    )
+    return load
+
+
+def _register_juris(con: duckdb.DuckDBPyConnection) -> SourceLoad:
+    """Register the JURIS view (yearly consolidated parquets, or IA fallback)."""
+    juris_files, needs_dedup, load = ensure_juris_parquets()
     if juris_files:
         juris_list = ", ".join(f"'{p}'" for p in juris_files)
         print(f"Registering JURIS view: {len(juris_files)} parquet file(s)")
-        con.execute(f"CREATE VIEW tjro_juris AS SELECT * FROM read_parquet([{juris_list}])")
-    else:
-        print(
-            "WARNING: no JURIS parquets found — JURIS contribution will be empty",
-            file=sys.stderr,
-        )
-        con.execute(
-            "CREATE VIEW tjro_juris AS "
-            "SELECT NULL::VARCHAR AS nr_processo, NULL::INTEGER AS id_documento, "
-            "NULL::VARCHAR AS tipo, NULL::DATE AS data_julgamento, "
-            "NULL::VARCHAR AS orgao, NULL::VARCHAR AS relator, "
-            "NULL::VARCHAR AS classe_judicial, NULL::VARCHAR AS url_portal, "
-            "NULL::VARCHAR AS texto_limpo "
-            "WHERE FALSE"
-        )
+        if needs_dedup:
+            # Monthly shards straight from IA may overlap between crawls —
+            # dedup by id_documento exactly like tjro_juris.dedup.consolidate_year.
+            con.execute(
+                "CREATE VIEW tjro_juris AS "
+                "SELECT * EXCLUDE (_rn) FROM ("
+                "  SELECT *, ROW_NUMBER() OVER ("
+                "    PARTITION BY id_documento ORDER BY extraido_em DESC NULLS LAST"
+                "  ) AS _rn "
+                f"  FROM read_parquet([{juris_list}], union_by_name=true) "
+                "  WHERE id_documento IS NOT NULL"
+                ") WHERE _rn = 1"
+            )
+        else:
+            con.execute(f"CREATE VIEW tjro_juris AS SELECT * FROM read_parquet([{juris_list}])")
+        return load
 
-    # Register STJ view
+    print(
+        "WARNING: no JURIS parquets found — JURIS contribution will be empty",
+        file=sys.stderr,
+    )
+    con.execute(
+        "CREATE VIEW tjro_juris AS "
+        "SELECT NULL::VARCHAR AS nr_processo, NULL::INTEGER AS id_documento, "
+        "NULL::VARCHAR AS tipo, NULL::DATE AS data_julgamento, "
+        "NULL::VARCHAR AS orgao, NULL::VARCHAR AS relator, "
+        "NULL::VARCHAR AS classe_judicial, NULL::VARCHAR AS url_portal, "
+        "NULL::VARCHAR AS texto_limpo "
+        "WHERE FALSE"
+    )
+    return load
+
+
+def _register_stj(con: duckdb.DuckDBPyConnection) -> SourceLoad:
+    stj_path, load = ensure_stj_parquet()
     if stj_path is not None:
         print(f"Registering STJ view: {stj_path}")
         con.execute(f"CREATE VIEW acordaos AS SELECT * FROM read_parquet('{stj_path}')")
-    else:
-        print("WARNING: STJ parquet unavailable — STJ contribution will be empty", file=sys.stderr)
-        con.execute(
-            "CREATE VIEW acordaos AS "
-            'SELECT NULL::VARCHAR AS "numeroProcesso", NULL::VARCHAR AS id, '
-            'NULL::VARCHAR AS "siglaClasse", NULL::VARCHAR AS "ministroRelator", '
-            'NULL::VARCHAR AS "tema", NULL::VARCHAR AS "teseJuridica", '
-            'NULL::VARCHAR AS "ementa", NULL::DATE AS "dataDecisao", '
-            'NULL::DATE AS "dataPublicacao" '
-            "WHERE FALSE"
-        )
+        return load
 
-    # Build aggregation CTEs
-    print("Building DJEN aggregation…")
-    con.execute(f"CREATE TEMP TABLE djen_agg AS {_DJEN_AGG_SQL}")
-    djen_count = con.execute("SELECT COUNT(*) FROM djen_agg").fetchone()[0]
-    print(f"  {djen_count:,} DJEN processes")
+    print("WARNING: STJ parquet unavailable — STJ contribution will be empty", file=sys.stderr)
+    con.execute(
+        "CREATE VIEW acordaos AS "
+        'SELECT NULL::VARCHAR AS "numeroProcesso", NULL::VARCHAR AS id, '
+        'NULL::VARCHAR AS "siglaClasse", NULL::VARCHAR AS "ministroRelator", '
+        'NULL::VARCHAR AS "tema", NULL::VARCHAR AS "teseJuridica", '
+        'NULL::VARCHAR AS "ementa", NULL::DATE AS "dataDecisao", '
+        'NULL::DATE AS "dataPublicacao" '
+        "WHERE FALSE"
+    )
+    return load
 
-    print("Building JURIS aggregation…")
-    con.execute(f"CREATE TEMP TABLE juris_agg AS {_JURIS_AGG_SQL}")
-    juris_count = con.execute("SELECT COUNT(*) FROM juris_agg").fetchone()[0]
-    print(f"  {juris_count:,} JURIS processes")
 
-    print("Building STJ aggregation…")
-    con.execute(f"CREATE TEMP TABLE stj_agg AS {_STJ_AGG_SQL}")
-    stj_count = con.execute("SELECT COUNT(*) FROM stj_agg").fetchone()[0]
-    print(f"  {stj_count:,} STJ processes (with valid CNJ number)")
+def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
+    """Register datajud_capa (local parquets, IA fallback, or empty).
 
-    # DataJud capa (optional enrichment) — join only when the parquet exists
-    # AND has the columns _DATAJUD_AGG_SQL needs; without it the datajud
-    # columns are NULL and tem_datajud is false. The empty fallback is
-    # derived from the producer's own pyarrow schema (datajud.archive.
-    # CAPA_SCHEMA) rather than hand-typed, so it can't drift from it — same
-    # pattern as scripts/render_queries.py's _synthetic_datajud_capa.
-    print("Building DataJud aggregation…")
+    Joins only when the parquet has the columns _DATAJUD_AGG_SQL needs;
+    without it the datajud columns are NULL and tem_datajud is false. The
+    empty fallback is derived from the producer's own pyarrow schema
+    (datajud.archive.CAPA_SCHEMA) rather than hand-typed, so it can't drift
+    from it — same pattern as scripts/render_queries.py's
+    _synthetic_datajud_capa.
+    """
     _datajud_required_cols = {
         "numero_processo",
         "classe_nome",
@@ -472,30 +782,69 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
         "data_ajuizamento",
         "ultima_atualizacao",
     }
-    datajud_files = datajud_parquet_files()
+    datajud_files, load = ensure_datajud_parquets()
     if datajud_files:
         datajud_list = ", ".join(f"'{p}'" for p in datajud_files)
         print(f"  Registering DataJud capa view: {len(datajud_files)} parquet file(s)")
         con.execute(f"CREATE VIEW datajud_capa AS SELECT * FROM read_parquet([{datajud_list}])")
         datajud_cols = {row[0] for row in con.execute("DESCRIBE datajud_capa").fetchall()}
-        if not _datajud_required_cols <= datajud_cols:
-            missing = sorted(_datajud_required_cols - datajud_cols)
-            print(
-                f"  SKIP: datajud-capa-*.parquet missing column(s) {missing} — "
-                "DataJud enrichment will be empty (incompatible/partial parquet?)",
-                file=sys.stderr,
-            )
-            con.execute("DROP VIEW datajud_capa")
-            con.register("datajud_capa", _DATAJUD_CAPA_SCHEMA.empty_table())
-    else:
+        if _datajud_required_cols <= datajud_cols:
+            return load
+        missing = sorted(_datajud_required_cols - datajud_cols)
         print(
-            "  SKIP: no datajud-capa-*.parquet found — DataJud enrichment will be empty",
+            f"  SKIP: datajud-capa-*.parquet missing column(s) {missing} — "
+            "DataJud enrichment will be empty (incompatible/partial parquet?)",
             file=sys.stderr,
         )
+        con.execute("DROP VIEW datajud_capa")
         con.register("datajud_capa", _DATAJUD_CAPA_SCHEMA.empty_table())
+        return SourceLoad(
+            "datajud", STATUS_UNAVAILABLE, f"parquet(s) missing required column(s) {missing}"
+        )
+
+    print(
+        "  SKIP: no datajud-capa-*.parquet found — DataJud enrichment will be empty",
+        file=sys.stderr,
+    )
+    con.register("datajud_capa", _DATAJUD_CAPA_SCHEMA.empty_table())
+    return load
+
+
+def reconcile(*, upload: bool = True) -> dict[str, Any]:
+    con = duckdb.connect()
+    try:
+        con.execute("INSTALL httpfs; LOAD httpfs;")
+    except duckdb.Error as exc:
+        print(
+            f"  WARNING: could not load DuckDB httpfs — remote parquet reads may fail: {exc}",
+            file=sys.stderr,
+        )
+
+    djen_load = _register_djen(con)
+    juris_load = _register_juris(con)
+    stj_load = _register_stj(con)
+
+    # Build aggregation CTEs
+    print("Building DJEN aggregation…")
+    con.execute(f"CREATE TEMP TABLE djen_agg AS {_DJEN_AGG_SQL}")
+    djen_load.rows = con.execute("SELECT COUNT(*) FROM djen_agg").fetchone()[0]
+    print(f"  {djen_load.rows:,} DJEN processes")
+
+    print("Building JURIS aggregation…")
+    con.execute(f"CREATE TEMP TABLE juris_agg AS {_JURIS_AGG_SQL}")
+    juris_load.rows = con.execute("SELECT COUNT(*) FROM juris_agg").fetchone()[0]
+    print(f"  {juris_load.rows:,} JURIS processes")
+
+    print("Building STJ aggregation…")
+    con.execute(f"CREATE TEMP TABLE stj_agg AS {_STJ_AGG_SQL}")
+    stj_load.rows = con.execute("SELECT COUNT(*) FROM stj_agg").fetchone()[0]
+    print(f"  {stj_load.rows:,} STJ processes (with valid CNJ number)")
+
+    print("Building DataJud aggregation…")
+    datajud_load = _register_datajud(con)
     con.execute(f"CREATE TEMP TABLE datajud_agg AS {_DATAJUD_AGG_SQL}")
-    datajud_count = con.execute("SELECT COUNT(*) FROM datajud_agg").fetchone()[0]
-    print(f"  {datajud_count:,} DataJud processes")
+    datajud_load.rows = con.execute("SELECT COUNT(*) FROM datajud_agg").fetchone()[0]
+    print(f"  {datajud_load.rows:,} DataJud processes")
 
     # Full outer join → processos_unificados
     print("Running full outer join…")
@@ -505,6 +854,14 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
         0
     ]
     print(f"  {total:,} unified processes ({multi:,} present in 2+ sources)")
+
+    # Intersection matrix: how many processos carry each fontes combination
+    combinations = dict(
+        con.execute(
+            "SELECT array_to_string(fontes, '+') AS combo, COUNT(*) "
+            "FROM processos_unificados GROUP BY combo ORDER BY combo"
+        ).fetchall()
+    )
 
     # Write processos_unificados.parquet
     DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -525,22 +882,34 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
     ).fetchone()[0]
     print(f"  {doc_count:,} document rows")
 
+    # Source coverage report — printed, and persisted next to the output
+    sources = {s.name: s for s in (djen_load, juris_load, stj_load, datajud_load)}
+    report = _build_report(sources, combinations, total, multi)
+    report_path = _PARQUET_UNIFICADOS.parent / _REPORT_NAME
+    report_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote coverage report: {report_path}")
+    _print_report(report)
+    _emit_validation(report["validation"]["errors"], report["validation"]["warnings"])
+
     if upload:
         upload_to_ia(_PARQUET_UNIFICADOS, "processos_unificados.parquet")
         if _PARQUET_DOCUMENTOS.exists():
             upload_to_ia(_PARQUET_DOCUMENTOS, "processo_documentos.parquet")
 
     return {
-        "djen": djen_count,
-        "juris": juris_count,
-        "stj": stj_count,
-        "datajud": datajud_count,
+        "djen": djen_load.rows,
+        "juris": juris_load.rows,
+        "stj": stj_load.rows,
+        "datajud": datajud_load.rows,
         "total": total,
         "multi_fonte": multi,
+        "report": report,
     }
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
     import argparse
 
     parser = argparse.ArgumentParser(description="Reconcile DJEN x JURIS x STJ processos")
@@ -549,9 +918,31 @@ if __name__ == "__main__":
         action="store_true",
         help="Skip uploading to Internet Archive",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--no-strict",
+        action="store_true",
+        help="Do not exit non-zero when an expected source is unavailable "
+        "(same as RECONCILE_STRICT=0)",
+    )
+    args = parser.parse_args(argv)
 
-    stats = reconcile(upload=not args.no_upload)  # type: ignore[call-arg]
+    stats = reconcile(upload=not args.no_upload)
     total = stats["total"]
     multi = stats["multi_fonte"]
     print(f"\nDone. {total:,} processos_unificados ({multi:,} multi-fonte).")
+
+    errors = stats["report"]["validation"]["errors"]
+    strict_env = os.environ.get("RECONCILE_STRICT", "1").strip().lower()
+    strict = not args.no_strict and strict_env not in {"0", "false", "no"}
+    if errors and strict:
+        print(
+            f"FATAL: {len(errors)} expected source(s) not loaded — failing "
+            "(use --no-strict or RECONCILE_STRICT=0 to downgrade).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -100,6 +100,16 @@ class SourceLoad:
     rows: int = 0
 
 
+class SourceDataError(Exception):
+    """A source's parquet file(s) could not be read (corrupt/invalid/truncated).
+
+    Distinct from httpx/OSError (transport failures) and duckdb.Error (raised
+    directly by SQL execution) — this is raised by our own validation step so
+    callers can catch exactly "the bytes we have are not usable parquet"
+    without swallowing unrelated programming errors.
+    """
+
+
 def _cache_dir() -> Path:
     return Path(os.environ.get("RECONCILE_CACHE_DIR", "") or str(DATA_DIR / "reconcile-cache"))
 
@@ -135,28 +145,82 @@ def formatar_cnj(n: str) -> str:
 # ── Data acquisition ───────────────────────────────────────────────────────────
 
 
-def _download(url: str, dest: Path, label: str) -> Path:
+def _is_valid_parquet(path: Path) -> bool:
+    """Cheap structural check: can DuckDB even open this as parquet?
+
+    Does not guarantee the *content* is semantically correct (e.g. expected
+    columns) — callers that care about that still validate downstream. This
+    only catches "not parquet at all" / truncated-file corruption.
+    """
+    con = duckdb.connect()
+    try:
+        con.execute(f"SELECT 1 FROM read_parquet('{path}') LIMIT 0")
+    except duckdb.Error:
+        return False
+    else:
+        return True
+    finally:
+        con.close()
+
+
+def _quarantine(path: Path) -> None:
+    """Remove an invalid *cached* file so future runs re-fetch instead of reusing it.
+
+    Only ever called on files under our own cache directory — never on a
+    local parquet the operator placed there themselves (see
+    ensure_juris_parquets / ensure_datajud_parquets / ensure_stj_parquet,
+    which never route operator-provided local files through this).
+    """
+    try:
+        path.unlink(missing_ok=True)
+        print(f"  quarantined invalid cache file: {path}", file=sys.stderr)
+    except OSError as exc:
+        print(f"  WARNING: could not remove invalid cache file {path} — {exc}", file=sys.stderr)
+
+
+def _atomic_download(client: httpx.Client, url: str, dest: Path, label: str) -> None:
+    """Download url to dest atomically: write to dest.part, then rename in place.
+
+    A crash or truncated transfer never leaves a partial/corrupt file at
+    `dest` itself — only a stray `.part` file, which is never treated as a
+    cache hit (see _fetch_cached). Raises SourceDataError if the completed
+    download is not readable as parquet.
+    """
     print(f"Downloading {label} from {url}")
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with httpx.Client(timeout=180, follow_redirects=True) as client:
-        resp = client.get(url)
-        resp.raise_for_status()
-        dest.write_bytes(resp.content)
+    tmp = dest.with_name(dest.name + ".part")
+    resp = client.get(url)
+    resp.raise_for_status()
+    tmp.write_bytes(resp.content)
+    if not _is_valid_parquet(tmp):
+        tmp.unlink(missing_ok=True)
+        msg = f"downloaded file from {url} is not valid parquet"
+        raise SourceDataError(msg)
+    tmp.replace(dest)
     print(f"  saved to {dest} ({dest.stat().st_size:,} bytes)")
+
+
+def _download(url: str, dest: Path, label: str) -> Path:
+    with httpx.Client(timeout=180, follow_redirects=True) as client:
+        _atomic_download(client, url, dest, label)
     return dest
 
 
 def _fetch_cached(client: httpx.Client, url: str, dest: Path, label: str) -> Path:
-    """Download url to dest unless a previous run already cached it."""
+    """Download url to dest unless a previous run already cached a valid copy.
+
+    A cached file that fails validation (corrupt / truncated by an
+    interrupted earlier run) is quarantined and re-fetched immediately —
+    it is never silently treated as good just because it exists and is
+    non-empty.
+    """
     if dest.exists() and dest.stat().st_size > 0:
-        print(f"  cached: {dest}")
-        return dest
-    print(f"Downloading {label} from {url}")
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    resp = client.get(url)
-    resp.raise_for_status()
-    dest.write_bytes(resp.content)
-    print(f"  saved to {dest} ({dest.stat().st_size:,} bytes)")
+        if _is_valid_parquet(dest):
+            print(f"  cached: {dest}")
+            return dest
+        print(f"  cached file failed validation, re-fetching: {dest}", file=sys.stderr)
+        _quarantine(dest)
+    _atomic_download(client, url, dest, label)
     return dest
 
 
@@ -199,7 +263,7 @@ def ensure_stj_parquet() -> tuple[Path | None, SourceLoad]:
         return _STJ_PARQUET, SourceLoad("stj", STATUS_LOADED_LOCAL, str(_STJ_PARQUET))
     try:
         path = _download(_STJ_IA_URL, _STJ_PARQUET, "STJ parquet")
-    except (httpx.HTTPError, OSError) as exc:
+    except (httpx.HTTPError, OSError, SourceDataError) as exc:
         print(f"  WARNING: could not download STJ parquet — {exc}", file=sys.stderr)
         return None, SourceLoad("stj", STATUS_UNAVAILABLE, f"IA download failed: {exc}")
     return path, SourceLoad("stj", STATUS_LOADED_REMOTE, _STJ_IA_URL)
@@ -280,7 +344,7 @@ def ensure_juris_parquets() -> tuple[list[Path], bool, SourceLoad]:
     print(f"No local JURIS parquets — trying IA items {_JURIS_ITEM_PREFIX}-{{year}}")
     try:
         remote, needs_dedup = fetch_juris_from_ia()
-    except (httpx.HTTPError, OSError) as exc:
+    except (httpx.HTTPError, OSError, SourceDataError) as exc:
         return [], False, SourceLoad("juris", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
     if remote:
         detail = f"{len(remote)} parquet file(s) from IA {_JURIS_ITEM_PREFIX}-* items"
@@ -326,7 +390,7 @@ def ensure_datajud_parquets() -> tuple[list[Path], SourceLoad]:
     print(f"No local DataJud capa parquets — trying IA item(s) {tribs}")
     try:
         remote = fetch_datajud_from_ia()
-    except (httpx.HTTPError, OSError) as exc:
+    except (httpx.HTTPError, OSError, SourceDataError) as exc:
         return [], SourceLoad("datajud", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
     if remote:
         detail = f"{len(remote)} parquet file(s) from IA ({tribs})"
@@ -668,21 +732,81 @@ def _build_report(
 # ── Main pipeline ──────────────────────────────────────────────────────────────
 
 
+def _empty_comunicacoes_view(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute("DROP VIEW IF EXISTS comunicacoes")
+    con.execute(
+        "CREATE VIEW comunicacoes AS "
+        "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
+        "NULL::VARCHAR AS tribunal WHERE FALSE"
+    )
+
+
+def _empty_juris_view(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute("DROP VIEW IF EXISTS tjro_juris")
+    con.execute(
+        "CREATE VIEW tjro_juris AS "
+        "SELECT NULL::VARCHAR AS nr_processo, NULL::INTEGER AS id_documento, "
+        "NULL::VARCHAR AS tipo, NULL::DATE AS data_julgamento, "
+        "NULL::VARCHAR AS orgao, NULL::VARCHAR AS relator, "
+        "NULL::VARCHAR AS classe_judicial, NULL::VARCHAR AS url_portal, "
+        "NULL::VARCHAR AS texto_limpo "
+        "WHERE FALSE"
+    )
+
+
+def _empty_acordaos_view(con: duckdb.DuckDBPyConnection) -> None:
+    con.execute("DROP VIEW IF EXISTS acordaos")
+    con.execute(
+        "CREATE VIEW acordaos AS "
+        'SELECT NULL::VARCHAR AS "numeroProcesso", NULL::VARCHAR AS id, '
+        'NULL::VARCHAR AS "siglaClasse", NULL::VARCHAR AS "ministroRelator", '
+        'NULL::VARCHAR AS "tema", NULL::VARCHAR AS "teseJuridica", '
+        'NULL::VARCHAR AS "ementa", NULL::DATE AS "dataDecisao", '
+        'NULL::DATE AS "dataPublicacao" '
+        "WHERE FALSE"
+    )
+
+
+def _quarantine_if_cached(files: list[Path], load: SourceLoad) -> None:
+    """Quarantine *files* only when they came from our own IA-fetch cache.
+
+    Never touches a local parquet the operator placed there themselves
+    (status loaded_local) — only STATUS_LOADED_REMOTE means these paths are
+    under _cache_dir(), populated by _fetch_cached/_download.
+    """
+    if load.status != STATUS_LOADED_REMOTE:
+        return
+    for path in files:
+        _quarantine(path)
+
+
 def _register_djen(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     """Register the DJEN comunicacoes view.
 
     Union of every consolidated date, read straight off IA — there's no single
     local cache file for this, unlike STJ/JURIS, since it's one small parquet
-    per consolidated date.
+    per consolidated date. A read failure here (e.g. one corrupt date among
+    many) makes the WHOLE DJEN source unavailable for this run rather than
+    crashing the reconciliation — the other sources still contribute.
     """
     comunicacoes_urls = comunicacoes_parquet_urls(con)
     if comunicacoes_urls:
         url_list = ", ".join(f"'{u}'" for u in comunicacoes_urls)
         print(f"Registering DJEN comunicacoes view: {len(comunicacoes_urls)} parquet file(s)")
-        con.execute(
-            f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], "
-            "union_by_name=true)"
-        )
+        try:
+            con.execute(
+                f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], "
+                "union_by_name=true)"
+            )
+            con.execute("SELECT COUNT(*) FROM comunicacoes")  # force read now, not mid-aggregation
+        except duckdb.Error as exc:
+            print(f"  WARNING: DJEN parquet(s) unreadable — {exc}", file=sys.stderr)
+            _empty_comunicacoes_view(con)
+            detail = (
+                f"parquet read failed for {len(comunicacoes_urls)} comunicacoes file(s) via IA "
+                f"catalog: {type(exc).__name__}: {exc}"
+            )
+            return SourceLoad("djen", STATUS_UNAVAILABLE, detail)
         detail = f"{len(comunicacoes_urls)} comunicacoes parquet(s) via IA catalog"
         return SourceLoad("djen", STATUS_LOADED_REMOTE, detail)
 
@@ -696,70 +820,83 @@ def _register_djen(con: duckdb.DuckDBPyConnection) -> SourceLoad:
         "WARNING: no comunicacoes.parquet available — DJEN contribution will be empty",
         file=sys.stderr,
     )
-    con.execute(
-        "CREATE VIEW comunicacoes AS "
-        "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
-        "NULL::VARCHAR AS tribunal WHERE FALSE"
-    )
+    _empty_comunicacoes_view(con)
     return load
 
 
 def _register_juris(con: duckdb.DuckDBPyConnection) -> SourceLoad:
-    """Register the JURIS view (yearly consolidated parquets, or IA fallback)."""
+    """Register the JURIS view (yearly consolidated parquets, or IA fallback).
+
+    A read failure (corrupt/invalid parquet) makes JURIS unavailable for this
+    run — the typed-empty fallback view is (re)created so the rest of the
+    pipeline (aggregation, join) proceeds unaffected, and IA-cached files
+    implicated in the failure are quarantined so the NEXT run re-fetches
+    instead of hitting the same wall forever.
+    """
     juris_files, needs_dedup, load = ensure_juris_parquets()
     if juris_files:
         juris_list = ", ".join(f"'{p}'" for p in juris_files)
         print(f"Registering JURIS view: {len(juris_files)} parquet file(s)")
-        if needs_dedup:
-            # Monthly shards straight from IA may overlap between crawls —
-            # dedup by id_documento exactly like tjro_juris.dedup.consolidate_year.
-            con.execute(
-                "CREATE VIEW tjro_juris AS "
-                "SELECT * EXCLUDE (_rn) FROM ("
-                "  SELECT *, ROW_NUMBER() OVER ("
-                "    PARTITION BY id_documento ORDER BY extraido_em DESC NULLS LAST"
-                "  ) AS _rn "
-                f"  FROM read_parquet([{juris_list}], union_by_name=true) "
-                "  WHERE id_documento IS NOT NULL"
-                ") WHERE _rn = 1"
-            )
-        else:
-            con.execute(f"CREATE VIEW tjro_juris AS SELECT * FROM read_parquet([{juris_list}])")
+        try:
+            if needs_dedup:
+                # Monthly shards straight from IA may overlap between crawls —
+                # dedup by id_documento exactly like
+                # tjro_juris.dedup.consolidate_year. Rows with a null
+                # id_documento (extraction bug) are excluded rather than
+                # collapsed together under a shared null key.
+                con.execute(
+                    "CREATE VIEW tjro_juris AS "
+                    "SELECT * EXCLUDE (_rn) FROM ("
+                    "  SELECT *, ROW_NUMBER() OVER ("
+                    "    PARTITION BY id_documento ORDER BY extraido_em DESC NULLS LAST"
+                    "  ) AS _rn "
+                    f"  FROM read_parquet([{juris_list}], union_by_name=true) "
+                    "  WHERE id_documento IS NOT NULL"
+                    ") WHERE _rn = 1"
+                )
+            else:
+                con.execute(f"CREATE VIEW tjro_juris AS SELECT * FROM read_parquet([{juris_list}])")
+            con.execute("SELECT COUNT(*) FROM tjro_juris")  # force read now, not mid-aggregation
+        except duckdb.Error as exc:
+            print(f"  WARNING: JURIS parquet(s) unreadable — {exc}", file=sys.stderr)
+            _quarantine_if_cached(juris_files, load)
+            _empty_juris_view(con)
+            files_desc = ", ".join(str(p) for p in juris_files)
+            detail = f"parquet read failed for [{files_desc}]: {type(exc).__name__}: {exc}"
+            return SourceLoad("juris", STATUS_UNAVAILABLE, detail)
         return load
 
     print(
         "WARNING: no JURIS parquets found — JURIS contribution will be empty",
         file=sys.stderr,
     )
-    con.execute(
-        "CREATE VIEW tjro_juris AS "
-        "SELECT NULL::VARCHAR AS nr_processo, NULL::INTEGER AS id_documento, "
-        "NULL::VARCHAR AS tipo, NULL::DATE AS data_julgamento, "
-        "NULL::VARCHAR AS orgao, NULL::VARCHAR AS relator, "
-        "NULL::VARCHAR AS classe_judicial, NULL::VARCHAR AS url_portal, "
-        "NULL::VARCHAR AS texto_limpo "
-        "WHERE FALSE"
-    )
+    _empty_juris_view(con)
     return load
 
 
 def _register_stj(con: duckdb.DuckDBPyConnection) -> SourceLoad:
+    """Register the STJ acordaos view (local file or IA fallback).
+
+    A read failure makes STJ unavailable for this run instead of crashing
+    the reconciliation; an IA-cached file implicated in the failure is
+    quarantined so the next run re-fetches.
+    """
     stj_path, load = ensure_stj_parquet()
     if stj_path is not None:
         print(f"Registering STJ view: {stj_path}")
-        con.execute(f"CREATE VIEW acordaos AS SELECT * FROM read_parquet('{stj_path}')")
+        try:
+            con.execute(f"CREATE VIEW acordaos AS SELECT * FROM read_parquet('{stj_path}')")
+            con.execute("SELECT COUNT(*) FROM acordaos")  # force read now, not mid-aggregation
+        except duckdb.Error as exc:
+            print(f"  WARNING: STJ parquet unreadable ({stj_path}) — {exc}", file=sys.stderr)
+            _quarantine_if_cached([stj_path], load)
+            _empty_acordaos_view(con)
+            detail = f"parquet read failed for {stj_path}: {type(exc).__name__}: {exc}"
+            return SourceLoad("stj", STATUS_UNAVAILABLE, detail)
         return load
 
     print("WARNING: STJ parquet unavailable — STJ contribution will be empty", file=sys.stderr)
-    con.execute(
-        "CREATE VIEW acordaos AS "
-        'SELECT NULL::VARCHAR AS "numeroProcesso", NULL::VARCHAR AS id, '
-        'NULL::VARCHAR AS "siglaClasse", NULL::VARCHAR AS "ministroRelator", '
-        'NULL::VARCHAR AS "tema", NULL::VARCHAR AS "teseJuridica", '
-        'NULL::VARCHAR AS "ementa", NULL::DATE AS "dataDecisao", '
-        'NULL::DATE AS "dataPublicacao" '
-        "WHERE FALSE"
-    )
+    _empty_acordaos_view(con)
     return load
 
 
@@ -771,7 +908,9 @@ def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     empty fallback is derived from the producer's own pyarrow schema
     (datajud.archive.CAPA_SCHEMA) rather than hand-typed, so it can't drift
     from it — same pattern as scripts/render_queries.py's
-    _synthetic_datajud_capa.
+    _synthetic_datajud_capa. A read failure (corrupt/invalid parquet) makes
+    DataJud unavailable for this run rather than crashing the reconciliation;
+    an IA-cached file implicated in the failure is quarantined.
     """
     _datajud_required_cols = {
         "numero_processo",
@@ -786,8 +925,17 @@ def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     if datajud_files:
         datajud_list = ", ".join(f"'{p}'" for p in datajud_files)
         print(f"  Registering DataJud capa view: {len(datajud_files)} parquet file(s)")
-        con.execute(f"CREATE VIEW datajud_capa AS SELECT * FROM read_parquet([{datajud_list}])")
-        datajud_cols = {row[0] for row in con.execute("DESCRIBE datajud_capa").fetchall()}
+        try:
+            con.execute(f"CREATE VIEW datajud_capa AS SELECT * FROM read_parquet([{datajud_list}])")
+            datajud_cols = {row[0] for row in con.execute("DESCRIBE datajud_capa").fetchall()}
+        except duckdb.Error as exc:
+            print(f"  WARNING: DataJud parquet(s) unreadable — {exc}", file=sys.stderr)
+            con.execute("DROP VIEW IF EXISTS datajud_capa")
+            _quarantine_if_cached(datajud_files, load)
+            con.register("datajud_capa", _DATAJUD_CAPA_SCHEMA.empty_table())
+            files_desc = ", ".join(str(p) for p in datajud_files)
+            detail = f"parquet read failed for [{files_desc}]: {type(exc).__name__}: {exc}"
+            return SourceLoad("datajud", STATUS_UNAVAILABLE, detail)
         if _datajud_required_cols <= datajud_cols:
             return load
         missing = sorted(_datajud_required_cols - datajud_cols)

--- a/tests/test_reconcile_processos.py
+++ b/tests/test_reconcile_processos.py
@@ -316,6 +316,137 @@ class TestUnavailableSources:
         assert any("'datajud'" in w for w in report["validation"]["warnings"])
 
 
+class TestCorruptedParquetHandling:
+    """duckdb.Error / SourceDataError boundaries: bad bytes must not crash the
+    whole reconciliation, must not poison the cache, and must not affect
+    unrelated sources or unrelated processos.
+    """
+
+    def test_corrupted_remote_fallback_makes_source_unavailable_report_written(
+        self, isolated_dirs: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        comunicacoes = _comunicacoes_parquet(fixtures / "comunicacoes.parquet")
+        catalog = _catalog_parquet(fixtures / "catalog.parquet", [comunicacoes])
+        monkeypatch.setattr(rp, "_IA_CATALOG_MANIFEST_URL", str(catalog))
+
+        with respx.mock() as router:
+            router.get(rp._STJ_IA_URL).respond(200, content=b"not a parquet file at all")
+            _mock_juris_remote(router, fixtures)
+            _mock_datajud_remote(router, fixtures)
+            stats = rp.reconcile(upload=False)  # must not raise, must still write a report
+
+        assert stats["stj"] == 0
+        report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
+        assert report["sources"]["stj"]["status"] == rp.STATUS_UNAVAILABLE
+        assert "not valid parquet" in report["sources"]["stj"]["detail"]
+        # other sources are unaffected by STJ's corruption
+        assert report["sources"]["djen"]["status"] == rp.STATUS_LOADED_REMOTE
+        assert report["sources"]["juris"]["status"] == rp.STATUS_LOADED_REMOTE
+        assert report["sources"]["datajud"]["status"] == rp.STATUS_LOADED_REMOTE
+        # the corrupt download must never be promoted to the final cache path
+        assert not rp._STJ_PARQUET.exists()
+
+    def test_already_corrupted_cache_file_is_not_treated_as_valid(
+        self, isolated_dirs: Path
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        cache_path = tmp_path / "cache" / "datajud" / rp._datajud_capa_name("tjro")
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"garbage left over from a crashed earlier run")
+
+        with respx.mock() as router:
+            _mock_datajud_remote(router, fixtures)
+            download_route = router.routes[-1]
+            paths = rp.fetch_datajud_from_ia()
+
+        # the invalid cache file was rejected and re-fetched, not reused
+        assert download_route.call_count == 1
+        assert rp._is_valid_parquet(paths[0])
+
+    def test_null_id_documento_discarded_without_merging_distinct_processos(
+        self, isolated_dirs: Path
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        shard = _juris_parquet(
+            fixtures / "2024-01-ACORDAO.parquet",
+            f"(NULL, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+            " '2024-01-15', 'texto null-1', 'https://juris/null1', '2024-01-31T00:00:00'),"
+            f"(1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+            " '2024-01-15', 'texto um', 'https://juris/1', '2024-01-31T00:00:00'),"
+            f"(NULL, '{CNJ_DJEN_DJ}', 'SENTENÇA', 'Apelação', '1a Vara', 'Juiz B', 'PJE',"
+            " '2024-02-10', 'texto null-2', 'https://juris/null2', '2024-02-28T00:00:00')",
+        )
+        with respx.mock() as router:
+            router.get(host="archive.org", path="/advancedsearch.php").respond(
+                200, json={"response": {"docs": [{"identifier": "tjro-juris-2024"}]}}
+            )
+            router.get(host="archive.org", path="/metadata/tjro-juris-2024").respond(
+                200, json={"files": [{"name": "2024-01-ACORDAO.parquet"}]}
+            )
+            router.get(
+                host="archive.org", path="/download/tjro-juris-2024/2024-01-ACORDAO.parquet"
+            ).respond(200, content=shard.read_bytes())
+
+            con = duckdb.connect()
+            try:
+                load = rp._register_juris(con)
+                rows = con.execute(
+                    "SELECT nr_processo, id_documento FROM tjro_juris ORDER BY nr_processo"
+                ).fetchall()
+            finally:
+                con.close()
+
+        assert load.status == rp.STATUS_LOADED_REMOTE
+        # Both null-id_documento rows are discarded outright — in particular the
+        # one for CNJ_DJEN_DJ must NOT survive by merging under a shared NULL
+        # key with CNJ_ALL's null row.
+        assert rows == [(CNJ_ALL, 1)]
+
+    def test_one_invalid_source_does_not_block_other_valid_sources(
+        self, isolated_dirs: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        comunicacoes = _comunicacoes_parquet(fixtures / "comunicacoes.parquet")
+        catalog = _catalog_parquet(fixtures / "catalog.parquet", [comunicacoes])
+        monkeypatch.setattr(rp, "_IA_CATALOG_MANIFEST_URL", str(catalog))
+
+        with respx.mock() as router:
+            _mock_stj_remote(router, fixtures)
+            _mock_datajud_remote(router, fixtures)
+            # JURIS's only shard is corrupted — the source becomes unavailable,
+            # but DJEN/STJ/DataJud must still load and contribute normally.
+            router.get(host="archive.org", path="/advancedsearch.php").respond(
+                200, json={"response": {"docs": [{"identifier": "tjro-juris-2024"}]}}
+            )
+            router.get(host="archive.org", path="/metadata/tjro-juris-2024").respond(
+                200, json={"files": [{"name": "2024-01-ACORDAO.parquet"}]}
+            )
+            router.get(
+                host="archive.org", path="/download/tjro-juris-2024/2024-01-ACORDAO.parquet"
+            ).respond(200, content=b"definitely not parquet")
+
+            stats = rp.reconcile(upload=False)  # must not raise
+
+        assert stats["juris"] == 0
+        assert stats["djen"] == 2
+        assert stats["stj"] == 1
+        assert stats["datajud"] == 2
+        report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
+        assert report["sources"]["juris"]["status"] == rp.STATUS_UNAVAILABLE
+        assert report["sources"]["djen"]["status"] == rp.STATUS_LOADED_REMOTE
+        assert report["sources"]["stj"]["status"] == rp.STATUS_LOADED_REMOTE
+        assert report["sources"]["datajud"]["status"] == rp.STATUS_LOADED_REMOTE
+
+
 class TestValidateCoverage:
     def test_zero_plus_unavailable_expected_is_error(self) -> None:
         sources = {"juris": rp.SourceLoad("juris", rp.STATUS_UNAVAILABLE, "no IA items", rows=0)}

--- a/tests/test_reconcile_processos.py
+++ b/tests/test_reconcile_processos.py
@@ -1,0 +1,342 @@
+"""Tests for scripts/reconcile_processos.py — IA fallback + source coverage.
+
+The full-reconcile tests run with NO local source parquets: JURIS and DataJud
+are served exclusively through the Internet Archive fallback (respx-mocked
+httpx), the DJEN catalog manifest is a local parquet whose ia_url entries
+point at local fixture parquets, and STJ is fetched via its (mocked) IA URL.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import duckdb
+import pytest
+import respx
+
+from datajud.archive import write_capa_parquet
+from scripts import reconcile_processos as rp
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Two valid 20-digit CNJs. CNJ_ALL appears in every source; CNJ_DJEN_DJ only
+# in DJEN + DataJud.
+CNJ_ALL = "00000010220248220001"
+CNJ_DJEN_DJ = "00000020320248220002"
+
+
+def _copy_sql_to_parquet(path: Path, sql: str) -> Path:
+    con = duckdb.connect()
+    try:
+        con.execute(f"COPY ({sql}) TO '{path}' (FORMAT PARQUET)")
+    finally:
+        con.close()
+    return path
+
+
+def _comunicacoes_parquet(path: Path) -> Path:
+    return _copy_sql_to_parquet(
+        path,
+        f"""
+        SELECT * FROM (VALUES
+            ('0000001-02.2024.8.22.0001', DATE '2024-03-01', 'TJRO'),
+            ('{CNJ_ALL}',                 DATE '2024-03-05', 'TJRO'),
+            ('{CNJ_DJEN_DJ}',             DATE '2024-04-01', 'TJRO')
+        ) AS t(numero_processo, data_disponibilizacao, tribunal)
+        """,
+    )
+
+
+def _catalog_parquet(path: Path, comunicacoes_paths: list[Path]) -> Path:
+    """A causaganha-catalog manifest whose ia_url entries are local paths."""
+    if comunicacoes_paths:
+        values = ", ".join(f"('{p}', 'comunicacoes')" for p in comunicacoes_paths)
+    else:
+        values = "('unused', 'other_table')"
+    return _copy_sql_to_parquet(path, f"SELECT * FROM (VALUES {values}) AS t(ia_url, table_name)")
+
+
+def _juris_parquet(path: Path, rows: str) -> Path:
+    return _copy_sql_to_parquet(
+        path,
+        f"""
+        SELECT * FROM (VALUES {rows})
+        AS t(id_documento, nr_processo, tipo, classe_judicial, orgao, relator,
+             sistema_origem, data_julgamento, texto_limpo, url_portal, extraido_em)
+        """,
+    )
+
+
+def _stj_parquet(path: Path, numero_processo: str = CNJ_ALL) -> Path:
+    return _copy_sql_to_parquet(
+        path,
+        f"""
+        SELECT * FROM (VALUES
+            ('stj-1', '{numero_processo}', 'REsp', 'MIN X', 'tema', 'tese', 'ementa',
+             DATE '2024-05-01', DATE '2024-05-10')
+        ) AS t(id, "numeroProcesso", "siglaClasse", "ministroRelator", tema,
+               "teseJuridica", ementa, "dataDecisao", "dataPublicacao")
+        """,
+    )
+
+
+def _datajud_capa_bytes(path: Path) -> bytes:
+    rows = [
+        {
+            "numero_processo": CNJ_ALL,
+            "tribunal": "tjro",
+            "grau": "G2",
+            "orgao_julgador": "2a Camara",
+            "classe_nome": "Apelacao Civel",
+            "assuntos": "Contratos",
+            "data_ajuizamento": "2024-01-10T00:00:00",
+            "ultima_atualizacao": "2024-06-01T00:00:00",
+        },
+        {
+            "numero_processo": CNJ_DJEN_DJ,
+            "tribunal": "tjro",
+            "grau": "G1",
+            "orgao_julgador": "1a Vara",
+            "classe_nome": "Procedimento Comum",
+            "assuntos": "Consumidor",
+            "data_ajuizamento": "2024-02-20T00:00:00",
+            "ultima_atualizacao": "2024-06-02T00:00:00",
+        },
+    ]
+    write_capa_parquet(rows, path)
+    return path.read_bytes()
+
+
+@pytest.fixture
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every module-level path at tmp_path so no repo data leaks in."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(rp, "ROOT", tmp_path)  # JURIS local globs find nothing
+    monkeypatch.setattr(rp, "DATA_DIR", data_dir)
+    monkeypatch.setattr(rp, "_PARQUET_UNIFICADOS", data_dir / "processos_unificados.parquet")
+    monkeypatch.setattr(rp, "_PARQUET_DOCUMENTOS", data_dir / "processo_documentos.parquet")
+    monkeypatch.setattr(rp, "_STJ_PARQUET", data_dir / "stj" / "stj-acordaos.parquet")
+    monkeypatch.setattr(rp, "_DATAJUD_DIR", data_dir / "datajud")
+    monkeypatch.setenv("RECONCILE_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.delenv("RECONCILE_EXPECTED_SOURCES", raising=False)
+    monkeypatch.delenv("RECONCILE_STRICT", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    return tmp_path
+
+
+def _mock_juris_remote(router: respx.MockRouter, fixtures: Path) -> None:
+    """Serve two overlapping monthly JURIS shards from a fake tjro-juris-2024 item."""
+    # id_documento 1 appears in BOTH shards (recrawl overlap) — the loader
+    # must dedup it; id 2 is unique to the second shard.
+    juris1 = _juris_parquet(
+        fixtures / "2024-01-ACORDAO.parquet",
+        f"(1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+        " '2024-01-15', 'texto um', 'https://juris/1', '2024-01-31T00:00:00')",
+    )
+    juris2 = _juris_parquet(
+        fixtures / "2024-02-SENTENCA.parquet",
+        f"(1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+        " '2024-01-15', 'texto um', 'https://juris/1', '2024-02-28T00:00:00'),"
+        f"(2, '{CNJ_ALL}', 'SENTENÇA', 'Apelação', '1a Vara', 'Juiz B', 'PJE',"
+        " '2024-02-10', 'texto dois', 'https://juris/2', '2024-02-28T00:00:00')",
+    )
+    router.get(host="archive.org", path="/advancedsearch.php").respond(
+        200, json={"response": {"docs": [{"identifier": "tjro-juris-2024"}]}}
+    )
+    router.get(host="archive.org", path="/metadata/tjro-juris-2024").respond(
+        200,
+        json={
+            "files": [
+                {"name": "2024-01-ACORDAO.parquet"},
+                {"name": "2024-02-SENTENCA.parquet"},
+                {"name": "tjro-juris-2024_meta.xml"},
+            ]
+        },
+    )
+    router.get(
+        host="archive.org", path="/download/tjro-juris-2024/2024-01-ACORDAO.parquet"
+    ).respond(200, content=juris1.read_bytes())
+    router.get(
+        host="archive.org", path="/download/tjro-juris-2024/2024-02-SENTENCA.parquet"
+    ).respond(200, content=juris2.read_bytes())
+
+
+def _mock_datajud_remote(router: respx.MockRouter, fixtures: Path) -> None:
+    capa_bytes = _datajud_capa_bytes(fixtures / "datajud-capa-tjro.parquet")
+    router.get(host="archive.org", path="/metadata/datajud-tjro").respond(
+        200, json={"files": [{"name": "datajud-capa-tjro.parquet"}]}
+    )
+    router.get(host="archive.org", path="/download/datajud-tjro/datajud-capa-tjro.parquet").respond(
+        200, content=capa_bytes
+    )
+
+
+def _mock_stj_remote(router: respx.MockRouter, fixtures: Path) -> None:
+    stj = _stj_parquet(fixtures / "stj-acordaos.parquet")
+    router.get(rp._STJ_IA_URL).respond(200, content=stj.read_bytes())
+
+
+class TestFullReconcileWithoutLocalParquets:
+    def test_all_sources_load_via_ia_fallback(
+        self, isolated_dirs: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        comunicacoes = _comunicacoes_parquet(fixtures / "comunicacoes.parquet")
+        catalog = _catalog_parquet(fixtures / "catalog.parquet", [comunicacoes])
+        monkeypatch.setattr(rp, "_IA_CATALOG_MANIFEST_URL", str(catalog))
+
+        with respx.mock() as router:
+            _mock_stj_remote(router, fixtures)
+            _mock_juris_remote(router, fixtures)
+            _mock_datajud_remote(router, fixtures)
+            stats = rp.reconcile(upload=False)
+
+        assert stats["djen"] == 2  # CNJ_ALL (two pubs collapse) + CNJ_DJEN_DJ
+        assert stats["juris"] == 1
+        assert stats["stj"] == 1
+        assert stats["datajud"] == 2
+        assert stats["total"] == 2
+        assert stats["multi_fonte"] == 2
+
+        # Output parquet: tem_datajud/tem_juris-style flags actually populated
+        con = duckdb.connect()
+        try:
+            rows = con.execute(
+                "SELECT nr_processo, tem_datajud, n_fontes, array_to_string(fontes, '+'), "
+                "juris_n_documentos "
+                f"FROM read_parquet('{rp._PARQUET_UNIFICADOS}') ORDER BY nr_processo"
+            ).fetchall()
+        finally:
+            con.close()
+        assert rows[0] == (CNJ_ALL, True, 4, "djen+juris+stj+datajud", 2)
+        assert rows[1] == (CNJ_DJEN_DJ, True, 2, "djen+datajud", None)
+
+        # Coverage report next to the output
+        report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
+        statuses = {name: src["status"] for name, src in report["sources"].items()}
+        assert statuses == {
+            "djen": "loaded_remote",
+            "juris": "loaded_remote",
+            "stj": "loaded_remote",
+            "datajud": "loaded_remote",
+        }
+        assert report["combinations"] == {"djen+juris+stj+datajud": 1, "djen+datajud": 1}
+        assert report["validation"]["errors"] == []
+        assert report["validation"]["warnings"] == []
+
+    def test_remote_downloads_are_cached_across_runs(self, isolated_dirs: Path) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+
+        with respx.mock() as router:
+            _mock_datajud_remote(router, fixtures)
+            download = router.routes[-1]
+            first = rp.fetch_datajud_from_ia()
+            second = rp.fetch_datajud_from_ia()
+
+        assert first == second
+        assert first[0].exists()
+        assert download.call_count == 1  # second run served from cache
+
+
+class TestUnavailableSources:
+    @pytest.fixture
+    def unavailable_env(self, isolated_dirs: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """DJEN/STJ loaded-but-zero; JURIS/DataJud unavailable on IA."""
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        # Catalog readable but with no comunicacoes rows → djen loaded, zero.
+        catalog = _catalog_parquet(fixtures / "catalog.parquet", [])
+        monkeypatch.setattr(rp, "_IA_CATALOG_MANIFEST_URL", str(catalog))
+        # Local STJ parquet whose CNJ is invalid → stj loaded_local, zero agg rows.
+        rp._STJ_PARQUET.parent.mkdir(parents=True, exist_ok=True)
+        _stj_parquet(rp._STJ_PARQUET, numero_processo="123")
+        return tmp_path
+
+    def _mock_empty_ia(self, router: respx.MockRouter) -> None:
+        router.get(host="archive.org", path="/advancedsearch.php").respond(
+            200, json={"response": {"docs": []}}
+        )
+        router.get(host="archive.org", path="/metadata/datajud-tjro").respond(200, json={})
+
+    @pytest.mark.usefixtures("unavailable_env")
+    def test_zero_and_unavailable_fails_strict(self) -> None:
+        with respx.mock() as router:
+            self._mock_empty_ia(router)
+            exit_code = rp.main(["--no-upload"])
+
+        assert exit_code == 1
+        report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
+        statuses = {name: src["status"] for name, src in report["sources"].items()}
+        assert statuses["juris"] == "unavailable"
+        assert statuses["datajud"] == "unavailable"
+        assert statuses["djen"] == "loaded_remote"
+        assert statuses["stj"] == "loaded_local"
+        errors = report["validation"]["errors"]
+        assert len(errors) == 2
+        assert any("'juris'" in e for e in errors)
+        assert any("'datajud'" in e for e in errors)
+        # loaded-but-zero sources warn instead of failing
+        warnings = report["validation"]["warnings"]
+        assert any("'djen'" in w for w in warnings)
+        assert any("'stj'" in w for w in warnings)
+
+    @pytest.mark.usefixtures("unavailable_env")
+    def test_strict_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RECONCILE_STRICT", "0")
+        with respx.mock() as router:
+            self._mock_empty_ia(router)
+            assert rp.main(["--no-upload"]) == 0
+
+    @pytest.mark.usefixtures("unavailable_env")
+    def test_strict_disabled_via_flag(self) -> None:
+        with respx.mock() as router:
+            self._mock_empty_ia(router)
+            assert rp.main(["--no-upload", "--no-strict"]) == 0
+
+    @pytest.mark.usefixtures("unavailable_env")
+    def test_unexpected_sources_downgrade_to_warnings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RECONCILE_EXPECTED_SOURCES", "djen,stj")
+        with respx.mock() as router:
+            self._mock_empty_ia(router)
+            assert rp.main(["--no-upload"]) == 0
+        report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
+        assert report["validation"]["errors"] == []
+        assert any("'juris'" in w for w in report["validation"]["warnings"])
+        assert any("'datajud'" in w for w in report["validation"]["warnings"])
+
+
+class TestValidateCoverage:
+    def test_zero_plus_unavailable_expected_is_error(self) -> None:
+        sources = {"juris": rp.SourceLoad("juris", rp.STATUS_UNAVAILABLE, "no IA items", rows=0)}
+        errors, warnings = rp.validate_coverage(sources, ("juris",))
+        assert len(errors) == 1
+        assert warnings == []
+
+    def test_zero_plus_loaded_is_warning(self) -> None:
+        sources = {"stj": rp.SourceLoad("stj", rp.STATUS_LOADED_LOCAL, "local", rows=0)}
+        errors, warnings = rp.validate_coverage(sources, ("stj",))
+        assert errors == []
+        assert len(warnings) == 1
+
+    def test_unavailable_but_not_expected_is_warning(self) -> None:
+        sources = {"juris": rp.SourceLoad("juris", rp.STATUS_UNAVAILABLE, "gone", rows=0)}
+        errors, warnings = rp.validate_coverage(sources, ("djen",))
+        assert errors == []
+        assert len(warnings) == 1
+
+    def test_loaded_with_rows_is_clean(self) -> None:
+        sources = {"djen": rp.SourceLoad("djen", rp.STATUS_LOADED_REMOTE, "ok", rows=10)}
+        errors, warnings = rp.validate_coverage(sources, ("djen",))
+        assert errors == []
+        assert warnings == []


### PR DESCRIPTION
## Description

`reconcile_processos.py` previously required local parquets for JURIS (`data/tjro_juris/*/tjro-juris-*.parquet`) and DataJud (`data/datajud/datajud-capa-*.parquet`) to contribute to `processos_unificados`. On any runner that hadn't just run the corresponding crawl/enrich CLI in the same job, those contributions silently degraded to empty — with no signal that anything was wrong. STJ already had an IA fallback; JURIS and DataJud did not.

**IA fallback for JURIS and DataJud**
- `ensure_juris_parquets()` / `fetch_juris_from_ia()`: discover `tjro-juris-{year}` IA items via `advancedsearch`, prefer each item's consolidated `tjro-juris-{year}.parquet`, fall back to the raw monthly shards the sync uploads (deduplicated by `id_documento` — shards can overlap between crawls, same logic as `tjro_juris.dedup.consolidate_year`).
- `ensure_datajud_parquets()` / `fetch_datajud_from_ia()`: same pattern for `datajud-{tribunal}` IA items (`RECONCILE_DATAJUD_TRIBUNAIS`, default `tjro`).
- Downloads are cached under `RECONCILE_CACHE_DIR` so repeated runs on the same runner don't re-fetch.

**Source coverage report and validation**
- Every source's load path is now tracked (`SourceLoad`: `loaded_local` / `loaded_remote` / `unavailable`) and a coverage report (`processos_unificados.report.json`) is written alongside the output: per-source row counts + load status, and the fontes-combination intersection matrix (how many processos are DJEN-only, DJEN+STJ, all four, etc.).
- `validate_coverage()` distinguishes "source unavailable so it contributed zero rows" (error, for `RECONCILE_EXPECTED_SOURCES` — default `djen,stj` since no `tjro-juris-*`/`datajud-*` IA items exist yet) from "source loaded fine but is legitimately empty" (warning). The failure mode this closes: running blind on an expected source with no signal that the reconciliation quietly degraded. CI annotations (`::error`/`::warning`) fire when `GITHUB_ACTIONS` is set. `--no-strict` / `RECONCILE_STRICT=0` downgrades errors to non-fatal for manual/exploratory runs.
- `update-catalog.yml` sets `RECONCILE_EXPECTED_SOURCES=djen,stj` — JURIS and DataJud aren't required yet since neither upload pipeline has landed real data on IA; add them to the list once they do.

**Per-source failure isolation and cache-poisoning prevention**
- Each source's view registration (DJEN/JURIS/STJ/DataJud) is its own error boundary: a `duckdb.Error` while creating or forcing the view is caught, the source is reported `unavailable` with the offending file list and a summary of the exception, a typed-empty fallback view/table is (re)created, and the reconciliation continues — a corrupt or truncated parquet for one source no longer crashes the whole run or prevents the coverage report from being written.
- Downloads are now atomic (write to `.part`, validate as parquet, then rename into place) and a cache hit is re-validated before reuse. Downloads incompletos não são promovidos ao cache; parquets remotos inválidos tornam apenas a fonte correspondente indisponível, sem impedir a emissão do relatório de cobertura. A cached file that fails validation (or was left over from an interrupted earlier run) is quarantined and re-fetched — only files under our own IA-fetch cache are ever removed this way; operator-provided local parquets are never touched.

14 tests exercise the full `reconcile()` pipeline with **no local source parquets** — JURIS and DataJud served exclusively through the IA fallback (respx-mocked httpx), plus the coverage-validation logic in isolation, plus targeted regressions for corrupted remote downloads, corrupted cache reuse, NULL `id_documento` handling, and one source's corruption not blocking the others.

Verified: `pytest tests/test_reconcile_processos.py` 14/14 green, `pytest` (full suite) green, ruff clean, format clean — all against a fresh `main` checkout (isolated worktree), independent of the concurrent STJ/TJRO sync work in #805.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HooVeMXcUNjcKTvYH9CqWr)_