### PR TITLE
fix(ci): drop hourly cron from STJ & TJRO Sync — 30/30 scheduled runs red

### DIFF
--- a/.github/workflows/stj-tjro-sync.yml
+++ b/.github/workflows/stj-tjro-sync.yml
@@ -2,26 +2,9 @@
 # STJ & TJRO SYNC — Manual ingestion of STJ acórdãos and TJRO JURIS corpus
 # ============================================================================
 #
-# workflow_dispatch only — NO cron. The hourly `schedule:` this workflow
-# previously ran was itself a deviation from RFC 0008 (docs/rfc/0008-testes-
-# operacionalizacao-stj-tjro.md), which specified workflow_dispatch-only
-# "until the owner turns cron on after successful manual runs" — that never
-# happened before the schedule was added, and the result was 30+ consecutive
-# hourly failures (2026-07-10 through 2026-07-12) with no successful
-# scheduled run in between. Root causes for those specific failures (not
-# infra-only): STJ's dedup step hit a DuckDB `BinderException` from a
-# positional `UNION ALL` breaking on cross-year JSON schema drift; TJRO's
-# crawl hit HTTP 500s from `juris-back.tjro.jus.br` consistent with a stale
-# API contract. Both are fixed, along with a genuine GitHub-Actions-runner
-# network block for TJRO (ConnectTimeout) and a suspected WAF block for STJ,
-# in PR #805, which also splits this file into `stj-sync.yml` /
-# `tjro-sync.yml` (both workflow_dispatch-only) and updates RFC 0008
-# accordingly. This change only removes the predictably-red cron from the
-# file that is live on `main` today, so the two sources stop failing hourly
-# in the meantime — it does not re-litigate PR #805's WAF/network diagnosis.
-#
-# Operational rule (per the RFC): only re-add a `schedule:` trigger after
-# two consecutive green workflow_dispatch runs, with owner sign-off.
+# Manual-only while STJ/TJRO ingestion is being stabilized.
+# Per RFC 0008, restore a schedule only after successful supervised runs
+# and explicit owner approval.
 #
 # Two independent jobs:
 #   stj  — `stj-acordaos download` + `stj-acordaos upload` (CKAN → dedup → IA)

--- a/.github/workflows/stj-tjro-sync.yml
+++ b/.github/workflows/stj-tjro-sync.yml
@@ -2,10 +2,26 @@
 # STJ & TJRO SYNC — Manual ingestion of STJ acórdãos and TJRO JURIS corpus
 # ============================================================================
 #
-# Hourly cron + workflow_dispatch. Scheduled runs are incremental: both
-# CLIs dedup against their IA manifests, and the TJRO crawl is limited to
-# the current year (full/backfill crawls stay available via dispatch).
-# The concurrency group queues (not cancels) if a previous run overruns.
+# workflow_dispatch only — NO cron. The hourly `schedule:` this workflow
+# previously ran was itself a deviation from RFC 0008 (docs/rfc/0008-testes-
+# operacionalizacao-stj-tjro.md), which specified workflow_dispatch-only
+# "until the owner turns cron on after successful manual runs" — that never
+# happened before the schedule was added, and the result was 30+ consecutive
+# hourly failures (2026-07-10 through 2026-07-12) with no successful
+# scheduled run in between. Root causes for those specific failures (not
+# infra-only): STJ's dedup step hit a DuckDB `BinderException` from a
+# positional `UNION ALL` breaking on cross-year JSON schema drift; TJRO's
+# crawl hit HTTP 500s from `juris-back.tjro.jus.br` consistent with a stale
+# API contract. Both are fixed, along with a genuine GitHub-Actions-runner
+# network block for TJRO (ConnectTimeout) and a suspected WAF block for STJ,
+# in PR #805, which also splits this file into `stj-sync.yml` /
+# `tjro-sync.yml` (both workflow_dispatch-only) and updates RFC 0008
+# accordingly. This change only removes the predictably-red cron from the
+# file that is live on `main` today, so the two sources stop failing hourly
+# in the meantime — it does not re-litigate PR #805's WAF/network diagnosis.
+#
+# Operational rule (per the RFC): only re-add a `schedule:` trigger after
+# two consecutive green workflow_dispatch runs, with owner sign-off.
 #
 # Two independent jobs:
 #   stj  — `stj-acordaos download` + `stj-acordaos upload` (CKAN → dedup → IA)
@@ -15,8 +31,6 @@
 name: STJ & TJRO Sync
 
 on:
-  schedule:
-    - cron: '7 * * * *'
   workflow_dispatch:
     inputs:
       run_stj:
@@ -51,8 +65,7 @@ concurrency:
 jobs:
   stj:
     name: STJ acórdãos (download + upload)
-    # inputs.* is empty on schedule events — gate must pass for cron runs
-    if: ${{ github.event_name == 'schedule' || inputs.run_stj }}
+    if: ${{ inputs.run_stj }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: dev
@@ -95,8 +108,7 @@ jobs:
 
   tjro:
     name: TJRO JURIS (crawl + upload)
-    # inputs.* is empty on schedule events — gate must pass for cron runs
-    if: ${{ github.event_name == 'schedule' || inputs.run_tjro }}
+    if: ${{ inputs.run_tjro }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: dev
@@ -116,11 +128,6 @@ jobs:
         run: |
           ANO="${{ inputs.tjro_ano }}"
           TIPOS="${{ inputs.tjro_tipos }}"
-
-          # Scheduled runs stay incremental: restrict to the current year
-          if [ "${{ github.event_name }}" = "schedule" ] && [ -z "$ANO" ]; then
-            ANO="$(date -u +%Y)"
-          fi
 
           CMD="uv run --no-dev tjro-juris crawl data/tjro-juris"
           if [ -n "$ANO" ]; then


### PR DESCRIPTION
## Description

Audit of `main`, PR #805, and issue #809 (full write-up in the originating task). This PR is the one small, unambiguous, safe fix that came out of it — everything else is either already handled by PR #805 or requires a product decision / new contract and is left as a plan.

**What's live on `main` today:** `.github/workflows/stj-tjro-sync.yml` runs `cron: '7 * * * *'` (hourly). I pulled all 30 scheduled runs visible in the Actions history (2026-07-10 → 2026-07-12): **30/30 failed.** Job logs for both sources show real, reproducing causes, not just "flaky infra":

- **STJ**: `stj-acordaos upload` raises a DuckDB `BinderException` ("Set operations can only apply to expressions with matching...") — `dedup_acordaos` does a positional `UNION ALL` across per-year JSON files whose columns drift over the years. This is a genuine code bug, currently reproducing on every run that actually downloads a changed resource.
- **TJRO**: `tjro-juris crawl` gets `HTTPStatusError: 500 Internal Server Error` from `https://juris-back.tjro.jus.br/search/varios_parametros/` — consistent with the client sending a stale/pre-migration request shape.

Neither of these is what I'd call "blocked by WAF" or "blocked by network" on `main`'s current code — both requests *reach* the server and get a real response back. (STJ's WAF and TJRO's GitHub-runner `ConnectTimeout` are real too, but they show up on the **already-fixed** client code on PR #805's branch, not on `main` as it stands today — worth keeping the two failure modes distinct.)

The hourly `schedule:` was also never supposed to be here yet: `docs/rfc/0008-testes-operacionalizacao-stj-tjro.md` (the RFC that introduced this workflow) explicitly specifies **workflow_dispatch only, "turning on cron is the owner's decision after successful manual runs."** No successful manual run preceded the cron being added.

**What this PR does:** removes the `schedule:` trigger (and the two `github.event_name == 'schedule'` conditionals it made necessary) from `stj-tjro-sync.yml`, restoring RFC 0008's original, already-approved rollout plan. `workflow_dispatch` (with its `run_stj`/`run_tjro`/`skip_upload` inputs) is untouched and fully functional — note dispatching it with no input overrides still runs both sources with upload enabled (`run_stj`/`run_tjro` default `true`, `skip_upload` default `false`); that's pre-existing dispatch behavior, not something this PR changes, but worth knowing operationally before triggering it.

**What this PR deliberately does *not* do:**
- Does not touch PR #805 or its branch (`claude/project-next-steps-7vaswi`) — that PR already fixes both root causes above, splits this file into `stj-sync.yml`/`tjro-sync.yml` (both `workflow_dispatch`-only, no cron, no push trigger — confirmed by reading its current HEAD diff directly), fixes the WAF/timeout fail-fast behavior, updates RFC 0008, and is CI-green. It's pending the owner's sign-off on the TJRO infra read, which is a product decision, not a mechanical one — not mine to make.
- Does not touch STJ/TJRO Python source, tests, or the `/publicacoes/[tribunal]` frontend page (issue #809) — out of scope for this fix, and #809 needs a new `.qmd` contract + product decisions before any code should move, per the audit.
- Does not trigger any STJ/TJRO collection, backfill, or IA upload.

Once #805 merges, it supersedes this workflow by deleting the file. If #813 merges first, updating #805 may produce a trivial modify/delete conflict; resolve it by keeping #805's deletion.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`) — parses, `on:` contains only `workflow_dispatch`, no `schedule` anywhere in the doc.
- [x] `uv run pytest tests/stj_acordaos tests/tjro_juris -q` — 80/80 passed (baseline unchanged; this PR touches no Python).
- [x] `uv run ruff check` / `uv run ruff format --check` — clean (no Python files touched).
- [x] Read the last 30 scheduled-run job logs directly via the GitHub Actions API to confirm the failure pattern and root causes quoted above, rather than trusting PR #805's self-description.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. — N/A, no CLI flags changed.
