### PR TITLE
feat(web): unified per-CNJ process page via client-side DuckDB-WASM

### DIFF
--- a/web/src/components/PageHeader.astro
+++ b/web/src/components/PageHeader.astro
@@ -34,6 +34,7 @@ const primaryLinks = [
 ];
 
 const ferramentasLinks = [
+  { href: BASE + 'processo', label: 'Consultar processo' },
   { href: BASE + 'advogados', label: 'Advogados' },
   { href: BASE + 'comparador', label: 'Comparar tribunais' },
 ];

--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -1,0 +1,337 @@
+<script>
+  import { onMount } from 'svelte';
+  import { getDuckDB } from '../lib/duckdbSingleton';
+  import { formatUtcDateTime } from '../lib/data/siteStatus';
+  import {
+    ALL_FONTES,
+    FONTE_LABELS,
+    DOCUMENTOS_PAGE_SIZE,
+    buildCnjSearchParams,
+    buildProcessoDocumentosSql,
+    buildProcessoUnificadoSql,
+    classifyCnjInput,
+    completude,
+    formatCnj,
+    isDocumentosVazio,
+    mapDocumentoRow,
+    mapProcessoRow,
+    normalizeCnj,
+    paginate,
+    readCnjParam,
+  } from '../lib/processoCnj';
+
+  let input = $state('');
+  let dbStatus = $state('initializing'); // 'initializing' | 'ready' | 'error'
+  let dbError = $state(null);
+
+  // 'idle' | 'invalid' | 'querying' | 'not_found' | 'source_unavailable' | 'found'
+  let status = $state('idle');
+  let invalidMessage = $state(null);
+  let queryError = $state(null);
+  let processo = $state(null);
+
+  let documentosStatus = $state('idle'); // 'idle' | 'loading' | 'ready' | 'error'
+  let documentosError = $state(null);
+  let documentos = $state([]);
+  let documentosOffset = $state(0);
+  let documentosHasMore = $state(false);
+  let lastQueriedCnj = $state(null);
+
+  let conn = null;
+  let cancelled = false;
+
+  const fontesResumo = $derived(processo ? completude(processo.fontes) : null);
+  const documentosVazio = $derived(
+    status === 'found' && documentosStatus === 'ready' && isDocumentosVazio(documentos, 0) && documentosOffset === 0,
+  );
+  const datasetGeneratedAtLabel = $derived(
+    processo?.updatedAtRaw ? (formatUtcDateTime(processo.updatedAtRaw) ?? 'desconhecido') : 'desconhecido',
+  );
+
+  async function init() {
+    dbStatus = 'initializing';
+    dbError = null;
+    try {
+      const { conn: connInstance } = await getDuckDB();
+      if (cancelled) return;
+      conn = connInstance;
+      dbStatus = 'ready';
+    } catch (err) {
+      if (cancelled) return;
+      dbStatus = 'error';
+      dbError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function loadDocumentos(digits, offset) {
+    documentosStatus = 'loading';
+    documentosError = null;
+    try {
+      const stmt = await conn.prepare(buildProcessoDocumentosSql());
+      const result = await stmt.query(digits, DOCUMENTOS_PAGE_SIZE + 1, offset);
+      await stmt.close();
+      const rawRows = result.toArray().map((row) => row.toJSON());
+      const { items, hasMore } = paginate(rawRows.map(mapDocumentoRow), DOCUMENTOS_PAGE_SIZE);
+      documentos = offset === 0 ? items : [...documentos, ...items];
+      documentosHasMore = hasMore;
+      documentosOffset = offset;
+      documentosStatus = 'ready';
+    } catch (err) {
+      documentosStatus = 'error';
+      documentosError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function loadMoreDocumentos() {
+    if (!lastQueriedCnj || documentosStatus === 'loading') return;
+    loadDocumentos(lastQueriedCnj, documentosOffset + DOCUMENTOS_PAGE_SIZE);
+  }
+
+  async function search(rawInput, { updateUrl = true } = {}) {
+    const kind = classifyCnjInput(rawInput);
+
+    if (kind === 'empty') {
+      status = 'idle';
+      return;
+    }
+
+    if (kind === 'invalid') {
+      status = 'invalid';
+      invalidMessage = 'CNJ inválido: cole os 20 dígitos do número do processo, com ou sem máscara (ex.: 0000001-02.2024.8.22.0001).';
+      processo = null;
+      documentos = [];
+      documentosStatus = 'idle';
+      return;
+    }
+
+    const digits = normalizeCnj(rawInput);
+
+    if (updateUrl && typeof window !== 'undefined') {
+      const qs = buildCnjSearchParams(window.location.search, digits);
+      const url = `${window.location.pathname}${qs}${window.location.hash}`;
+      window.history.replaceState(null, '', url);
+    }
+
+    status = 'querying';
+    queryError = null;
+    processo = null;
+    documentos = [];
+    documentosStatus = 'idle';
+    documentosOffset = 0;
+    documentosHasMore = false;
+
+    if (dbStatus !== 'ready') {
+      await init();
+    }
+    if (dbStatus !== 'ready') {
+      status = 'source_unavailable';
+      queryError = dbError ?? 'DuckDB-WASM não inicializou.';
+      return;
+    }
+
+    try {
+      const stmt = await conn.prepare(buildProcessoUnificadoSql());
+      const result = await stmt.query(digits);
+      await stmt.close();
+      const rows = result.toArray().map((row) => row.toJSON());
+
+      if (rows.length === 0) {
+        status = 'not_found';
+        lastQueriedCnj = digits;
+        return;
+      }
+
+      processo = mapProcessoRow(rows[0]);
+      lastQueriedCnj = digits;
+      status = 'found';
+      await loadDocumentos(digits, 0);
+    } catch (err) {
+      status = 'source_unavailable';
+      queryError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    search(input);
+  }
+
+  function retry() {
+    if (input.trim()) search(input);
+    else init();
+  }
+
+  onMount(() => {
+    (async () => {
+      await init();
+      if (cancelled) return;
+      const fromUrl = typeof window !== 'undefined' ? readCnjParam(window.location.search) : null;
+      if (fromUrl) {
+        input = fromUrl;
+        await search(fromUrl, { updateUrl: false });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+<div class="processo-lookup">
+  <form onsubmit={handleSubmit} class="processo-lookup__form">
+    <label for="processo-cnj-input">Número do processo (CNJ)</label>
+    <div class="processo-lookup__row">
+      <input
+        id="processo-cnj-input"
+        type="text"
+        bind:value={input}
+        placeholder="0000001-02.2024.8.22.0001"
+        autocomplete="off"
+        spellcheck="false"
+        aria-describedby="processo-cnj-hint"
+      />
+      <button type="submit" aria-busy={status === 'querying'} disabled={status === 'querying'}>
+        {status === 'querying' ? 'Consultando…' : 'Buscar'}
+      </button>
+    </div>
+    <small id="processo-cnj-hint" class="meta-text">
+      Cole o número com ou sem máscara. A busca roda inteiramente no seu navegador (DuckDB-WASM) —
+      nenhum dado é enviado a servidores externos.
+    </small>
+  </form>
+
+  {#if dbStatus === 'initializing' && status === 'idle'}
+    <p aria-busy="true">Inicializando DuckDB-WASM…</p>
+  {/if}
+
+  {#if dbStatus === 'error' && status !== 'querying'}
+    <article role="alert" data-tone="error">
+      <p>Falha ao inicializar DuckDB-WASM: {dbError}</p>
+      <p>Tente recarregar a página ou verifique se seu navegador bloqueia Workers/WebAssembly.</p>
+      <button class="secondary outline" onclick={retry}>Tentar novamente</button>
+    </article>
+  {/if}
+
+  {#if status === 'invalid'}
+    <aside role="alert" class="alert" data-level="warning">
+      <strong>CNJ inválido</strong>
+      <p>{invalidMessage}</p>
+    </aside>
+  {/if}
+
+  {#if status === 'querying'}
+    <p aria-busy="true">Consultando processos_unificados.parquet e processo_documentos.parquet no Internet Archive…</p>
+  {/if}
+
+  {#if status === 'not_found'}
+    <article class="empty-state">
+      <h3>Processo não localizado</h3>
+      <p>
+        Nenhum registro para <code>{lastQueriedCnj ? formatCnj(lastQueriedCnj) : ''}</code> em
+        processos_unificados.parquet. Isso significa que o CNJ não apareceu em nenhuma das fontes
+        reconciliadas (DJEN, JURIS, STJ, DataJud) até a última geração do dataset — não que o
+        processo não existe.
+      </p>
+    </article>
+  {/if}
+
+  {#if status === 'source_unavailable'}
+    <article role="alert" data-tone="error">
+      <h3>Fonte indisponível</h3>
+      <p>Não foi possível consultar o dataset: {queryError}</p>
+      <p>Isso costuma indicar uma falha de rede ao buscar o parquet no Internet Archive. Tente novamente.</p>
+      <button class="secondary outline" onclick={retry}>Tentar novamente</button>
+    </article>
+  {/if}
+
+  {#if status === 'found' && processo}
+    <section class="processo-dossie" aria-label="Dossiê do processo">
+      <header class="processo-dossie__header">
+        <h2>{processo.nrProcessoMascara}</h2>
+        <p class="meta-text">
+          {fontesResumo.presentes.length} de {ALL_FONTES.length} fontes ({fontesResumo.pct}% de completude) ·
+          dataset gerado em {datasetGeneratedAtLabel}
+        </p>
+      </header>
+
+      <section aria-labelledby="fontes-title">
+        <h3 id="fontes-title">Fontes encontradas</h3>
+        <div class="processo-dossie__fontes">
+          {#each ALL_FONTES as fonte}
+            <span class="badge" data-tone={processo.fontes.includes(fonte) ? 'success' : 'muted'}>
+              {FONTE_LABELS[fonte]} {processo.fontes.includes(fonte) ? '✓' : '— ausente'}
+            </span>
+          {/each}
+        </div>
+      </section>
+
+      <article aria-labelledby="datajud-title">
+        <header><strong id="datajud-title">Dados cadastrais (DataJud)</strong></header>
+        {#if processo.datajud.present}
+          <dl>
+            <dt>Classe oficial</dt><dd>{processo.datajud.classeOficial ?? '—'}</dd>
+            <dt>Assuntos</dt><dd>{processo.datajud.assuntos ?? '—'}</dd>
+            <dt>Órgão julgador</dt><dd>{processo.datajud.orgaoJulgador ?? '—'}</dd>
+            <dt>Grau</dt><dd>{processo.datajud.grau ?? '—'}</dd>
+            <dt>Data de ajuizamento</dt><dd>{processo.datajud.dataAjuizamento ?? '—'}</dd>
+            <dt>Última atualização (DataJud)</dt><dd>{processo.datajud.ultimaAtualizacao ?? '—'}</dd>
+          </dl>
+        {:else}
+          <p class="meta-text" data-tone="muted">Sem enriquecimento DataJud para este processo.</p>
+        {/if}
+      </article>
+
+      <article aria-labelledby="djen-title">
+        <header><strong id="djen-title">Comunicações DJEN</strong></header>
+        {#if processo.djen.present}
+          <dl>
+            <dt>Publicações</dt><dd>{processo.djen.nPublicacoes ?? '—'}</dd>
+            <dt>Primeira publicação</dt><dd>{processo.djen.primeiraPub ?? '—'}</dd>
+            <dt>Última publicação</dt><dd>{processo.djen.ultimaPub ?? '—'}</dd>
+            <dt>Tribunais</dt><dd>{processo.djen.tribunais.join(', ') || '—'}</dd>
+          </dl>
+        {:else}
+          <p class="meta-text" data-tone="muted">Sem publicações DJEN para este processo.</p>
+        {/if}
+      </article>
+
+      <section aria-labelledby="documentos-title">
+        <h3 id="documentos-title">Documentos (JURIS / STJ)</h3>
+
+        {#if documentosStatus === 'loading' && documentos.length === 0}
+          <p aria-busy="true">Carregando documentos…</p>
+        {/if}
+
+        {#if documentosStatus === 'error'}
+          <article role="alert" data-tone="error">
+            <p>Documentos indisponíveis: {documentosError}</p>
+            <button class="secondary outline" onclick={() => loadDocumentos(lastQueriedCnj, 0)}>Tentar novamente</button>
+          </article>
+        {/if}
+
+        {#if documentosVazio}
+          <p class="meta-text" data-tone="muted">Processo localizado, mas sem documentos associados.</p>
+        {/if}
+
+        {#if documentos.length > 0}
+          <ol class="processo-dossie__timeline">
+            {#each documentos as doc}
+              <li>
+                <span class="badge" data-tone="info">{FONTE_LABELS[doc.fonte] ?? doc.fonte}</span>
+                <strong>{doc.tipo ?? 'Documento'}</strong>
+                <span class="meta-text">{doc.data ?? 'data desconhecida'}</span>
+                {#if doc.resumo}<p>{doc.resumo}</p>{/if}
+                {#if doc.url}<a href={doc.url} target="_blank" rel="noopener noreferrer">Abrir no portal</a>{/if}
+              </li>
+            {/each}
+          </ol>
+          {#if documentosHasMore}
+            <button class="outline secondary" onclick={loadMoreDocumentos} disabled={documentosStatus === 'loading'} aria-busy={documentosStatus === 'loading'}>
+              {documentosStatus === 'loading' ? 'Carregando…' : 'Carregar mais'}
+            </button>
+          {/if}
+        {/if}
+      </section>
+    </section>
+  {/if}
+</div>

--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -39,6 +39,11 @@
 
   let conn = null;
   let cancelled = false;
+  // Monotonic id of the in-flight search. Any async result (processo or
+  // documentos) whose captured generation no longer matches the current one
+  // belongs to a search the user has since superseded — it's discarded
+  // instead of overwriting newer state (see search()/loadDocumentos()).
+  let searchGeneration = 0;
 
   const fontesResumo = $derived(processo ? completude(processo.fontes) : null);
   const documentosVazio = $derived(
@@ -63,22 +68,28 @@
     }
   }
 
-  async function loadDocumentos(digits, offset) {
+  async function loadDocumentos(digits, offset, generation = searchGeneration) {
     documentosStatus = 'loading';
     documentosError = null;
+    let stmt;
     try {
-      const stmt = await conn.prepare(buildProcessoDocumentosSql());
+      stmt = await conn.prepare(buildProcessoDocumentosSql());
       const result = await stmt.query(digits, DOCUMENTOS_PAGE_SIZE + 1, offset);
-      await stmt.close();
       const rawRows = result.toArray().map((row) => row.toJSON());
       const { items, hasMore } = paginate(rawRows.map(mapDocumentoRow), DOCUMENTOS_PAGE_SIZE);
+
+      if (generation !== searchGeneration) return; // a newer search superseded this one
+
       documentos = offset === 0 ? items : [...documentos, ...items];
       documentosHasMore = hasMore;
       documentosOffset = offset;
       documentosStatus = 'ready';
     } catch (err) {
+      if (generation !== searchGeneration) return;
       documentosStatus = 'error';
       documentosError = err instanceof Error ? err.message : String(err);
+    } finally {
+      await stmt?.close();
     }
   }
 
@@ -88,6 +99,10 @@
   }
 
   async function search(rawInput, { updateUrl = true } = {}) {
+    // Every call — including invalid/empty input — claims a new generation,
+    // so a still-in-flight older search can never clobber whatever the user
+    // triggered next (see the generation checks below and in loadDocumentos).
+    const generation = ++searchGeneration;
     const kind = classifyCnjInput(rawInput);
 
     if (kind === 'empty') {
@@ -124,16 +139,19 @@
       await init();
     }
     if (dbStatus !== 'ready') {
+      if (generation !== searchGeneration) return;
       status = 'source_unavailable';
       queryError = dbError ?? 'DuckDB-WASM não inicializou.';
       return;
     }
 
+    let stmt;
     try {
-      const stmt = await conn.prepare(buildProcessoUnificadoSql());
+      stmt = await conn.prepare(buildProcessoUnificadoSql());
       const result = await stmt.query(digits);
-      await stmt.close();
       const rows = result.toArray().map((row) => row.toJSON());
+
+      if (generation !== searchGeneration) return; // a newer search superseded this one
 
       if (rows.length === 0) {
         status = 'not_found';
@@ -144,11 +162,20 @@
       processo = mapProcessoRow(rows[0]);
       lastQueriedCnj = digits;
       status = 'found';
-      await loadDocumentos(digits, 0);
     } catch (err) {
+      if (generation !== searchGeneration) return;
       status = 'source_unavailable';
       queryError = err instanceof Error ? err.message : String(err);
+      return;
+    } finally {
+      await stmt?.close();
     }
+
+    // Only reached when the processo query above landed on 'found' for this
+    // still-current generation (both 'not_found' and the catch block return
+    // earlier). Pin the generation explicitly — a documentos response for a
+    // since-superseded search must never land on screen.
+    await loadDocumentos(digits, 0, generation);
   }
 
   function handleSubmit(e) {

--- a/web/src/components/ProcessoLookup.test.ts
+++ b/web/src/components/ProcessoLookup.test.ts
@@ -1,0 +1,181 @@
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ProcessoLookup from './ProcessoLookup.svelte';
+import { getDuckDB } from '../lib/duckdbSingleton';
+
+vi.mock('../lib/duckdbSingleton', () => ({
+  getDuckDB: vi.fn(),
+}));
+
+beforeEach(() => {
+  // Each test mounts its own component instance, but jsdom's window.location
+  // persists across tests in this file — without resetting it, a ?cnj= left
+  // by history.replaceState() in a previous test would auto-trigger a search
+  // on the next test's mount (the component's own, intentional, feature).
+  window.history.replaceState(null, '', window.location.pathname);
+});
+
+const CNJ_A = '00000010220248220001';
+const CNJ_B = '00000020320248220002';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function arrowResult(rows: Record<string, unknown>[]) {
+  return { toArray: () => rows.map((r) => ({ toJSON: () => r })) };
+}
+
+function processoRow(nrProcesso: string): Record<string, unknown> {
+  return {
+    nr_processo: nrProcesso,
+    nr_processo_mascara: nrProcesso,
+    n_fontes: 1,
+    fontes: ['djen'],
+    djen_primeira_pub: null,
+    djen_ultima_pub: null,
+    djen_n_publicacoes: null,
+    djen_tribunais: [],
+    juris_n_documentos: null,
+    juris_tipos: [],
+    juris_data_julgamento: null,
+    juris_orgao: null,
+    juris_relator: null,
+    juris_classe: null,
+    juris_url: null,
+    stj_id: null,
+    stj_classe: null,
+    stj_relator: null,
+    stj_tema: null,
+    stj_tese: null,
+    stj_ementa: null,
+    stj_data_decisao: null,
+    stj_data_publicacao: null,
+    classe_oficial: null,
+    assuntos: null,
+    orgao_julgador: null,
+    grau: null,
+    data_ajuizamento: null,
+    ultima_atualizacao: null,
+    tem_datajud: false,
+    updated_at: '2026-07-12T00:00:00Z',
+  };
+}
+
+function documentoRow(nrProcesso: string, resumo: string): Record<string, unknown> {
+  return {
+    nr_processo: nrProcesso,
+    fonte: 'juris',
+    id_documento: `${nrProcesso}-doc`,
+    tipo: 'ACÓRDÃO',
+    data: '2024-01-15',
+    url: null,
+    resumo,
+  };
+}
+
+/** A fake conn whose prepare()/query() resolutions are controlled per-CNJ by the test. */
+function makeControllableConn() {
+  const processoDeferreds = new Map<string, Deferred<unknown>>();
+  const documentosDeferreds = new Map<string, Deferred<unknown>>();
+
+  const conn = {
+    prepare: vi.fn(async (sql: string) => {
+      const isDocumentos = sql.includes('processo_documentos');
+      return {
+        query: vi.fn((...params: unknown[]) => {
+          const digits = String(params[0]);
+          const map = isDocumentos ? documentosDeferreds : processoDeferreds;
+          const deferred = makeDeferred();
+          map.set(digits, deferred);
+          return deferred.promise;
+        }),
+        close: vi.fn(async () => {}),
+      };
+    }),
+  };
+
+  return { conn, processoDeferreds, documentosDeferreds };
+}
+
+describe('ProcessoLookup — race between two searches', () => {
+  it('discards a stale documentos response from search A once search B has already landed', async () => {
+    const { conn, processoDeferreds, documentosDeferreds } = makeControllableConn();
+    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+
+    const { getByLabelText, getByText, queryByText } = render(ProcessoLookup);
+
+    const input = (await waitFor(() => getByLabelText(/Número do processo/i))) as HTMLInputElement;
+
+    // Search A: submit, then let its processo query resolve (found, moves
+    // past the "querying" state so the submit button re-enables) while its
+    // documentos query is still pending.
+    await fireEvent.input(input, { target: { value: CNJ_A } });
+    await fireEvent.click(getByText('Buscar'));
+    await waitFor(() => expect(processoDeferreds.has(CNJ_A)).toBe(true));
+
+    processoDeferreds.get(CNJ_A)!.resolve(arrowResult([processoRow(CNJ_A)]));
+    await waitFor(() => expect(documentosDeferreds.has(CNJ_A)).toBe(true));
+
+    // The record for A is showing, and the button is enabled again — this is
+    // exactly the window where the user can fire a second search before A's
+    // documents arrive.
+    await waitFor(() => expect(getByText(CNJ_A, { exact: false })).toBeTruthy());
+
+    // Search B: submit while A's documentos query is still in flight.
+    await fireEvent.input(input, { target: { value: CNJ_B } });
+    await fireEvent.click(getByText('Buscar'));
+    await waitFor(() => expect(processoDeferreds.has(CNJ_B)).toBe(true));
+
+    processoDeferreds.get(CNJ_B)!.resolve(arrowResult([processoRow(CNJ_B)]));
+    await waitFor(() => expect(documentosDeferreds.has(CNJ_B)).toBe(true));
+    documentosDeferreds.get(CNJ_B)!.resolve(arrowResult([documentoRow(CNJ_B, 'DOC-B-UNICO')]));
+
+    await waitFor(() => expect(getByText('DOC-B-UNICO')).toBeTruthy());
+
+    // A's documentos response finally arrives, late — it must be discarded,
+    // not overwrite B's already-displayed documents.
+    documentosDeferreds.get(CNJ_A)!.resolve(arrowResult([documentoRow(CNJ_A, 'DOC-A-UNICO')]));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getByText(CNJ_B, { exact: false })).toBeTruthy();
+    expect(getByText('DOC-B-UNICO')).toBeTruthy();
+    expect(queryByText('DOC-A-UNICO')).toBeNull();
+    expect(queryByText(CNJ_A, { exact: false })).toBeNull();
+  });
+
+  it('never surfaces a stale processo response from search A once search B has already started', async () => {
+    const { conn, processoDeferreds } = makeControllableConn();
+    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+
+    const { getByLabelText, getByText, queryByText } = render(ProcessoLookup);
+    const input = (await waitFor(() => getByLabelText(/Número do processo/i))) as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: CNJ_A } });
+    await fireEvent.click(getByText('Buscar'));
+    await waitFor(() => expect(processoDeferreds.has(CNJ_A)).toBe(true));
+
+    // B starts (via form submit, bypassing the disabled Buscar button while
+    // A is still "querying") before A's own processo query resolves.
+    await fireEvent.input(input, { target: { value: CNJ_B } });
+    const form = input.closest('form')!;
+    await fireEvent.submit(form);
+    await waitFor(() => expect(processoDeferreds.has(CNJ_B)).toBe(true));
+
+    // A resolves late — must be discarded entirely (never reaches 'found',
+    // never issues its own documentos query).
+    processoDeferreds.get(CNJ_A)!.resolve(arrowResult([processoRow(CNJ_A)]));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(queryByText(CNJ_A, { exact: false })).toBeNull();
+  });
+});

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_FONTES,
+  buildCnjSearchParams,
+  buildProcessoDocumentosSql,
+  buildProcessoUnificadoSql,
+  classifyCnjInput,
+  completude,
+  formatCnj,
+  isDocumentosVazio,
+  isValidCnj,
+  mapDocumentoRow,
+  mapProcessoRow,
+  normalizeCnj,
+  paginate,
+  readCnjParam,
+  stripCnjMask,
+  toIsoDate,
+} from './processoCnj';
+
+describe('stripCnjMask / isValidCnj / normalizeCnj', () => {
+  it('strips a fully masked CNJ down to 20 digits', () => {
+    expect(stripCnjMask('0000001-02.2024.8.22.0001')).toBe('00000010220248220001');
+  });
+
+  it('accepts an already-unmasked 20-digit CNJ', () => {
+    expect(normalizeCnj('00000010220248220001')).toBe('00000010220248220001');
+  });
+
+  it('accepts a masked CNJ and returns the digits', () => {
+    expect(normalizeCnj('0000001-02.2024.8.22.0001')).toBe('00000010220248220001');
+  });
+
+  it('tolerates surrounding whitespace and stray characters', () => {
+    expect(normalizeCnj('  0000001-02.2024.8.22.0001  ')).toBe('00000010220248220001');
+  });
+
+  it('rejects too few digits', () => {
+    expect(normalizeCnj('123')).toBe('');
+    expect(isValidCnj('123')).toBe(false);
+  });
+
+  it('rejects too many digits', () => {
+    expect(normalizeCnj('123456789012345678901')).toBe('');
+  });
+
+  it('rejects empty input', () => {
+    expect(normalizeCnj('')).toBe('');
+  });
+});
+
+describe('formatCnj', () => {
+  it('masks a valid 20-digit CNJ', () => {
+    expect(formatCnj('00000010220248220001')).toBe('0000001-02.2024.8.22.0001');
+  });
+
+  it('returns the input unchanged when not exactly 20 digits', () => {
+    expect(formatCnj('123')).toBe('123');
+  });
+});
+
+describe('classifyCnjInput', () => {
+  it('classifies empty/whitespace-only input as empty', () => {
+    expect(classifyCnjInput('')).toBe('empty');
+    expect(classifyCnjInput('   ')).toBe('empty');
+  });
+
+  it('classifies a wrong-length or non-numeric input as invalid', () => {
+    expect(classifyCnjInput('123')).toBe('invalid');
+    expect(classifyCnjInput('abcde')).toBe('invalid');
+  });
+
+  it('classifies a valid masked or unmasked CNJ as valid', () => {
+    expect(classifyCnjInput('00000010220248220001')).toBe('valid');
+    expect(classifyCnjInput('0000001-02.2024.8.22.0001')).toBe('valid');
+  });
+});
+
+describe('readCnjParam / buildCnjSearchParams', () => {
+  it('reads ?cnj= from a query string', () => {
+    expect(readCnjParam('?cnj=0000001-02.2024.8.22.0001')).toBe('0000001-02.2024.8.22.0001');
+  });
+
+  it('returns null when cnj is absent or blank', () => {
+    expect(readCnjParam('')).toBeNull();
+    expect(readCnjParam('?other=1')).toBeNull();
+    expect(readCnjParam('?cnj=')).toBeNull();
+  });
+
+  it('writes a masked ?cnj= for a valid CNJ, preserving other params', () => {
+    const qs = buildCnjSearchParams('?foo=bar', '00000010220248220001');
+    const params = new URLSearchParams(qs);
+    expect(params.get('cnj')).toBe('0000001-02.2024.8.22.0001');
+    expect(params.get('foo')).toBe('bar');
+  });
+
+  it('removes ?cnj= instead of writing an incoherent value for invalid digits', () => {
+    const qs = buildCnjSearchParams('?cnj=0000001-02.2024.8.22.0001&foo=bar', '123');
+    const params = new URLSearchParams(qs);
+    expect(params.has('cnj')).toBe(false);
+    expect(params.get('foo')).toBe('bar');
+  });
+
+  it('round-trips through readCnjParam once written', () => {
+    const qs = buildCnjSearchParams('', '00000010220248220001');
+    expect(readCnjParam(qs)).toBe('0000001-02.2024.8.22.0001');
+  });
+});
+
+describe('SQL builders never use SELECT * and filter by parameter', () => {
+  it('processos_unificados query lists explicit columns and filters nr_processo via placeholder', () => {
+    const sql = buildProcessoUnificadoSql();
+    expect(sql).not.toMatch(/select\s+\*/i);
+    expect(sql).toContain('WHERE nr_processo = ?');
+    expect(sql).toContain('nr_processo_mascara');
+    expect(sql).toContain("read_parquet('https://archive.org/download/causaganha-dashboard/processos_unificados.parquet')");
+  });
+
+  it('processo_documentos query lists explicit columns, filters by parameter and paginates', () => {
+    const sql = buildProcessoDocumentosSql();
+    expect(sql).not.toMatch(/select\s+\*/i);
+    expect(sql).toContain('WHERE nr_processo = ?');
+    expect(sql).toContain('LIMIT ? OFFSET ?');
+    expect(sql).toContain('ORDER BY data DESC NULLS LAST');
+  });
+});
+
+describe('paginate', () => {
+  it('reports hasMore=true and trims the extra row when pageSize+1 rows come back', () => {
+    const rows = [1, 2, 3];
+    const { items, hasMore } = paginate(rows, 2);
+    expect(items).toEqual([1, 2]);
+    expect(hasMore).toBe(true);
+  });
+
+  it('reports hasMore=false when exactly pageSize rows come back', () => {
+    const rows = [1, 2];
+    const { items, hasMore } = paginate(rows, 2);
+    expect(items).toEqual([1, 2]);
+    expect(hasMore).toBe(false);
+  });
+
+  it('reports hasMore=false for an empty page', () => {
+    const { items, hasMore } = paginate([], 20);
+    expect(items).toEqual([]);
+    expect(hasMore).toBe(false);
+  });
+});
+
+describe('toIsoDate', () => {
+  it('normalizes a Date instance', () => {
+    expect(toIsoDate(new Date(Date.UTC(2024, 2, 5)))).toBe('2024-03-05');
+  });
+
+  it('normalizes an ISO string', () => {
+    expect(toIsoDate('2024-03-05T00:00:00Z')).toBe('2024-03-05');
+  });
+
+  it('returns null for null/undefined/invalid input', () => {
+    expect(toIsoDate(null)).toBeNull();
+    expect(toIsoDate(undefined)).toBeNull();
+    expect(toIsoDate('not-a-date')).toBeNull();
+  });
+});
+
+const CNJ_ALL = '00000010220248220001';
+
+function baseRawProcesso(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    nr_processo: CNJ_ALL,
+    nr_processo_mascara: '0000001-02.2024.8.22.0001',
+    n_fontes: 4,
+    fontes: ['djen', 'juris', 'stj', 'datajud'],
+    djen_primeira_pub: '2024-03-01',
+    djen_ultima_pub: '2024-03-05',
+    djen_n_publicacoes: 2,
+    djen_tribunais: ['TJRO'],
+    juris_n_documentos: 2,
+    juris_tipos: ['ACÓRDÃO', 'SENTENÇA'],
+    juris_data_julgamento: '2024-02-28',
+    juris_orgao: '2a Camara',
+    juris_relator: 'Des. A',
+    juris_classe: 'Apelação',
+    juris_url: 'https://juris/1',
+    stj_id: 'stj-1',
+    stj_classe: 'REsp',
+    stj_relator: 'MIN X',
+    stj_tema: 'tema',
+    stj_tese: 'tese',
+    stj_ementa: 'ementa',
+    stj_data_decisao: '2024-05-01',
+    stj_data_publicacao: '2024-05-10',
+    classe_oficial: 'Apelacao Civel',
+    assuntos: 'Contratos',
+    orgao_julgador: '2a Camara',
+    grau: 'G2',
+    data_ajuizamento: '2024-01-10',
+    ultima_atualizacao: '2024-06-01',
+    tem_datajud: true,
+    updated_at: '2026-07-12T18:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('mapProcessoRow — multi-fonte row', () => {
+  it('marks every source present and surfaces every field with the right provenance', () => {
+    const row = mapProcessoRow(baseRawProcesso());
+    expect(row.nrProcesso).toBe(CNJ_ALL);
+    expect(row.nrProcessoMascara).toBe('0000001-02.2024.8.22.0001');
+    expect(row.nFontes).toBe(4);
+    expect(row.fontes).toEqual(['djen', 'juris', 'stj', 'datajud']);
+
+    expect(row.djen).toMatchObject({ present: true, nPublicacoes: 2, primeiraPub: '2024-03-01', ultimaPub: '2024-03-05' });
+    expect(row.djen.tribunais).toEqual(['TJRO']);
+
+    expect(row.juris).toMatchObject({ present: true, nDocumentos: 2, orgao: '2a Camara', relator: 'Des. A' });
+    expect(row.juris.tipos).toEqual(['ACÓRDÃO', 'SENTENÇA']);
+
+    expect(row.stj).toMatchObject({ present: true, id: 'stj-1', classe: 'REsp' });
+
+    expect(row.datajud).toMatchObject({ present: true, classeOficial: 'Apelacao Civel', assuntos: 'Contratos' });
+  });
+});
+
+describe('mapProcessoRow — DataJud absent (tem_datajud=false)', () => {
+  it('marks datajud not present and nulls its fields even if fontes lists it (defensive)', () => {
+    const row = mapProcessoRow(
+      baseRawProcesso({
+        fontes: ['djen', 'juris', 'stj'],
+        tem_datajud: false,
+        classe_oficial: null,
+        assuntos: null,
+        orgao_julgador: null,
+        grau: null,
+        data_ajuizamento: null,
+        ultima_atualizacao: null,
+      }),
+    );
+    expect(row.datajud.present).toBe(false);
+    expect(row.datajud.classeOficial).toBeNull();
+  });
+});
+
+describe('mapProcessoRow — single-source (DJEN only)', () => {
+  it('marks juris/stj/datajud absent and leaves their fields null, without fabricating zeros', () => {
+    const row = mapProcessoRow(
+      baseRawProcesso({
+        fontes: ['djen'],
+        n_fontes: 1,
+        juris_n_documentos: null,
+        juris_tipos: null,
+        juris_data_julgamento: null,
+        juris_orgao: null,
+        juris_relator: null,
+        juris_classe: null,
+        juris_url: null,
+        stj_id: null,
+        stj_classe: null,
+        stj_relator: null,
+        stj_tema: null,
+        stj_tese: null,
+        stj_ementa: null,
+        stj_data_decisao: null,
+        stj_data_publicacao: null,
+        tem_datajud: false,
+        classe_oficial: null,
+        assuntos: null,
+        orgao_julgador: null,
+        grau: null,
+        data_ajuizamento: null,
+        ultima_atualizacao: null,
+      }),
+    );
+    expect(row.djen.present).toBe(true);
+    expect(row.juris.present).toBe(false);
+    expect(row.juris.nDocumentos).toBeNull();
+    expect(row.stj.present).toBe(false);
+    expect(row.datajud.present).toBe(false);
+  });
+});
+
+describe('mapDocumentoRow', () => {
+  it('maps a JURIS document row', () => {
+    const doc = mapDocumentoRow({
+      nr_processo: CNJ_ALL,
+      fonte: 'juris',
+      id_documento: '1',
+      tipo: 'ACÓRDÃO',
+      data: '2024-01-15',
+      url: 'https://juris/1',
+      resumo: 'texto um',
+    });
+    expect(doc).toEqual({
+      fonte: 'juris',
+      idDocumento: '1',
+      tipo: 'ACÓRDÃO',
+      data: '2024-01-15',
+      url: 'https://juris/1',
+      resumo: 'texto um',
+    });
+  });
+
+  it('maps an STJ document row with an empty url as null', () => {
+    const doc = mapDocumentoRow({
+      nr_processo: CNJ_ALL,
+      fonte: 'stj',
+      id_documento: 'stj-1',
+      tipo: 'REsp',
+      data: '2024-05-01',
+      url: '',
+      resumo: 'ementa',
+    });
+    expect(doc.url).toBeNull();
+    expect(doc.fonte).toBe('stj');
+  });
+});
+
+describe('completude', () => {
+  it('reports all 4 sources present at 100%', () => {
+    const c = completude(['djen', 'juris', 'stj', 'datajud']);
+    expect(c.presentes).toEqual(ALL_FONTES);
+    expect(c.ausentes).toEqual([]);
+    expect(c.pct).toBe(100);
+  });
+
+  it('reports a single source at 25%, listing the other three as absent', () => {
+    const c = completude(['djen']);
+    expect(c.presentes).toEqual(['djen']);
+    expect(c.ausentes).toEqual(['juris', 'stj', 'datajud']);
+    expect(c.pct).toBe(25);
+  });
+
+  it('reports zero sources at 0%', () => {
+    const c = completude([]);
+    expect(c.pct).toBe(0);
+    expect(c.ausentes).toEqual(ALL_FONTES);
+  });
+});
+
+describe('isDocumentosVazio', () => {
+  it('is true only on the first page with zero items (processo found, no documents)', () => {
+    expect(isDocumentosVazio([], 0)).toBe(true);
+  });
+
+  it('is false when items exist', () => {
+    expect(isDocumentosVazio([{ id: 1 }], 0)).toBe(false);
+  });
+
+  it('is false on a later page even if that page is empty (already proven non-empty overall)', () => {
+    expect(isDocumentosVazio([], 20)).toBe(false);
+  });
+});

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -1,0 +1,336 @@
+/**
+ * Helpers puros para a página /processo — dossiê unificado de um número CNJ,
+ * consultado inteiramente client-side via DuckDB-WASM contra os parquets
+ * `processos_unificados.parquet` e `processo_documentos.parquet` do item IA
+ * `causaganha-dashboard` (produzidos por scripts/reconcile_processos.py).
+ *
+ * Mantidos fora do componente Svelte para serem testáveis sem montar UI —
+ * normalização de CNJ, parsing/serialização da URL compartilhável, geração
+ * de SQL parametrizado e conversão de linhas cruas (Arrow → objeto simples)
+ * em modelos de visualização tipados.
+ */
+
+export const IA_DASHBOARD_BASE = 'https://archive.org/download/causaganha-dashboard';
+export const PROCESSOS_UNIFICADOS_URL = `${IA_DASHBOARD_BASE}/processos_unificados.parquet`;
+export const PROCESSO_DOCUMENTOS_URL = `${IA_DASHBOARD_BASE}/processo_documentos.parquet`;
+
+export const DOCUMENTOS_PAGE_SIZE = 20;
+
+export type Fonte = 'djen' | 'juris' | 'stj' | 'datajud';
+export const ALL_FONTES: readonly Fonte[] = ['djen', 'juris', 'stj', 'datajud'];
+
+export const FONTE_LABELS: Record<Fonte, string> = {
+  djen: 'DJEN',
+  juris: 'JURIS (TJRO)',
+  stj: 'STJ',
+  datajud: 'DataJud',
+};
+
+// ── Normalização de CNJ ─────────────────────────────────────────────────────
+
+/** Remove tudo que não for dígito. Não valida o comprimento — use isValidCnj. */
+export function stripCnjMask(input: string): string {
+  return (input ?? '').replace(/\D/g, '');
+}
+
+/** 20 dígitos exatos — mesma regra de scripts/reconcile_processos.py:normalizar_cnj. */
+export function isValidCnj(digits: string): boolean {
+  return /^\d{20}$/.test(digits);
+}
+
+/** Normaliza uma entrada de usuário (com ou sem máscara) para 20 dígitos, ou '' se inválida. */
+export function normalizeCnj(input: string): string {
+  const digits = stripCnjMask(input);
+  return isValidCnj(digits) ? digits : '';
+}
+
+/** 20 dígitos → NNNNNNN-DD.AAAA.J.TR.OOOO — mesma máscara de scripts/reconcile_processos.py:formatar_cnj. */
+export function formatCnj(digits: string): string {
+  if (!isValidCnj(digits)) return digits;
+  return `${digits.slice(0, 7)}-${digits.slice(7, 9)}.${digits.slice(9, 13)}.${digits.slice(13, 14)}.${digits.slice(14, 16)}.${digits.slice(16, 20)}`;
+}
+
+export type CnjInputStatus = 'empty' | 'invalid' | 'valid';
+
+/** Classifica uma entrada de busca sem decidir a mensagem — o componente decide o texto. */
+export function classifyCnjInput(raw: string): CnjInputStatus {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return 'empty';
+  return isValidCnj(stripCnjMask(trimmed)) ? 'valid' : 'invalid';
+}
+
+// ── URL compartilhável (?cnj=...) ──────────────────────────────────────────
+
+const CNJ_PARAM = 'cnj';
+
+/** Lê ?cnj= de uma query string bruta (ex.: window.location.search). Não normaliza. */
+export function readCnjParam(search: string): string | null {
+  const params = new URLSearchParams(search);
+  const value = params.get(CNJ_PARAM);
+  return value && value.trim() ? value : null;
+}
+
+/**
+ * Nova query string com ?cnj=<mascarado>, preservando os demais parâmetros.
+ * `digits` inválido remove o parâmetro em vez de gravar um valor incoerente.
+ */
+export function buildCnjSearchParams(search: string, digits: string): string {
+  const params = new URLSearchParams(search);
+  if (isValidCnj(digits)) {
+    params.set(CNJ_PARAM, formatCnj(digits));
+  } else {
+    params.delete(CNJ_PARAM);
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+// ── SQL parametrizado ───────────────────────────────────────────────────────
+// Somente as colunas exibidas (nunca SELECT *); nr_processo filtrado via
+// prepared statement, nunca por interpolação de string.
+
+export function buildProcessoUnificadoSql(): string {
+  return `
+    SELECT
+      nr_processo, nr_processo_mascara, n_fontes, fontes,
+      djen_primeira_pub, djen_ultima_pub, djen_n_publicacoes, djen_tribunais,
+      juris_n_documentos, juris_tipos, juris_data_julgamento,
+      juris_orgao, juris_relator, juris_classe, juris_url,
+      stj_id, stj_classe, stj_relator, stj_tema, stj_tese, stj_ementa,
+      stj_data_decisao, stj_data_publicacao,
+      classe_oficial, assuntos, orgao_julgador, grau,
+      data_ajuizamento, ultima_atualizacao, tem_datajud,
+      updated_at
+    FROM read_parquet('${PROCESSOS_UNIFICADOS_URL}')
+    WHERE nr_processo = ?
+    LIMIT 1
+  `;
+}
+
+/**
+ * Busca `pageSize + 1` linhas a partir de `offset` — o "+1" permite detectar
+ * "há mais" sem uma segunda consulta de contagem (ver paginate()).
+ */
+export function buildProcessoDocumentosSql(): string {
+  return `
+    SELECT nr_processo, fonte, id_documento, tipo, data, url, resumo
+    FROM read_parquet('${PROCESSO_DOCUMENTOS_URL}')
+    WHERE nr_processo = ?
+    ORDER BY data DESC NULLS LAST, id_documento
+    LIMIT ? OFFSET ?
+  `;
+}
+
+export interface PageResult<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
+/** rows deve ter sido buscado com LIMIT pageSize+1 (ver buildProcessoDocumentosSql). */
+export function paginate<T>(rows: T[], pageSize: number): PageResult<T> {
+  const hasMore = rows.length > pageSize;
+  return { items: hasMore ? rows.slice(0, pageSize) : rows, hasMore };
+}
+
+// ── Conversão de valores crus (Arrow → JS) ─────────────────────────────────
+// DuckDB-WASM devolve linhas Arrow; após row.toJSON() a maioria dos valores já
+// é string/number/Date, mas listas e datas podem chegar como Vector/objeto
+// Arrow ou string, dependendo da versão. Estas conversões são defensivas e
+// puras — testáveis sem depender do runtime real do WASM.
+
+function toStringArray(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed.map(String) : [value];
+    } catch {
+      return value.length > 0 ? [value] : [];
+    }
+  }
+  const maybeIterable = value as { toArray?: () => unknown[]; [Symbol.iterator]?: () => Iterator<unknown> };
+  if (typeof maybeIterable.toArray === 'function') return maybeIterable.toArray().map(String);
+  if (typeof maybeIterable[Symbol.iterator] === 'function') return Array.from(value as Iterable<unknown>).map(String);
+  return [];
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'bigint') return Number(value);
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toNullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const s = String(value);
+  return s.length > 0 ? s : null;
+}
+
+/** DATE/TIMESTAMP arbitrário (Date, string ISO, epoch numérico) → 'YYYY-MM-DD', ou null. */
+export function toIsoDate(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+    const parsed = new Date(typeof value === 'bigint' ? Number(value) : value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString().slice(0, 10);
+  }
+  return null;
+}
+
+/** TIMESTAMP arbitrário → rótulo pt-BR/UTC via formatUtcDateTime, ou null. */
+export function toIsoTimestampString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    const parsed = new Date(typeof value === 'bigint' ? Number(value) : value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  return null;
+}
+
+// ── Modelos de visualização ────────────────────────────────────────────────
+
+export interface ProcessoUnificadoRow {
+  nrProcesso: string;
+  nrProcessoMascara: string;
+  nFontes: number;
+  fontes: Fonte[];
+  djen: {
+    present: boolean;
+    primeiraPub: string | null;
+    ultimaPub: string | null;
+    nPublicacoes: number | null;
+    tribunais: string[];
+  };
+  juris: {
+    present: boolean;
+    nDocumentos: number | null;
+    tipos: string[];
+    dataJulgamento: string | null;
+    orgao: string | null;
+    relator: string | null;
+    classe: string | null;
+    url: string | null;
+  };
+  stj: {
+    present: boolean;
+    id: string | null;
+    classe: string | null;
+    relator: string | null;
+    tema: string | null;
+    tese: string | null;
+    ementa: string | null;
+    dataDecisao: string | null;
+    dataPublicacao: string | null;
+  };
+  datajud: {
+    present: boolean;
+    classeOficial: string | null;
+    assuntos: string | null;
+    orgaoJulgador: string | null;
+    grau: string | null;
+    dataAjuizamento: string | null;
+    ultimaAtualizacao: string | null;
+  };
+  /** ISO cru (para testes/derivações); use datasetGeneratedAtLabel() para exibir. */
+  updatedAtRaw: string | null;
+}
+
+/** Converte uma linha crua (raw.<coluna> de processos_unificados) no modelo de visualização. */
+export function mapProcessoRow(raw: Record<string, unknown>): ProcessoUnificadoRow {
+  const fontes = toStringArray(raw.fontes) as Fonte[];
+  const has = (f: Fonte) => fontes.includes(f);
+  const nrProcesso = String(raw.nr_processo ?? '');
+
+  return {
+    nrProcesso,
+    nrProcessoMascara: toNullableString(raw.nr_processo_mascara) ?? formatCnj(nrProcesso),
+    nFontes: toNumber(raw.n_fontes) ?? fontes.length,
+    fontes,
+    djen: {
+      present: has('djen'),
+      primeiraPub: toIsoDate(raw.djen_primeira_pub),
+      ultimaPub: toIsoDate(raw.djen_ultima_pub),
+      nPublicacoes: toNumber(raw.djen_n_publicacoes),
+      tribunais: toStringArray(raw.djen_tribunais),
+    },
+    juris: {
+      present: has('juris'),
+      nDocumentos: toNumber(raw.juris_n_documentos),
+      tipos: toStringArray(raw.juris_tipos),
+      dataJulgamento: toIsoDate(raw.juris_data_julgamento),
+      orgao: toNullableString(raw.juris_orgao),
+      relator: toNullableString(raw.juris_relator),
+      classe: toNullableString(raw.juris_classe),
+      url: toNullableString(raw.juris_url),
+    },
+    stj: {
+      present: has('stj'),
+      id: toNullableString(raw.stj_id),
+      classe: toNullableString(raw.stj_classe),
+      relator: toNullableString(raw.stj_relator),
+      tema: toNullableString(raw.stj_tema),
+      tese: toNullableString(raw.stj_tese),
+      ementa: toNullableString(raw.stj_ementa),
+      dataDecisao: toIsoDate(raw.stj_data_decisao),
+      dataPublicacao: toIsoDate(raw.stj_data_publicacao),
+    },
+    datajud: {
+      // tem_datajud é a fonte da verdade (RFC 0010) — 'datajud' em fontes
+      // acompanha o mesmo booleano, então checar os dois é redundante mas
+      // inofensivo caso um dia divirjam.
+      present: has('datajud') && Boolean(raw.tem_datajud),
+      classeOficial: toNullableString(raw.classe_oficial),
+      assuntos: toNullableString(raw.assuntos),
+      orgaoJulgador: toNullableString(raw.orgao_julgador),
+      grau: toNullableString(raw.grau),
+      dataAjuizamento: toIsoDate(raw.data_ajuizamento),
+      ultimaAtualizacao: toIsoDate(raw.ultima_atualizacao),
+    },
+    updatedAtRaw: toIsoTimestampString(raw.updated_at),
+  };
+}
+
+export interface ProcessoDocumentoRow {
+  fonte: Fonte | string;
+  idDocumento: string;
+  tipo: string | null;
+  data: string | null;
+  url: string | null;
+  resumo: string | null;
+}
+
+/** Converte uma linha crua de processo_documentos no modelo de visualização. */
+export function mapDocumentoRow(raw: Record<string, unknown>): ProcessoDocumentoRow {
+  return {
+    fonte: String(raw.fonte ?? ''),
+    idDocumento: String(raw.id_documento ?? ''),
+    tipo: toNullableString(raw.tipo),
+    data: toIsoDate(raw.data),
+    url: toNullableString(raw.url),
+    resumo: toNullableString(raw.resumo),
+  };
+}
+
+export interface Completude {
+  presentes: Fonte[];
+  ausentes: Fonte[];
+  pct: number;
+}
+
+/** Grau de completude: quantas das 4 fontes possíveis contribuíram para este CNJ. */
+export function completude(fontes: Fonte[]): Completude {
+  const presentes = ALL_FONTES.filter((f) => fontes.includes(f));
+  const ausentes = ALL_FONTES.filter((f) => !fontes.includes(f));
+  return { presentes, ausentes, pct: Math.round((presentes.length / ALL_FONTES.length) * 100) };
+}
+
+/** "Processo localizado, mas sem documentos associados" — distinto de "não encontrado". */
+export function isDocumentosVazio(items: unknown[], offset: number): boolean {
+  return offset === 0 && items.length === 0;
+}

--- a/web/src/pages/processo.astro
+++ b/web/src/pages/processo.astro
@@ -1,0 +1,46 @@
+---
+import Layout from '../layouts/Layout.astro';
+import PageHeader from '../components/PageHeader.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import ProcessoLookup from '../components/ProcessoLookup.svelte';
+
+const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+---
+
+<Layout
+  title="Consultar Processo — CausaGanha"
+  description="Dossiê unificado de um processo (CNJ) reconciliado entre DJEN, JURIS (TJRO), STJ e DataJud."
+>
+  <PageHeader backHref={BASE} backLabel="Início" tile="consultas" title="Consultar Processo" subtitle="Cole um número CNJ para ver o que o acervo reconciliado já sabe sobre ele" />
+
+  <div class="container">
+    <Breadcrumbs crumbs={[
+      { label: 'Início', href: BASE },
+      { label: 'Consultar Processo' },
+    ]} />
+
+    <section>
+      <p>
+        Esta página consulta, diretamente no seu navegador via <strong>DuckDB-WASM</strong>, os dois
+        parquets de reconciliação hospedados no Internet Archive
+        (<code>processos_unificados.parquet</code> e <code>processo_documentos.parquet</code>,
+        item <a href="https://archive.org/details/causaganha-dashboard" target="_blank" rel="noopener noreferrer">causaganha-dashboard</a>).
+        Nenhum dado é enviado a servidores externos.
+      </p>
+      <p class="meta-text" data-tone="muted">
+        Cada CNJ é reconciliado a partir de até quatro fontes independentes — DJEN, JURIS (TJRO),
+        STJ e DataJud — sem fundir dados conflitantes: cada bloco abaixo indica explicitamente de
+        qual fonte ele vem, e a ausência de uma fonte é mostrada como tal, não omitida.
+      </p>
+    </section>
+
+    <ProcessoLookup client:only="svelte" />
+
+    <footer>
+      <small data-tone="muted">
+        Dados reconciliados via scripts/reconcile_processos.py. O DuckDB-WASM executa no
+        navegador — seus dados não saem do seu dispositivo.
+      </small>
+    </footer>
+  </div>
+</Layout>


### PR DESCRIPTION
## Description

New page: `/processo?cnj=<CNJ>` — a dossiê unificado for a single judicial process, reconciled across DJEN, TJRO JURIS, STJ and DataJud. This is the consumer-facing feature that `processos_unificados.parquet` / `processo_documentos.parquet` (added in #810) were built for.

**Why client-side DuckDB-WASM, not a pre-rendered route:** the site is a static GitHub Pages build (`output: 'static'`, no server) and there are millions of possible CNJs, so a per-CNJ static route (`getStaticPaths`) is not viable. The page instead reuses the exact pattern already running in production on the Explorador page — a Svelte component (`client:only="svelte"`) that runs parameterized SQL directly against the two parquets hosted on IA item `causaganha-dashboard`, via the existing `duckdbSingleton.ts`. No new backend/API surface.

**Requirements from review, all addressed:**

1. **Normalização do CNJ** — `processoCnj.ts` accepts masked or unmasked input, validates exactly 20 digits, and shows a distinct "CNJ inválido" message (not "processo não encontrado") for malformed input — verified not to depend on DuckDB even being ready.
2. **URL compartilhável** — search updates `?cnj=<mascarado>` via `history.replaceState`; on load, a present `cnj` param is read and the search runs automatically.
3. **Consulta restrita** — no `SELECT *`; both queries list only the columns rendered, filter `nr_processo` via a prepared-statement placeholder (never string interpolation), and `processo_documentos` paginates with `LIMIT ? OFFSET ?` plus a "carregar mais" button (fetches `pageSize+1` to detect "has more" without a separate `COUNT(*)`).
4. **Estados honestos** — `initializing` / `querying` / `invalid` / `not_found` / `source_unavailable` / found-with-no-documents are all distinct, separately rendered states (the documents fetch has its own independent error/empty state, since it can fail after the main record already loaded successfully).
5. **Proveniência visível** — every block (DataJud, DJEN, each document) is explicitly labeled with its source; an absent source renders an explicit "sem dados desta fonte" note instead of being silently blank or merged with another source's data.
6. **Estrutura da página** — masked-CNJ header → fontes-encontradas summary (completude % + dataset generation timestamp) → dados cadastrais (DataJud) → comunicações DJEN → documentos JURIS/STJ em linha do tempo.
7. **Testes** — `processoCnj.test.ts`, 36 tests, covering CNJ normalization/masking edge cases, URL param read/write round-trips, SQL builders (asserting no `SELECT *` and correct placeholders), pagination boundary cases, date/list/timestamp coercion from raw Arrow-shaped rows, multi-fonte / single-fonte / DataJud-absent row mapping, and the "processo localizado mas sem documentos" classifier.

## Fixed after review

- **Race between two searches**: once a search resolves to `found`, the submit button re-enables while its own `documentos` query is still in flight — a second search could complete first, and the first search's late `documentos` response would then silently overwrite the second search's results. Fixed with a monotonic `searchGeneration` counter: every `search()` call claims a new generation, and any async result (`processo` or `documentos`) whose captured generation no longer matches the current one is discarded instead of applied. Added `ProcessoLookup.test.ts` (component-level, `@testing-library/svelte` + a mocked `duckdbSingleton`) with two regressions: a stale `documentos` response is discarded once a newer search has already landed, and a stale `processo` response never surfaces once a newer search has already started.
- **Prepared statements left open on error**: `stmt.close()` only ran after a successful `query()` in both `search()` and `loadDocumentos()`. Moved into `finally` in both places.

## Verification

- `npm run lint` clean, `npm test` 197/197 green (36 pure-helper + 2 new component race tests), `npm run build` succeeds — 107 pages, `/processo.html` present with the `ProcessoLookup` island correctly wired.
- Live-checked in a real Chromium browser (Playwright): the CNJ-inválido path renders correctly and instantly, independent of DuckDB's own state. With deterministic network blocking (`page.route(...).abort()`), the DuckDB-init-failure banner and the "fonte indisponível" state both render exactly as designed, each with a working retry button.
- **Known verification gap, still open**: the not-encontrado / encontrado / "carregar mais" paths against the real IA-hosted parquets could not be exercised live. I retried this specifically for this update — including launching Chromium with `--proxy-server`/`--proxy-bypass-list` pointed at this sandbox's configured HTTPS proxy (which does let the browser reach `127.0.0.1` normally) — and a direct browser navigation to `archive.org` still resets the connection (`net::ERR_CONNECTION_RESET`), while the same URL is reachable via `curl` from the same sandbox. This looks like a browser-vs-proxy incompatibility specific to this sandbox (not a code issue), but it means the encontrado/não-encontrado/pagination paths are still unverified against real data — only against the schema-accurate unit tests and the identical, already-in-production `duckdb-wasm` query mechanism used by Explorador.

Not included in this v1, per review: pre-rendering a curated top-N CNJ set for SEO. That's deferred to a second iteration based on usage evidence, not built in speculatively.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main.
