### PR TITLE
fix(web): restore semantic CSS token boundary in publicacoes/index.astro

### DIFF
--- a/web/src/pages/publicacoes/index.astro
+++ b/web/src/pages/publicacoes/index.astro
@@ -65,11 +65,11 @@ function fmt(n: number): string {
 
 <style>
   .publication-search-section {
-    padding: var(--s-7) 0 var(--s-9);
+    padding: var(--space-lg, 2.5rem) 0 var(--space-2xl, 6rem);
   }
 
   .page-head__meta {
-    margin-top: var(--s-2);
+    margin-top: var(--space-2, 0.5rem);
     font-family: var(--font-mono);
     font-size: var(--t-micro);
     color: var(--fg-muted);


### PR DESCRIPTION
## Description

Follow-up nit from the #808 review: `publicacoes/index.astro` is a functional/data page, but both of its style rules used Brazilian-Modernism spacing tokens (`--s-2`, `--s-7`, `--s-9`). Per CLAUDE.md, `--s-*`/`--papel-*`/`--tinta-*` are reserved for the homepage and `sobre.astro`; functional/data pages should use the semantic scale (`--color-*`, `--space-*`, `--pico-*`).

Fixed both rules in the file — the pre-existing `.publication-search-section` violation and the one `#808` added in `.page-head__meta` — instead of touching only the newest line and leaving the older violation behind:

- `--s-2` (8px) → `--space-2` (0.5rem) — exact match.
- `--s-9` (96px) → `--space-2xl` (6rem) — exact match.
- `--s-7` (48px) has no exact semantic equivalent (the scale jumps `--space-lg` 40px → `--space-xl` 64px); picked `--space-lg`, the closer of the two neighbors, matching the section-spacing precedent already used in `advogados.astro`.

No visual/behavioral change beyond a few px of section padding. Verified: `npm run lint` clean, `npm test` 159/159 green, `npm run build` succeeds (106 pages), and the compiled CSS for `/publicacoes` confirms both rules now resolve through `--space-*` with no remaining `--s-*` reference.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HooVeMXcUNjcKTvYH9CqWr)_