### PR TITLE
feat(relay): Cloud Run HTTP relay unblocks STJ/TJRO from GitHub runners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,17 @@ IA_ACCESS_KEY=your_ia_access_key_here
 IA_SECRET_KEY=your_ia_secret_key_here
 
 # =============================================================================
+# HTTP RELAY (STJ / TJRO — bypasses GitHub-runner IP blocks in CI)
+# =============================================================================
+# Optional. Only needed in CI (stj-sync.yml / tjro-sync.yml crawl steps),
+# where the STJ WAF blocks GitHub-hosted runner IPs and TJRO connect-times-out
+# from them. Local/dev runs should leave both unset — src/common/relay.py
+# falls back to a direct connection when either is missing. See
+# deployment/relay/ for the Cloud Run function this points at.
+# RELAY_URL=https://southamerica-east1-<project>.cloudfunctions.net/relay
+# RELAY_TOKEN=your_relay_token_here
+
+# =============================================================================
 # PIPELINE CONFIGURATION
 # =============================================================================
 # DJEN access mode

--- a/.github/workflows/stj-sync.yml
+++ b/.github/workflows/stj-sync.yml
@@ -2,12 +2,14 @@
 # STJ SYNC — Ingestion of STJ acórdãos (Primeira Seção) to Internet Archive
 # ============================================================================
 #
-# workflow_dispatch only — NO cron. The STJ WAF blocks GitHub-hosted runner
-# IP ranges persistently (confirmed via authenticated CI logs: every
-# scheduled attempt fails with STJWAFBlockedError after 4 retries). A GitHub-
-# hosted runner cannot out-retry an IP-range block, so a cron here would be
-# pure noise, not signal — trigger manually until a self-hosted runner,
-# proxy, or other infrastructure with a non-blocked egress IP is available.
+# The STJ WAF blocks GitHub-hosted runner IP ranges persistently (confirmed
+# via authenticated CI logs: every scheduled attempt failed with
+# STJWAFBlockedError after 4 retries). A GitHub-hosted runner cannot
+# out-retry an IP-range block, so downloads route through a Cloud Run
+# function relay (southamerica-east1, validated live 2026-07-13 — see
+# deployment/relay/) via RELAY_URL/RELAY_TOKEN, set only on the download
+# step (see common.relay). Upload to IA never goes through the relay — it
+# isn't blocked and doesn't need to be.
 # Runs are incremental: the CLI restores its manifest from IA and skips
 # resources already uploaded with unchanged last_modified. A WAF block fails
 # fast (STJWAFBlockedError) instead of grinding through every remaining
@@ -57,7 +59,12 @@ jobs:
       # while the API stays up for everyone else. The download step retries
       # 403/429/5xx with exponential backoff and raises STJWAFBlockedError
       # with an explicit diagnosis when the block persists (stj_acordaos/client.py).
+      # RELAY_URL/RELAY_TOKEN route the request through the Cloud Run relay
+      # instead — scoped to this step only, never the upload step below.
       - name: Download STJ resources
+        env:
+          RELAY_URL: ${{ secrets.RELAY_URL }}
+          RELAY_TOKEN: ${{ secrets.RELAY_TOKEN }}
         run: |
           uv run --no-dev stj-acordaos download \
             --data-dir data/stj \

--- a/.github/workflows/stj-sync.yml
+++ b/.github/workflows/stj-sync.yml
@@ -17,11 +17,18 @@
 #
 # Split from the former stj-tjro-sync.yml so a TJRO failure can't mask an
 # STJ failure (and vice versa) — see tjro-sync.yml for the other corpus.
+#
+# Cron reactivated 2026-07-14 after a live workflow_dispatch run through the
+# relay came back green with real data (51 manifest entries). 07:00 UTC =
+# 04:00 BR, outside business hours; distinct from tjro-sync.yml's 09:00 UTC
+# so the two crawls don't overlap on the relay.
 # ============================================================================
 
 name: STJ Sync
 
 on:
+  schedule:
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       skip_upload:

--- a/.github/workflows/tjro-sync.yml
+++ b/.github/workflows/tjro-sync.yml
@@ -20,11 +20,18 @@
 #
 # Split from the former stj-tjro-sync.yml so an STJ failure can't mask a
 # TJRO failure (and vice versa) — see stj-sync.yml for the other corpus.
+#
+# Cron reactivated 2026-07-14 after a live workflow_dispatch run through the
+# relay came back green with real data (6 manifest entries, all uploaded).
+# 09:00 UTC = 06:00 BR, outside business hours; distinct from stj-sync.yml's
+# 07:00 UTC so the two crawls don't overlap on the relay.
 # ============================================================================
 
 name: TJRO Sync
 
 on:
+  schedule:
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       tjro_ano:

--- a/.github/workflows/tjro-sync.yml
+++ b/.github/workflows/tjro-sync.yml
@@ -2,22 +2,16 @@
 # TJRO SYNC — Ingestion of the TJRO JURIS corpus to Internet Archive
 # ============================================================================
 #
-# workflow_dispatch only — NO cron, provisionally, pending investigation.
 # Four consecutive acceptance runs on GitHub-hosted runners failed
 # identically with ConnectTimeout on the very first request to
-# juris-back.tjro.jus.br/search/varios_parametros/, after exhausting all 4
-# retry attempts with backoff (~2m20s each). The same request succeeds
-# immediately (HTTP 200, ~200ms connect) from a different network path, and
-# a full live crawl from that same path (all 7 tipos, current month, 12,853
-# docs, 0 duplicates/nulls) completed cleanly — JURIS itself and this code
-# are both healthy. This looks like the same class of problem as STJ's WAF
-# block (an infra-level block/drop against GitHub's IP ranges), just
-# manifesting as a connection failure instead of an HTTP 403. Applying the
-# owner's STJ policy symmetrically: a GitHub-hosted runner cannot out-retry
-# a network-level block, so an hourly cron here would be noise, not signal,
-# until this is confirmed intermittent vs. persistent (or a self-hosted
-# runner / proxy is available). Trigger manually until then; re-enabling
-# the schedule is a one-line change once resolved.
+# juris-back.tjro.jus.br/search/varios_parametros/. The same request
+# succeeds immediately (HTTP 200, ~200ms connect) from a different network
+# path — same class of problem as STJ's WAF block (an infra-level
+# block/drop against GitHub's IP ranges). The crawl step now routes through
+# a Cloud Run function relay (southamerica-east1, validated live
+# 2026-07-13 — see deployment/relay/) via RELAY_URL/RELAY_TOKEN (see
+# common.relay), scoped to the crawl step only — upload to IA isn't blocked
+# and doesn't go through the relay.
 #
 # Scheduled-style runs are incremental when dispatched: the CLI restores its
 # manifest from IA, crawls ONLY the current month (--mes), and skips
@@ -74,6 +68,9 @@ jobs:
           dev: "false"
 
       - name: Crawl JURIS
+        env:
+          RELAY_URL: ${{ secrets.RELAY_URL }}
+          RELAY_TOKEN: ${{ secrets.RELAY_TOKEN }}
         run: |
           ANO="${{ inputs.tjro_ano }}"
           MES="${{ inputs.tjro_mes }}"

--- a/deployment/relay/README.md
+++ b/deployment/relay/README.md
@@ -1,0 +1,98 @@
+# HTTP relay (STJ / TJRO)
+
+Cloud Run function (gen2, Python 3.12, `southamerica-east1`) that forwards a
+single HTTP request to an allowlisted host (`*.stj.jus.br`, `*.tjro.jus.br`).
+Exists because GitHub-hosted runners are blocked at the network level for
+both sources — STJ's WAF returns 403 for runner IP ranges
+(`STJWAFBlockedError`), and TJRO's backend times out connecting from them —
+while this function's egress IP is not blocked (validated live, 2026-07-13,
+before any of this was built — see the Fase 0 note below).
+
+Serverless platforms don't support proxy `CONNECT`, so the repo routes
+through this via a custom httpx transport (`src/common/relay.py`) instead of
+`HTTPS_PROXY`: the destination URL travels in an `X-Relay-Url` header, and
+the relay forwards method/body/headers to it directly.
+
+## Why this exists (Fase 0)
+
+Before writing any of this, a throwaway `probe` function was deployed to the
+same region to confirm serverless egress IPs aren't *also* blocked (Google's
+IP ranges are a plausible target too). It made the exact same GET/POST the
+real crawlers make and got back real content in both cases (STJ: CKAN JSON;
+TJRO: Elasticsearch hits, ~3s). The probe function was deleted immediately
+after — it was never part of the relay.
+
+## Deploying
+
+```bash
+# One-time: create the shared-secret token (rotate by adding a new version
+# and redeploying — the function always reads `:latest`).
+openssl rand -base64 32 | tr -d '\n' > /tmp/relay-token.txt
+gcloud secrets create relay-token --data-file=/tmp/relay-token.txt
+# (or, to rotate an existing secret: gcloud secrets versions add relay-token --data-file=/tmp/relay-token.txt)
+
+gcloud secrets add-iam-policy-binding relay-token \
+  --member="serviceAccount:<PROJECT_NUMBER>-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Deploy the relay function.
+cd deployment/relay/function
+gcloud functions deploy relay \
+  --gen2 \
+  --runtime=python312 \
+  --region=southamerica-east1 \
+  --source=. \
+  --entry-point=relay \
+  --trigger-http \
+  --allow-unauthenticated \
+  --memory=256Mi \
+  --timeout=120s \
+  --set-secrets="RELAY_TOKEN=relay-token:latest"
+```
+
+`--allow-unauthenticated` is safe here because authorization is enforced by
+the application itself (`X-Relay-Token`, constant-time compared) plus the
+host allowlist — not by IAM. Rotating to `--no-allow-unauthenticated` +
+Workload Identity Federation from GitHub Actions is a reasonable hardening
+step later, but wasn't required for this delivery.
+
+## Validating after deploy
+
+```bash
+RELAY_URL="$(gcloud functions describe relay --region=southamerica-east1 --gen2 --format='value(serviceConfig.uri)')"
+TOKEN="$(gcloud secrets versions access latest --secret=relay-token)"
+
+# STJ — real content, not a WAF challenge page
+curl -s -H "X-Relay-Url: https://dadosabertos.web.stj.jus.br/api/3/action/package_show?id=a96a175b-a54b-4bfd-82b8-fcd7cc0200bc" \
+     -H "X-Relay-Token: $TOKEN" "$RELAY_URL" | head -c 300
+
+# TJRO — POST, real ES hits
+curl -s -H "X-Relay-Url: https://juris-back.tjro.jus.br/search/varios_parametros/" \
+     -H "X-Relay-Token: $TOKEN" -H "Content-Type: application/json" \
+     -d '{"from":0,"size":1,"fields":{"tipo.raw":["ACÓRDÃO"]},"sort":[{"dtjulgamento":"desc"},{"_score":"desc"},{"id_processo_documento":"asc"}]}' \
+     "$RELAY_URL" | head -c 300
+
+# Allowlist rejection — expect 403
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-Relay-Url: https://example.com/" -H "X-Relay-Token: $TOKEN" "$RELAY_URL"
+
+# Missing token — expect 401
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-Relay-Url: https://dadosabertos.web.stj.jus.br/" "$RELAY_URL"
+```
+
+## Cost
+
+Gen2 Cloud Run functions free tier: 2M invocations/month, 360k GB-seconds,
+180k vCPU-seconds. At 256Mi/~0.17 vCPU and a few hundred requests/day
+(dozens to low hundreds per sync run, well under 1k/day), this stays inside
+the free tier by a wide margin — expected cost is $0/month.
+
+## Repo-side wiring
+
+- `src/common/relay.py` — `RelayTransport`/`AsyncRelayTransport`, activated
+  by `RELAY_URL`/`RELAY_TOKEN` env vars; falls back to a direct connection
+  when either is unset (local/dev default, zero impact).
+- `src/stj_acordaos/client.py`, `src/tjro_juris/client.py` — pass
+  `transport=relay_transport_from_env()` into their `httpx.Client`.
+- `.github/workflows/stj-sync.yml`, `tjro-sync.yml` — `RELAY_URL`/
+  `RELAY_TOKEN` (GitHub Secrets) are exported **only** on the
+  download/crawl step, never on the IA upload step.

--- a/deployment/relay/function/__init__.py
+++ b/deployment/relay/function/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud Run relay function deployment source (deployment/relay/README.md)."""

--- a/deployment/relay/function/main.py
+++ b/deployment/relay/function/main.py
@@ -57,6 +57,14 @@ _STRIP_HEADERS = frozenset(
     }
 )
 
+# httpx's client transparently gunzips the upstream response into
+# `.content` — the bytes we return are already decoded. Forwarding the
+# upstream's original Content-Encoding header alongside that decoded body
+# makes the CALLER's httpx try to gunzip it a second time and raise
+# DecodingError. Response-only: request-side Content-Encoding (basically
+# never sent by these crawlers) is left alone.
+_RESPONSE_STRIP_HEADERS = _STRIP_HEADERS | {"content-encoding"}
+
 _RELAY_TOKEN = os.environ.get("RELAY_TOKEN", "")
 
 # One shared client for the function instance's lifetime — connection reuse
@@ -131,6 +139,8 @@ def relay(request: Request) -> Response | tuple[str, int] | tuple[bytes, int, di
     )
 
     response_headers = {
-        key: value for key, value in upstream.headers.items() if key.lower() not in _STRIP_HEADERS
+        key: value
+        for key, value in upstream.headers.items()
+        if key.lower() not in _RESPONSE_STRIP_HEADERS
     }
     return (upstream.content, upstream.status_code, response_headers)

--- a/deployment/relay/function/main.py
+++ b/deployment/relay/function/main.py
@@ -1,0 +1,136 @@
+"""HTTP relay: forwards a single request to an allowlisted destination host.
+
+Built because Cloud Run functions (gen2, southamerica-east1) can reach both
+scon.stj.jus.br and juris-back.tjro.jus.br with real content — validated in
+Fase 0 with a throwaway probe function before this was written (GitHub
+Actions runners are blocked; these serverless egress IPs are not, as of
+2026-07-13). This is not an open proxy: only *.stj.jus.br and *.tjro.jus.br
+are forwardable, and every request must carry a valid ``X-Relay-Token``.
+
+Contract:
+- Destination URL comes in the ``X-Relay-Url`` request header.
+- Auth via ``X-Relay-Token`` (constant-time compare against the
+  ``RELAY_TOKEN`` env var, sourced from Secret Manager at deploy time).
+- Method, body and headers are forwarded as-is (minus hop-by-hop and
+  ``X-Relay-*`` headers); ``Host`` is rewritten to the destination host.
+- Redirects are NOT followed — the 3xx is returned to the caller, who
+  decides whether to follow it back through the relay.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import functions_framework
+import httpx
+
+
+if TYPE_CHECKING:
+    from flask import Request, Response
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("relay")
+
+_ALLOWED_SUFFIXES = (".stj.jus.br", ".tjro.jus.br")
+_ALLOWED_EXACT = frozenset({"stj.jus.br", "tjro.jus.br"})
+
+# Headers that must never be blindly forwarded: hop-by-hop headers (RFC 9110
+# §7.6.1) plus Content-Length (httpx recomputes it from the body it sends)
+# and Host (rewritten explicitly to the destination's host below).
+_STRIP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "content-length",
+        "host",
+    }
+)
+
+_RELAY_TOKEN = os.environ.get("RELAY_TOKEN", "")
+
+# One shared client for the function instance's lifetime — connection reuse
+# across warm invocations, same rationale as the repo's own tjro_juris client.
+_client = httpx.Client(timeout=60, follow_redirects=False)
+
+
+def _host_allowed(hostname: str | None) -> bool:
+    """True if *hostname* is under the STJ/TJRO allowlist."""
+    if not hostname:
+        return False
+    hostname = hostname.lower()
+    return hostname in _ALLOWED_EXACT or hostname.endswith(_ALLOWED_SUFFIXES)
+
+
+def _token_valid(request: Request) -> bool:
+    """Constant-time check of ``X-Relay-Token`` against ``RELAY_TOKEN``."""
+    supplied = request.headers.get("X-Relay-Token", "")
+    if not _RELAY_TOKEN or not supplied:
+        return False
+    # Compare as bytes — hmac.compare_digest rejects non-ASCII str inputs,
+    # and header values may arrive latin-1-decoded by werkzeug.
+    return hmac.compare_digest(supplied.encode("utf-8"), _RELAY_TOKEN.encode("utf-8"))
+
+
+def _forward_headers(request: Request, target_host: str) -> dict[str, str]:
+    """Client headers minus hop-by-hop/``X-Relay-*``, with ``Host`` rewritten."""
+    headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() not in _STRIP_HEADERS and not key.lower().startswith("x-relay-")
+    }
+    headers["Host"] = target_host
+    return headers
+
+
+@functions_framework.http
+def relay(request: Request) -> Response | tuple[str, int] | tuple[bytes, int, dict[str, str]]:
+    """Forward *request* to the host named in ``X-Relay-Url``, allowlist-checked."""
+    if not _token_valid(request):
+        return ("unauthorized", 401)
+
+    target_url = request.headers.get("X-Relay-Url", "")
+    parsed = urlparse(target_url)
+    host_ok = _host_allowed(parsed.hostname)
+    if not target_url or parsed.scheme not in ("http", "https") or not host_ok:
+        return ("forbidden: destination host not in allowlist", 403)
+
+    method = request.method
+    body = request.get_data() or None
+    headers = _forward_headers(request, parsed.hostname)
+
+    start = time.monotonic()
+    try:
+        upstream = _client.request(method, target_url, headers=headers, content=body)
+    except httpx.HTTPError as exc:
+        logger.info(
+            "relay_upstream_error method=%s host=%s error=%s elapsed_s=%.2f",
+            method,
+            parsed.hostname,
+            type(exc).__name__,
+            time.monotonic() - start,
+        )
+        return (f"upstream error: {type(exc).__name__}", 502)
+
+    logger.info(
+        "relay_ok method=%s host=%s status=%s elapsed_s=%.2f",
+        method,
+        parsed.hostname,
+        upstream.status_code,
+        time.monotonic() - start,
+    )
+
+    response_headers = {
+        key: value for key, value in upstream.headers.items() if key.lower() not in _STRIP_HEADERS
+    }
+    return (upstream.content, upstream.status_code, response_headers)

--- a/deployment/relay/function/requirements.txt
+++ b/deployment/relay/function/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.*
+httpx==0.28.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ dev = [
     "pytest-cov>=6.2.1",
     "respx>=0.22.0",
     "ruff>=0.12.0",
+    # Runtime of deployment/relay/function/main.py (Cloud Run relay) — needed
+    # to import and unit-test it; not used anywhere else in the repo.
+    "functions-framework>=3.0.0",
     "pip-audit>=2.7.2",
     "safety>=3.2.0",
     "mkdocs>=1.6.1",

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,3 @@
+"""Shared helpers used across causaganha's crawler packages."""
+
+from __future__ import annotations

--- a/src/common/relay.py
+++ b/src/common/relay.py
@@ -1,0 +1,114 @@
+"""httpx transport that routes requests through the causaganha relay.
+
+GitHub-hosted runners are blocked by the STJ WAF (``STJWAFBlockedError``) and
+time out connecting to ``juris-back.tjro.jus.br`` — but a Cloud Run function
+in ``southamerica-east1`` reaches both with real content (validated live,
+2026-07-13; see ``deployment/relay/``). Serverless platforms don't support
+proxy ``CONNECT``, so this routes traffic via a custom transport instead of
+``HTTPS_PROXY``: the transport swaps the request's URL for the relay
+function's URL, and moves the original destination into the ``X-Relay-Url``
+header for the relay to forward to.
+
+Activated purely by env (``RELAY_URL`` + ``RELAY_TOKEN``); if either is
+unset, callers get ``None`` back and fall through to a direct connection —
+zero behavior change for local/dev runs that don't opt in.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+
+_RELAY_URL_ENV = "RELAY_URL"
+_RELAY_TOKEN_ENV = "RELAY_TOKEN"  # noqa: S105 — env var name, not a credential
+
+
+def _relay_env() -> tuple[str, str] | None:
+    url = os.environ.get(_RELAY_URL_ENV)
+    token = os.environ.get(_RELAY_TOKEN_ENV)
+    if not url or not token:
+        return None
+    return url, token
+
+
+def _build_relayed_request(
+    request: httpx.Request, relay_url: str, relay_token: str
+) -> httpx.Request:
+    """Rebuild *request* targeting the relay, original URL/token in headers."""
+    headers = httpx.Headers(request.headers)
+    headers["X-Relay-Url"] = str(request.url)
+    headers["X-Relay-Token"] = relay_token
+    # Recompute Host for the relay's own hostname — otherwise the relay's
+    # HTTP server sees a Host header for the original destination.
+    headers["host"] = httpx.URL(relay_url).host
+    return httpx.Request(
+        method=request.method,
+        url=relay_url,
+        headers=headers,
+        stream=request.stream,
+        extensions=request.extensions,
+    )
+
+
+class RelayTransport(httpx.BaseTransport):
+    """Synchronous transport that forwards every request through the relay."""
+
+    def __init__(
+        self,
+        relay_url: str,
+        relay_token: str,
+        *,
+        inner: httpx.BaseTransport | None = None,
+    ) -> None:
+        """Wrap *inner* (default: a real ``httpx.HTTPTransport``) with relay rewriting."""
+        self._relay_url = relay_url
+        self._relay_token = relay_token
+        self._inner = inner or httpx.HTTPTransport()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """Rewrite *request* to the relay and delegate to the inner transport."""
+        relayed = _build_relayed_request(request, self._relay_url, self._relay_token)
+        return self._inner.handle_request(relayed)
+
+    def close(self) -> None:
+        """Close the inner transport."""
+        self._inner.close()
+
+
+class AsyncRelayTransport(httpx.AsyncBaseTransport):
+    """Async counterpart of :class:`RelayTransport`."""
+
+    def __init__(
+        self,
+        relay_url: str,
+        relay_token: str,
+        *,
+        inner: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        """Wrap *inner* (default: a real ``httpx.AsyncHTTPTransport``) with relay rewriting."""
+        self._relay_url = relay_url
+        self._relay_token = relay_token
+        self._inner = inner or httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Rewrite *request* to the relay and delegate to the inner transport."""
+        relayed = _build_relayed_request(request, self._relay_url, self._relay_token)
+        return await self._inner.handle_async_request(relayed)
+
+    async def aclose(self) -> None:
+        """Close the inner transport."""
+        await self._inner.aclose()
+
+
+def relay_transport_from_env() -> RelayTransport | None:
+    """Build a :class:`RelayTransport` from ``RELAY_URL``/``RELAY_TOKEN``, or ``None``."""
+    env = _relay_env()
+    return RelayTransport(*env) if env else None
+
+
+def async_relay_transport_from_env() -> AsyncRelayTransport | None:
+    """Build an :class:`AsyncRelayTransport` from env, or ``None`` if unset."""
+    env = _relay_env()
+    return AsyncRelayTransport(*env) if env else None

--- a/src/stj_acordaos/client.py
+++ b/src/stj_acordaos/client.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 import httpx
 import structlog
 
+from common.relay import relay_transport_from_env
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -56,8 +58,18 @@ class STJWAFBlockedError(httpx.HTTPStatusError):
 
 
 def _make_client() -> httpx.Client:
-    """Create a configured synchronous HTTP client."""
-    return httpx.Client(timeout=120, follow_redirects=True, headers=_BROWSER_HEADERS)
+    """Create a configured synchronous HTTP client.
+
+    Routes through the relay (see ``common.relay``) when ``RELAY_URL``/
+    ``RELAY_TOKEN`` are set — used in CI, where the STJ WAF blocks GitHub
+    runner IP ranges. Direct connection otherwise (local/dev default).
+    """
+    return httpx.Client(
+        timeout=120,
+        follow_redirects=True,
+        headers=_BROWSER_HEADERS,
+        transport=relay_transport_from_env(),
+    )
 
 
 def _sleep(seconds: float) -> None:

--- a/src/tjro_juris/client.py
+++ b/src/tjro_juris/client.py
@@ -31,6 +31,8 @@ from urllib.parse import urlencode
 import httpx
 import structlog
 
+from common.relay import relay_transport_from_env
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -81,10 +83,15 @@ _SORT_RECENT = [
 # One shared client for the whole crawl: connection reuse (keep-alive) makes a
 # multi-thousand-request crawl far less likely to hit connect timeouts than
 # opening a fresh TCP+TLS handshake per request.
+#
+# transport routes through the relay (see common.relay) when RELAY_URL/
+# RELAY_TOKEN are set — used in CI, where runner egress ConnectTimeouts on
+# juris-back.tjro.jus.br. Direct connection otherwise (local/dev default).
 _CLIENT = httpx.Client(
     timeout=30,
     headers=_HEADERS,
     limits=httpx.Limits(max_connections=4, max_keepalive_connections=2),
+    transport=relay_transport_from_env(),
 )
 
 

--- a/tests/common/test_relay.py
+++ b/tests/common/test_relay.py
@@ -1,0 +1,111 @@
+"""Tests for common.relay — the RELAY_URL/RELAY_TOKEN httpx transport.
+
+Verifies the transport rewrites the request to the relay URL, moves the
+original destination + token into headers, and passes method/body through
+untouched — using httpx.MockTransport as the "inner" transport so no real
+network call happens.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from common.relay import (
+    AsyncRelayTransport,
+    RelayTransport,
+    async_relay_transport_from_env,
+    relay_transport_from_env,
+)
+
+
+RELAY_URL = "https://relay-abc.a.run.app/"
+RELAY_TOKEN = "s3cr3t-token"  # noqa: S105 — test fixture, not a real credential
+ORIGINAL_URL = "https://juris-back.tjro.jus.br/search/varios_parametros/"
+
+
+def test_relay_transport_rewrites_url_and_headers() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = RelayTransport(RELAY_URL, RELAY_TOKEN, inner=httpx.MockTransport(handler))
+    with httpx.Client(transport=transport) as client:
+        resp = client.post(
+            ORIGINAL_URL,
+            json={"tipo": "ACÓRDÃO"},
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    sent = captured[0]
+    assert str(sent.url) == RELAY_URL
+    assert sent.headers["X-Relay-Url"] == ORIGINAL_URL
+    assert sent.headers["X-Relay-Token"] == RELAY_TOKEN
+    assert sent.headers["Content-Type"] == "application/json"
+    assert sent.method == "POST"
+    assert json.loads(sent.read()) == {"tipo": "ACÓRDÃO"}
+
+
+def test_relay_transport_preserves_method_and_body() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, text="ok")
+
+    transport = RelayTransport(RELAY_URL, RELAY_TOKEN, inner=httpx.MockTransport(handler))
+    with httpx.Client(transport=transport) as client:
+        client.get(ORIGINAL_URL, headers={"Accept": "application/json"})
+
+    sent = captured[0]
+    assert sent.method == "GET"
+    assert sent.headers["Accept"] == "application/json"
+    assert sent.read() == b""
+
+
+@pytest.mark.asyncio
+async def test_async_relay_transport_rewrites_url_and_headers() -> None:
+    captured: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = AsyncRelayTransport(RELAY_URL, RELAY_TOKEN, inner=httpx.MockTransport(handler))
+    async with httpx.AsyncClient(transport=transport) as client:
+        resp = await client.post(ORIGINAL_URL, json={"from": 0, "size": 1})
+
+    assert resp.status_code == 200
+    sent = captured[0]
+    assert str(sent.url) == RELAY_URL
+    assert sent.headers["X-Relay-Url"] == ORIGINAL_URL
+    assert sent.headers["X-Relay-Token"] == RELAY_TOKEN
+    assert sent.method == "POST"
+
+
+def test_relay_transport_from_env_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RELAY_URL", raising=False)
+    monkeypatch.delenv("RELAY_TOKEN", raising=False)
+    assert relay_transport_from_env() is None
+    assert async_relay_transport_from_env() is None
+
+
+def test_relay_transport_from_env_builds_when_both_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RELAY_URL", RELAY_URL)
+    monkeypatch.setenv("RELAY_TOKEN", RELAY_TOKEN)
+    transport = relay_transport_from_env()
+    assert isinstance(transport, RelayTransport)
+    async_transport = async_relay_transport_from_env()
+    assert isinstance(async_transport, AsyncRelayTransport)
+
+
+def test_relay_transport_from_env_none_when_only_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RELAY_URL", RELAY_URL)
+    monkeypatch.delenv("RELAY_TOKEN", raising=False)
+    assert relay_transport_from_env() is None

--- a/tests/deployment/relay/test_main.py
+++ b/tests/deployment/relay/test_main.py
@@ -1,0 +1,193 @@
+"""Tests for the Cloud Run relay function (deployment/relay/function/main.py).
+
+Exercises the actual security boundary — host allowlist, token auth, and
+header stripping — which tests/common/test_relay.py can't reach since it
+only covers the client-side RelayTransport (which just rewrites headers and
+always defers to the relay). Uses Werkzeug's Request/EnvironBuilder to build
+real Flask Request objects (the same type functions_framework hands the
+handler) and monkeypatches the module's shared httpx client so no real
+network call happens.
+"""
+
+from __future__ import annotations
+
+import gzip
+
+import httpx
+import pytest
+from flask import Request
+from werkzeug.test import EnvironBuilder
+
+from deployment.relay.function import main
+
+
+RELAY_TOKEN = "s3cr3t-token"  # noqa: S105 — test fixture, not a real credential
+
+
+def _request(
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+) -> Request:
+    builder = EnvironBuilder(method=method, headers=headers or {}, data=data)
+    return Request(builder.get_environ())
+
+
+@pytest.fixture(autouse=True)
+def _relay_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "_RELAY_TOKEN", RELAY_TOKEN)
+
+
+# ── _host_allowed ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "stj.jus.br",
+        "scon.stj.jus.br",
+        "dadosabertos.web.stj.jus.br",
+        "tjro.jus.br",
+        "juris-back.tjro.jus.br",
+        "STJ.JUS.BR",
+    ],
+)
+def test_host_allowed_accepts_allowlisted_hosts(hostname: str) -> None:
+    assert main._host_allowed(hostname) is True
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        None,
+        "",
+        "example.com",
+        "evilstj.jus.br",
+        "stj.jus.br.attacker.com",
+        "notstj.jus.br.evil.com",
+    ],
+)
+def test_host_allowed_rejects_everything_else(hostname: str | None) -> None:
+    assert main._host_allowed(hostname) is False
+
+
+# ── _token_valid ─────────────────────────────────────────────────────────
+
+
+def test_token_valid_accepts_correct_token() -> None:
+    request = _request(headers={"X-Relay-Token": RELAY_TOKEN})
+    assert main._token_valid(request) is True
+
+
+def test_token_valid_rejects_wrong_token() -> None:
+    request = _request(headers={"X-Relay-Token": "wrong"})
+    assert main._token_valid(request) is False
+
+
+def test_token_valid_rejects_missing_token() -> None:
+    request = _request()
+    assert main._token_valid(request) is False
+
+
+def test_token_valid_rejects_when_relay_token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "_RELAY_TOKEN", "")
+    request = _request(headers={"X-Relay-Token": "anything"})
+    assert main._token_valid(request) is False
+
+
+# ── _forward_headers ─────────────────────────────────────────────────────
+
+
+def test_forward_headers_strips_hop_by_hop_and_relay_headers() -> None:
+    request = _request(
+        headers={
+            "X-Relay-Token": RELAY_TOKEN,
+            "X-Relay-Url": "https://scon.stj.jus.br/",
+            "Connection": "keep-alive",
+            "Accept": "application/json",
+        }
+    )
+    headers = main._forward_headers(request, "scon.stj.jus.br")
+    assert "X-Relay-Token" not in headers
+    assert "X-Relay-Url" not in headers
+    assert "Connection" not in headers
+    assert "Content-Length" not in headers
+    assert headers["Accept"] == "application/json"
+    assert headers["Host"] == "scon.stj.jus.br"
+
+
+# ── relay() end-to-end (monkeypatched upstream client) ────────────────────
+
+
+def test_relay_rejects_missing_token() -> None:
+    request = _request()
+    _body, status = main.relay(request)
+    assert status == 401
+
+
+def test_relay_rejects_off_allowlist_host() -> None:
+    request = _request(
+        headers={"X-Relay-Token": RELAY_TOKEN, "X-Relay-Url": "https://example.com/"}
+    )
+    _body, status = main.relay(request)
+    assert status == 403
+
+
+def test_relay_rejects_missing_url() -> None:
+    request = _request(headers={"X-Relay-Token": RELAY_TOKEN})
+    _body, status = main.relay(request)
+    assert status == 403
+
+
+def test_relay_rejects_non_http_scheme() -> None:
+    request = _request(headers={"X-Relay-Token": RELAY_TOKEN, "X-Relay-Url": "file:///etc/passwd"})
+    _body, status = main.relay(request)
+    assert status == 403
+
+
+def test_relay_forwards_to_upstream_and_strips_content_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(
+            200,
+            content=gzip.compress(b'{"ok": true}'),
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/json"},
+        )
+
+    monkeypatch.setattr(main, "_client", httpx.Client(transport=httpx.MockTransport(handler)))
+
+    request = _request(
+        headers={
+            "X-Relay-Token": RELAY_TOKEN,
+            "X-Relay-Url": "https://scon.stj.jus.br/api/resource",
+            "Accept": "application/json",
+        }
+    )
+    body, status, headers = main.relay(request)
+
+    assert status == 200
+    assert body == b'{"ok": true}'
+    assert "content-encoding" not in headers
+    assert headers["content-type"] == "application/json"
+    assert len(captured) == 1
+    assert str(captured[0].url) == "https://scon.stj.jus.br/api/resource"
+    assert captured[0].headers["Host"] == "scon.stj.jus.br"
+
+
+def test_relay_returns_502_on_upstream_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        message = "boom"
+        raise httpx.ConnectTimeout(message, request=req)
+
+    monkeypatch.setattr(main, "_client", httpx.Client(transport=httpx.MockTransport(handler)))
+
+    request = _request(
+        headers={"X-Relay-Token": RELAY_TOKEN, "X-Relay-Url": "https://scon.stj.jus.br/"}
+    )
+    _body, status = main.relay(request)
+    assert status == 502


### PR DESCRIPTION
## Summary

GitHub-hosted runners are network-blocked by both sources: STJ's WAF 403s runner IP ranges (`STJWAFBlockedError`), and `juris-back.tjro.jus.br` `ConnectTimeout`s from them. Serverless platforms don't support proxy `CONNECT`, so this routes crawl traffic through a Cloud Run function relay via a custom httpx transport instead of `HTTPS_PROXY`.

### Fase 0 — validated before building anything
A throwaway `probe` function (deleted immediately after) confirmed Cloud Run's egress IPs in `southamerica-east1` are **not** blocked: both the real STJ GET and TJRO POST came back with real content (not a WAF challenge page), well within timeout. Only then was the relay itself built.

### Fase 1 — relay function (`deployment/relay/`)
- Gen2, Python 3.12, `southamerica-east1`, `256Mi`/`120s` timeout.
- Allowlist: only `*.stj.jus.br` / `*.tjro.jus.br` forwardable — anything else 403s. Not an open proxy.
- Auth: `X-Relay-Token` header, constant-time compared against a Secret Manager secret (`relay-token`). Missing/wrong → 401.
- Forwards method/body/headers (minus hop-by-hop + `X-Relay-*`), no redirect-following (3xx returned to caller as-is).
- **Bug caught by the first live run**: httpx auto-decompresses the upstream response but the relay was forwarding the original `Content-Encoding: gzip` header alongside the already-decoded body — the caller's httpx tried to gunzip a second time (`DecodingError`). Fixed by stripping `Content-Encoding` from the relayed response.
- Cost: well within Cloud Run's free tier at this volume (dozens–hundreds of requests/day).

### Fase 2 — repo wiring
- `src/common/relay.py`: `RelayTransport`/`AsyncRelayTransport`, activated by `RELAY_URL`/`RELAY_TOKEN` env; falls back to a direct connection when unset (zero impact on local/dev).
- Wired into `stj_acordaos` and `tjro_juris`'s httpx clients.
- `stj-sync.yml` / `tjro-sync.yml`: secrets scoped to the download/crawl step only, never the IA upload step. Cron reactivated (distinct off-hours BR times) after live `workflow_dispatch` runs came back green with real data.

## Validation

- Fase 0 probe: STJ GET + TJRO POST both real content, deleted after.
- Relay `curl` checks: STJ GET ✅, TJRO POST ✅, out-of-allowlist host → 403 ✅, missing token → 401 ✅, wrong token → 401 ✅.
- Local real-client smoke test through the deployed relay: `stj_acordaos.client.get_resource_list()` → 51 resources; `tjro_juris.client.search()` → real ES hits.
- Live `workflow_dispatch` on this branch: **STJ Sync** green, manifest 51 entries. **TJRO Sync** green, manifest 6 entries, all uploaded to IA.
- `uv run ruff check && uv run ruff format --check && uv run pytest -q` — all clean, full suite passing.

## Test plan
- [x] Fase 0 probe validated hypothesis, then deleted
- [x] Relay deployed + curl-validated (allowlist, auth, both real endpoints)
- [x] `RelayTransport`/`AsyncRelayTransport` unit tests (`tests/common/test_relay.py`)
- [x] Live `workflow_dispatch` green for both STJ Sync and TJRO Sync with real manifest data
- [x] Cron reactivated post-green-run
- [ ] Watch the first real cron firing (07:00 / 09:00 UTC) post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cer4wHLPHztUVHhVZuwWJV