### PR TITLE
feat(tjro-juris): capture 9 more metadata fields per document

### DIFF
--- a/src/tjro_juris/__main__.py
+++ b/src/tjro_juris/__main__.py
@@ -67,7 +67,31 @@ _PARQUET_SCHEMA = pa.schema(
         pa.field("texto_limpo", pa.string()),
         pa.field("url_portal", pa.string()),
         pa.field("extraido_em", pa.string()),
+        # Added 2026-07-14 — see crawler._extract_doc for why these and not
+        # the rest of the ~29 raw ES fields.
+        pa.field("id_processo", pa.int64()),
+        pa.field("cd_assunto_trf", pa.string()),
+        pa.field("ds_assunto_trf", pa.string()),
+        pa.field("cd_classe_judicial", pa.string()),
+        pa.field("nivel_sigilo_processo", pa.int64()),
+        pa.field("grau_jurisdicao", pa.int64()),
+        pa.field("ds_md5_documento", pa.string()),
+        pa.field("id_orgao_julgador", pa.int64()),
+        pa.field("id_orgao_julgador_colegiado", pa.int64()),
     ]
+)
+
+# Parquet-typed as int64 in _PARQUET_SCHEMA above — _rows_to_parquet uses this
+# to decide int-coercion vs plain string for every other field.
+_INT_FIELD_NAMES = frozenset(
+    {
+        "id_documento",
+        "id_processo",
+        "nivel_sigilo_processo",
+        "grau_jurisdicao",
+        "id_orgao_julgador",
+        "id_orgao_julgador_colegiado",
+    }
 )
 
 
@@ -177,6 +201,15 @@ def _to_row(src: dict) -> dict:
         "texto_limpo": src.get("texto_limpo") or clean_html(src.get("ds_modelo_documento") or ""),
         "url_portal": src.get("url_portal") or "",
         "extraido_em": src.get("extraido_em") or datetime.now(UTC).isoformat(),
+        "id_processo": src.get("id_processo"),
+        "cd_assunto_trf": src.get("cd_assunto_trf") or "",
+        "ds_assunto_trf": src.get("ds_assunto_trf") or "",
+        "cd_classe_judicial": src.get("cd_classe_judicial") or "",
+        "nivel_sigilo_processo": src.get("nivel_sigilo_processo"),
+        "grau_jurisdicao": src.get("grau_jurisdicao"),
+        "ds_md5_documento": src.get("ds_md5_documento") or "",
+        "id_orgao_julgador": src.get("id_orgao_julgador"),
+        "id_orgao_julgador_colegiado": src.get("id_orgao_julgador_colegiado"),
     }
 
 
@@ -196,7 +229,7 @@ def _rows_to_parquet(rows: list[dict], out: Path) -> None:
     for row in rows:
         for field in _PARQUET_SCHEMA:
             val = row.get(field.name)
-            if field.name == "id_documento":
+            if field.name in _INT_FIELD_NAMES:
                 arrays[field.name].append(int(val) if val is not None else None)
             elif field.name == "data_julgamento":
                 arrays[field.name].append(val)

--- a/src/tjro_juris/crawler.py
+++ b/src/tjro_juris/crawler.py
@@ -57,8 +57,23 @@ class JurisWindowOverflowError(RuntimeError):
     """
 
 
+def _int_or_none(value: object) -> int | None:
+    """Coerce a raw ES field to int, tolerating None/empty-string (both observed live)."""
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
 def _extract_doc(raw: dict) -> dict:
-    """Normalize a raw JURIS hit into a flat, cleaned dict."""
+    """Normalize a raw JURIS hit into a flat, cleaned dict.
+
+    Captures the subset of the ~29 raw ES fields with clear analytical value
+    beyond the original 11 (case grouping, subject classification, secrecy
+    flag, content hash, instance level, stable órgão IDs) — see the
+    2026-07-14 field audit. Deliberately excludes clearly redundant/
+    low-value fields (``dtjulgamento_str`` duplicates ``dtjulgamento``,
+    ``datarodape``/``cod_ini`` are display-only, etc).
+    """
     src = raw.get("_source", raw)
     orgao = src.get("ds_orgao_julgador_colegiado") or src.get("ds_orgao_julgador", "")
     relator = src.get("nome_relator_acordao") or src.get("ds_nome", "")
@@ -83,6 +98,15 @@ def _extract_doc(raw: dict) -> dict:
         "texto_limpo": clean_html(src.get("ds_modelo_documento", "") or ""),
         "url_portal": url,
         "extraido_em": datetime.now(UTC).isoformat(),
+        "id_processo": _int_or_none(src.get("id_processo")),
+        "cd_assunto_trf": src.get("cd_assunto_trf") or "",
+        "ds_assunto_trf": src.get("ds_assunto_trf") or "",
+        "cd_classe_judicial": src.get("cd_classe_judicial") or "",
+        "nivel_sigilo_processo": _int_or_none(src.get("nivel_sigilo_processo")),
+        "grau_jurisdicao": _int_or_none(src.get("grau_jurisdicao")),
+        "ds_md5_documento": src.get("ds_md5_documento") or "",
+        "id_orgao_julgador": _int_or_none(src.get("id_orgao_julgador")),
+        "id_orgao_julgador_colegiado": _int_or_none(src.get("id_orgao_julgador_colegiado")),
     }
 
 

--- a/tests/tjro_juris/test_juris_crawler.py
+++ b/tests/tjro_juris/test_juris_crawler.py
@@ -12,6 +12,7 @@ from tjro_juris.crawler import (
     JurisWindowOverflowError,
     _exceeds_window,
     _extract_doc,
+    _int_or_none,
     _iter_year_months,
     _month_bounds,
     _split_range,
@@ -39,6 +40,15 @@ def _hit(doc_id: int, **extra: object) -> dict:
         "sistema_origem": "pje2instancia",
         "dtjulgamento": "2024-03-15",
         "ds_modelo_documento": "<p>EMENTA: teste</p>",
+        "id_processo": 999,
+        "cd_assunto_trf": "3372",
+        "ds_assunto_trf": "Homicídio Qualificado",
+        "cd_classe_judicial": "417",
+        "nivel_sigilo_processo": 0,
+        "grau_jurisdicao": 2,
+        "ds_md5_documento": "abc123",
+        "id_orgao_julgador": 22,
+        "id_orgao_julgador_colegiado": 12,
     }
     src.update(extra)
     return {"_source": src}
@@ -65,6 +75,35 @@ def test_extract_doc_maps_all_fields() -> None:
     assert "id=42" in doc["url_portal"]
     assert "id_documento_principal=7" in doc["url_portal"]
     assert doc["extraido_em"]  # timestamp stamped
+    assert doc["id_processo"] == 999
+    assert doc["cd_assunto_trf"] == "3372"
+    assert doc["ds_assunto_trf"] == "Homicídio Qualificado"
+    assert doc["cd_classe_judicial"] == "417"
+    assert doc["nivel_sigilo_processo"] == 0
+    assert doc["grau_jurisdicao"] == 2
+    assert doc["ds_md5_documento"] == "abc123"
+    assert doc["id_orgao_julgador"] == 22
+    assert doc["id_orgao_julgador_colegiado"] == 12
+
+
+def test_extract_doc_new_fields_default_when_missing() -> None:
+    doc = _extract_doc({"_source": {"tipo": "VOTO"}})
+    assert doc["id_processo"] is None
+    assert doc["cd_assunto_trf"] == ""
+    assert doc["ds_assunto_trf"] == ""
+    assert doc["cd_classe_judicial"] == ""
+    assert doc["nivel_sigilo_processo"] is None
+    assert doc["grau_jurisdicao"] is None
+    assert doc["ds_md5_documento"] == ""
+    assert doc["id_orgao_julgador"] is None
+    assert doc["id_orgao_julgador_colegiado"] is None
+
+
+def test_int_or_none_handles_none_empty_string_and_numeric_string() -> None:
+    assert _int_or_none(None) is None
+    assert _int_or_none("") is None
+    assert _int_or_none(5) == 5
+    assert _int_or_none("5") == 5
 
 
 def test_extract_doc_orgao_falls_back_to_non_colegiado() -> None:

--- a/tests/tjro_juris/test_juris_main.py
+++ b/tests/tjro_juris/test_juris_main.py
@@ -6,15 +6,94 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import httpx
+import pyarrow.parquet as pq
 import pytest
 import typer
 
-from tjro_juris.__main__ import _crawl_bounds, _load_manifest, _should_skip_window
+from tjro_juris.__main__ import (
+    _crawl_bounds,
+    _load_manifest,
+    _rows_to_parquet,
+    _should_skip_window,
+    _to_row,
+)
 from tjro_juris.manifest import ManifestJuris, ManifestJurisEntry
 
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+# ── _to_row / _rows_to_parquet ───────────────────────────────────────────
+
+_FULL_CRAWLER_DOC = {
+    "id_documento": 42,
+    "nr_processo": "00042-11.2024.8.22.0001",
+    "tipo": "ACÓRDÃO",
+    "classe_judicial": "Apelação Cível",
+    "orgao": "1ª Câmara Cível",
+    "relator": "Des. Fulano",
+    "sistema_origem": "pje2instancia",
+    "data_julgamento": "2024-03-15",
+    "texto_limpo": "EMENTA: teste",
+    "url_portal": "https://juris.tjro.jus.br/jurisprudencia/?id=42",
+    "extraido_em": "2026-07-14T00:00:00+00:00",
+    "id_processo": 999,
+    "cd_assunto_trf": "3372",
+    "ds_assunto_trf": "Homicídio Qualificado",
+    "cd_classe_judicial": "417",
+    "nivel_sigilo_processo": 0,
+    "grau_jurisdicao": 2,
+    "ds_md5_documento": "abc123",
+    "id_orgao_julgador": 22,
+    "id_orgao_julgador_colegiado": 12,
+}
+
+
+def test_to_row_maps_new_metadata_fields() -> None:
+    row = _to_row(_FULL_CRAWLER_DOC)
+    assert row["id_processo"] == 999
+    assert row["cd_assunto_trf"] == "3372"
+    assert row["ds_assunto_trf"] == "Homicídio Qualificado"
+    assert row["cd_classe_judicial"] == "417"
+    assert row["nivel_sigilo_processo"] == 0
+    assert row["grau_jurisdicao"] == 2
+    assert row["ds_md5_documento"] == "abc123"
+    assert row["id_orgao_julgador"] == 22
+    assert row["id_orgao_julgador_colegiado"] == 12
+
+
+def test_to_row_defaults_new_fields_when_missing() -> None:
+    row = _to_row({"data_julgamento": "2024-01-01"})
+    assert row["id_processo"] is None
+    assert row["cd_assunto_trf"] == ""
+    assert row["nivel_sigilo_processo"] is None
+    assert row["id_orgao_julgador"] is None
+
+
+def test_rows_to_parquet_round_trips_new_int_and_string_fields(tmp_path: Path) -> None:
+    """New int64 fields (nivel_sigilo_processo etc.) must not get str()-coerced,
+    and a None int field must round-trip as a real parquet null, not "None".
+    """
+    row = _to_row(_FULL_CRAWLER_DOC)
+    missing_row = _to_row({"data_julgamento": "2024-01-01"})
+    out = tmp_path / "test.parquet"
+    _rows_to_parquet([row, missing_row], out)
+
+    table = pq.read_table(out)
+    data = table.to_pylist()
+    assert data[0]["id_processo"] == 999
+    assert data[0]["nivel_sigilo_processo"] == 0
+    assert data[0]["id_orgao_julgador_colegiado"] == 12
+    assert data[0]["ds_assunto_trf"] == "Homicídio Qualificado"
+    assert data[1]["id_processo"] is None
+    assert data[1]["nivel_sigilo_processo"] is None
+    assert data[1]["cd_assunto_trf"] == ""
+
+    schema_types = {f.name: f.type for f in table.schema}
+    assert str(schema_types["id_processo"]) == "int64"
+    assert str(schema_types["nivel_sigilo_processo"]) == "int64"
+    assert str(schema_types["ds_assunto_trf"]) == "string"
 
 
 # ── _crawl_bounds ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Prompted by "are we extracting all the data and metadata?" — audited a raw JURIS document and found the crawler discards ~18 of the ~29 raw fields, keeping only 11. Adds the 9 highest-value fields:

- `id_processo` — case-level ID (distinct from `id_documento`), needed to group every document belonging to the same case
- `cd_assunto_trf` / `ds_assunto_trf` — subject-matter code/label (e.g. "Homicídio Qualificado")
- `cd_classe_judicial` — classification code (vs. today's free-text `classe_judicial`)
- `nivel_sigilo_processo` — secrecy flag; sampled 150 live docs across the 3 largest tipos, all were `0`/public, but worth capturing going forward as a monitored signal rather than assumed
- `grau_jurisdicao` — 1st/2nd instance
- `ds_md5_documento` — content hash (integrity/dedup)
- `id_orgao_julgador` / `id_orgao_julgador_colegiado` — numeric órgão IDs for stable joins vs. today's name-only string

Deliberately excludes fields with no observed value: `dtjulgamento_str` (redundant), `datarodape`/`cod_ini` (display-only), `nmpresidente` (empty in every sample), `dtpublicacao`/`data_indexacao` (mostly null/redundant), `nome_relator_processo` (matched `nome_relator_acordao` in every sample).

## ⚠️ Merge timing

**Do not merge until the concurrent historical backfill (1988-2026) finishes.** That backfill is running separately right now against the previous 11-field schema. Merging this mid-run would split the schema across years crawled before vs. after the merge. Once the backfill completes, decide then whether to re-crawl earlier years for schema parity or accept the split (documented per-year).

## Test plan
- [x] `_extract_doc` unit tests for all 9 new fields (present + defaulted-when-missing)
- [x] `_to_row` mapping tests
- [x] `_rows_to_parquet` round-trip test — confirms new int64 fields don't get `str()`-coerced and `None` round-trips as a real parquet null
- [x] `uv run ruff check && ruff format --check && pytest -q` — all clean, 93/93 tjro_juris tests + full suite passing
- [ ] Hold for backfill completion before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cer4wHLPHztUVHhVZuwWJV