### PR TITLE
feat(web): route CNJ searches to the process dossier, quiet network banner on static pages

### DIFF
--- a/web/src/components/CommandPalette.astro
+++ b/web/src/components/CommandPalette.astro
@@ -46,6 +46,11 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       </div>
 
       <div>
+        <dt>Consultar processo</dt>
+        <dd><a href={BASE + 'processo'}>Dossiê CNJ reconciliado</a></dd>
+      </div>
+
+      <div>
         <dt>Fechar diálogos / dicas</dt>
         <dd><kbd>Esc</kbd></dd>
       </div>

--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -6,6 +6,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   <p id="footer-brand" class="footer-brand">CausaGanha</p>
   <nav aria-label="Links do rodapé" class="footer-nav">
     <a href={BASE + 'publicacoes'}>Publicações</a>
+    <a href={BASE + 'processo'}>Consultar processo</a>
     <a href={BASE + 'sobre'}>Metodologia</a>
     <a
       href="https://github.com/franklinbaldo/causaganha"

--- a/web/src/components/PublicationSearch.svelte
+++ b/web/src/components/PublicationSearch.svelte
@@ -15,6 +15,7 @@
     searchParamsToQuery,
     hasAnyQueryValue,
   } from '../lib/searchQueryString';
+  import { formatCnj } from '../lib/processoCnj';
   import PublicationCard from './PublicationCard.svelte';
   import SmartSearchInput from './SmartSearchInput.svelte';
   import SearchFilters from './SearchFilters.svelte';
@@ -113,6 +114,16 @@
   });
 
   const smart = $derived(smartParseInput(preparedInput));
+  // Este formulário só consulta o DJEN. Quando o input é um CNJ válido, o
+  // dossiê reconciliado em /processo tem mais fontes (DJEN + JURIS + STJ +
+  // DataJud) do que esta busca sozinha — por isso o link em vez de fundir
+  // as duas UIs.
+  const BASE_URL = import.meta.env.BASE_URL;
+  const processoHref = $derived.by(() => {
+    if (smart.kind !== 'processo' || !smart.patch.numeroProcesso) return null;
+    const base = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
+    return `${base}processo?cnj=${encodeURIComponent(formatCnj(smart.patch.numeroProcesso))}`;
+  });
   const effectiveQuery = $derived<DjenComunicacaoQuery>({ ...filters, ...smart.patch });
   const criteriaFilters = $derived({
     siglaTribunal: filters.siglaTribunal,
@@ -499,6 +510,13 @@
     submitLabel={status === 'loading' ? 'Buscando…' : cooldownRemaining > 0 ? `Aguarde ${cooldownRemaining}s` : 'Buscar'}
   />
 
+  {#if processoHref}
+    <p class="processo-hint" data-tone="info">
+      Isto busca só no DJEN. Para ver este processo reconciliado com JURIS (TJRO), STJ e DataJud,
+      <a href={processoHref}>abra o dossiê completo →</a>
+    </p>
+  {/if}
+
   <section aria-label="Filtros ativos">
     <strong>Filtros ativos</strong>
     {#if activeFilterChips.length > 0}
@@ -654,6 +672,12 @@
 
 
 <style>
+  .processo-hint {
+    margin: 0.5rem 0 0;
+    font-size: 0.875rem;
+    color: var(--fg-muted, var(--color-content-tertiary));
+  }
+
   .criteria-summary {
     margin-block: 1rem;
     padding: 1rem;

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ALL_FONTES,
   buildCnjSearchParams,
+  buildHeroSearchRedirect,
   buildProcessoDocumentosSql,
   buildProcessoUnificadoSql,
   classifyCnjInput,
@@ -73,6 +74,36 @@ describe('classifyCnjInput', () => {
   it('classifies a valid masked or unmasked CNJ as valid', () => {
     expect(classifyCnjInput('00000010220248220001')).toBe('valid');
     expect(classifyCnjInput('0000001-02.2024.8.22.0001')).toBe('valid');
+  });
+});
+
+describe('buildHeroSearchRedirect', () => {
+  it('redirects an unmasked 20-digit CNJ to /processo with a masked ?cnj=', () => {
+    expect(buildHeroSearchRedirect('00000010220248220001', '/processo')).toBe(
+      '/processo?cnj=0000001-02.2024.8.22.0001',
+    );
+  });
+
+  it('redirects a masked CNJ to /processo with the same masked ?cnj=', () => {
+    expect(buildHeroSearchRedirect('0000001-02.2024.8.22.0001', '/processo')).toBe(
+      '/processo?cnj=0000001-02.2024.8.22.0001',
+    );
+  });
+
+  it('returns null for free text, leaving the caller to submit to /publicacoes', () => {
+    expect(buildHeroSearchRedirect('mandado de segurança', '/processo')).toBeNull();
+  });
+
+  it('returns null for OAB-shaped input', () => {
+    expect(buildHeroSearchRedirect('OAB/SP 245.812', '/processo')).toBeNull();
+  });
+
+  it('returns null for malformed CNJ-like text (wrong digit count)', () => {
+    expect(buildHeroSearchRedirect('0000001-02.2024.8.22', '/processo')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(buildHeroSearchRedirect('', '/processo')).toBeNull();
   });
 });
 

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -59,6 +59,19 @@ export function classifyCnjInput(raw: string): CnjInputStatus {
   return isValidCnj(stripCnjMask(trimmed)) ? 'valid' : 'invalid';
 }
 
+/**
+ * Decide para onde a busca da home deve ir: um CNJ válido tem o dossiê
+ * reconciliado (DJEN + JURIS + STJ + DataJud) em /processo, mais completo do
+ * que a busca DJEN-only de /publicacoes. Retorna a URL de redirecionamento,
+ * ou null quando a entrada não é um CNJ válido — nesse caso o chamador deixa
+ * o formulário seguir o fluxo padrão (GET para /publicacoes).
+ */
+export function buildHeroSearchRedirect(raw: string, processoHref: string): string | null {
+  if (classifyCnjInput(raw) !== 'valid') return null;
+  const digits = normalizeCnj(raw);
+  return `${processoHref}?cnj=${encodeURIComponent(formatCnj(digits))}`;
+}
+
 // ── URL compartilhável (?cnj=...) ──────────────────────────────────────────
 
 const CNJ_PARAM = 'cnj';

--- a/web/src/pages/advogados.astro
+++ b/web/src/pages/advogados.astro
@@ -37,7 +37,7 @@ const avgCoverage = tribunalStats.length
 // confiança adequados.
 ---
 
-<Layout title="Advogados — CausaGanha" description="Cobertura por tribunal para exploração de dados de advogados/OAB no acervo público.">
+<Layout title="Advogados — CausaGanha" description="Cobertura por tribunal para exploração de dados de advogados/OAB no acervo público." showNetworkBanner={false}>
   <PageHeader title="Advogados / OAB" subtitle="Cobertura por tribunal para consultas de advogados" backHref={BASE} backLabel="Início" tile="advogados" />
 
   <div class="container">

--- a/web/src/pages/advogados/[tribunal].astro
+++ b/web/src/pages/advogados/[tribunal].astro
@@ -31,7 +31,7 @@ const entry = tribunalStats.find((item) => item.tribunal === key);
 const query = `SELECT numero_oab, uf_oab, COUNT(*) AS aparicoes\nFROM advogados\nWHERE tribunal = '${key}'\nGROUP BY numero_oab, uf_oab\nORDER BY aparicoes DESC\nLIMIT 25;`;
 ---
 
-<Layout title={`${key} — Advogados — CausaGanha`} description={`Guia de consulta de advogados/OAB para ${key}.`}>
+<Layout title={`${key} — Advogados — CausaGanha`} description={`Guia de consulta de advogados/OAB para ${key}.`} showNetworkBanner={false}>
   <PageHeader backHref={BASE + 'advogados'} backLabel="Advogados" tile="advogados" title={`Guia por Tribunal: ${key}`} subtitle="Use no Explorador para consultar OABs com dados já coletados" />
 
   <div class="container">

--- a/web/src/pages/changelog.astro
+++ b/web/src/pages/changelog.astro
@@ -26,7 +26,7 @@ const dateFormatter = new Intl.DateTimeFormat('pt-BR', {
 });
 ---
 
-<Layout title="Changelog — CausaGanha" description="Atualizações de produto e status do projeto CausaGanha.">
+<Layout title="Changelog — CausaGanha" description="Atualizações de produto e status do projeto CausaGanha." showNetworkBanner={false}>
   <PageHeader title="Changelog" subtitle="Evolução do dashboard e do pipeline" backHref={BASE} backLabel="Início" tile="changelog" />
 
   <div class="container">

--- a/web/src/pages/comparador.astro
+++ b/web/src/pages/comparador.astro
@@ -29,7 +29,7 @@ const tribunais = coverage
   .slice(0, 12);
 ---
 
-<Layout title="Comparador de Tribunais — CausaGanha" description="Compare cobertura e volume de publicações entre tribunais.">
+<Layout title="Comparador de Tribunais — CausaGanha" description="Compare cobertura e volume de publicações entre tribunais." showNetworkBanner={false}>
   <PageHeader title="Comparador de Tribunais" subtitle="Tribunais com maior cobertura histórica — do mais antigo ao mais recente" backHref={BASE + 'publicacoes'} backLabel="Publicações" tile="comparador" />
 
   <div class="container">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -59,7 +59,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         Cole um número de processo CNJ, uma inscrição na OAB, o nome de uma parte —
         ou pesquise por palavra-chave. A consulta online respeita a cota pública da API DJEN; quando ela limitar requisições, você ainda pode recorrer ao arquivo histórico preservado.
       </p>
-      <form class="hero__search" action={BASE + 'publicacoes'} method="get" role="search">
+      <form class="hero__search" action={BASE + 'publicacoes'} method="get" role="search" data-processo-href={BASE + 'processo'}>
         <fieldset role="group">
           <input
             class="input hero__search-input"
@@ -195,6 +195,22 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 </Layout>
 
 <script>
+  import { classifyCnjInput, normalizeCnj, formatCnj } from '../lib/processoCnj';
+
+  // Um CNJ colado na busca da home vai direto para o dossiê reconciliado
+  // (/processo), não para a busca DJEN-only em /publicacoes — é lá que o
+  // usuário vê as quatro fontes (DJEN, JURIS, STJ, DataJud) juntas.
+  const heroForm = document.querySelector<HTMLFormElement>('.hero__search');
+  const heroInput = heroForm?.querySelector<HTMLInputElement>('input[name="texto"]');
+  heroForm?.addEventListener('submit', (e) => {
+    const raw = heroInput?.value ?? '';
+    if (classifyCnjInput(raw) !== 'valid') return;
+    e.preventDefault();
+    const digits = normalizeCnj(raw);
+    const processoHref = heroForm.dataset.processoHref ?? 'processo';
+    window.location.href = `${processoHref}?cnj=${encodeURIComponent(formatCnj(digits))}`;
+  });
+
   // Hero tiles — Bulcão-inspired ornament
   function mulberry32(seed: number) {
     return function() {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -195,20 +195,22 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 </Layout>
 
 <script>
-  import { classifyCnjInput, normalizeCnj, formatCnj } from '../lib/processoCnj';
+  import { buildHeroSearchRedirect } from '../lib/processoCnj';
 
   // Um CNJ colado na busca da home vai direto para o dossiê reconciliado
   // (/processo), não para a busca DJEN-only em /publicacoes — é lá que o
-  // usuário vê as quatro fontes (DJEN, JURIS, STJ, DataJud) juntas.
+  // usuário vê as quatro fontes (DJEN, JURIS, STJ, DataJud) juntas. A decisão
+  // em si (buildHeroSearchRedirect) fica em lib/processoCnj para ser testável
+  // sem montar o formulário.
   const heroForm = document.querySelector<HTMLFormElement>('.hero__search');
   const heroInput = heroForm?.querySelector<HTMLInputElement>('input[name="texto"]');
   heroForm?.addEventListener('submit', (e) => {
     const raw = heroInput?.value ?? '';
-    if (classifyCnjInput(raw) !== 'valid') return;
-    e.preventDefault();
-    const digits = normalizeCnj(raw);
     const processoHref = heroForm.dataset.processoHref ?? 'processo';
-    window.location.href = `${processoHref}?cnj=${encodeURIComponent(formatCnj(digits))}`;
+    const redirect = buildHeroSearchRedirect(raw, processoHref);
+    if (!redirect) return;
+    e.preventDefault();
+    window.location.href = redirect;
   });
 
   // Hero tiles — Bulcão-inspired ornament

--- a/web/src/pages/sobre.astro
+++ b/web/src/pages/sobre.astro
@@ -9,6 +9,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 <Layout
   title="Sobre o Projeto — CausaGanha"
   description="Entenda a metodologia, as fontes de dados e a licença do projeto CausaGanha — acervo público do DJEN preservado no Internet Archive."
+  showNetworkBanner={false}
 >
   <PageHeader title="Projeto" backHref={BASE} backLabel="Início" tile="sobre" />
 

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -69,6 +69,7 @@ const base = import.meta.env.BASE_URL;
 <Layout
   title="Indicadores — CausaGanha"
   description="Análise de cobertura histórica e confiabilidade dos tribunais."
+  showNetworkBanner={false}
 >
   <PageHeader
     title="Indicadores"


### PR DESCRIPTION
## Description

This is the first slice of a broader "make `/processo` the product" direction: unify search around the reconciled case dossier, and stop showing a network-status banner on pages that never actually make a client-side network call.

**Smart CNJ routing**
- Homepage hero search now detects a valid CNJ number and redirects straight to `/processo?cnj=...` (the dossier reconciled across DJEN, JURIS/TJRO, STJ and DataJud) instead of the DJEN-only `/publicacoes` search. Free-text/OAB input is unaffected — it still goes to `/publicacoes`. The redirect decision itself lives in `buildHeroSearchRedirect()` (`lib/processoCnj.ts`), kept out of the page's inline script so it's unit-testable without mounting the form.
- `/publicacoes`'s own smart search already detects a CNJ and searches DJEN by process number; it now also surfaces a link to the fuller reconciled dossier ("abra o dossiê completo →"), since that search only covers one of the four sources.
- `/processo` is now linked from the footer and the command palette (`Ctrl+K` help dialog) on every page — previously it was only reachable from the "Ferramentas" dropdown on interior page headers, and absent from the homepage and footer entirely.

**Network banner trust fix**
- `NetworkStatusBanner`'s own doc comment says pages that hydrate purely from build-time JSON should opt out (`showNetworkBanner={false}`) so transient IA polling failures don't flash a banner they have nothing to do with. That opt-out was only wired up on `index.astro` and `publicacoes`; `sobre`, `changelog`, `comparador`, `advogados`, `advogados/[tribunal]` and `stats` all render exclusively from build-time contracts (no `client:load`/`client:only` islands, no `fetch`) and never dispatch the `cg-network-*` events the banner listens for, so I've turned it off there too. Pages that do run live client-side fetches against Internet Archive (`explorador`, `processo`) keep the banner unchanged.

## Testing

- `npm run lint`, `npm run typecheck`, `npm test` (203 tests, including 6 new cases for `buildHeroSearchRedirect`: masked CNJ, unmasked CNJ, free text, OAB-shaped input, malformed CNJ-like input, empty input) all pass.
- `npm run build` succeeds (with stubbed `web/public/data/*.json`, same stubs CI uses).
- Drove the built site with Playwright/Chromium, before and after the `buildHeroSearchRedirect` extraction:
  - Homepage search with a CNJ number → redirects to `/processo?cnj=...`.
  - Homepage search with free text → still goes to `/publicacoes?texto=...`.
  - Footer "Consultar processo" link present.
  - `/publicacoes` search with a CNJ shows the "abra o dossiê completo" link with the correct `href`.
  - `/processo?cnj=...` loads correctly.
  - Network banner element absent on `sobre`, `changelog`, `comparador`, `advogados`, `stats`, `index`, `publicacoes`; still present on `explorador`.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] N/A — this PR does not modify workflow CLI flags.
