### PR TITLE
feat(web): align homepage copy and primary nav with the process dossier

### DIFF
--- a/web/src/components/CommandPalette.astro
+++ b/web/src/components/CommandPalette.astro
@@ -41,13 +41,13 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       </div>
 
       <div>
-        <dt>Ir para publicações</dt>
-        <dd><a href={BASE + 'publicacoes'}>Buscar no DJEN</a></dd>
+        <dt>Consultar processo</dt>
+        <dd><a href={BASE + 'processo'}>Dossiê CNJ reconciliado</a></dd>
       </div>
 
       <div>
-        <dt>Consultar processo</dt>
-        <dd><a href={BASE + 'processo'}>Dossiê CNJ reconciliado</a></dd>
+        <dt>Ir para publicações</dt>
+        <dd><a href={BASE + 'publicacoes'}>Buscar publicações</a></dd>
       </div>
 
       <div>

--- a/web/src/components/PageHeader.astro
+++ b/web/src/components/PageHeader.astro
@@ -28,13 +28,13 @@ function isActive(href: string): boolean {
 }
 
 const primaryLinks = [
-  { href: BASE + 'publicacoes', label: 'Jurisprudência' },
-  { href: BASE + 'explorador', label: 'Explorador' },
+  { href: BASE + 'processo', label: 'Consultar processo' },
+  { href: BASE + 'publicacoes', label: 'Publicações' },
   { href: BASE + 'sobre', label: 'Metodologia' },
 ];
 
 const ferramentasLinks = [
-  { href: BASE + 'processo', label: 'Consultar processo' },
+  { href: BASE + 'explorador', label: 'Explorador' },
   { href: BASE + 'advogados', label: 'Advogados' },
   { href: BASE + 'comparador', label: 'Comparar tribunais' },
 ];
@@ -82,7 +82,7 @@ const ferramentasActive = [...ferramentasLinks, ...recursosLinks].some(l => isAc
       ))}
       <li class="desktop-only">
         <details role="list">
-          <summary aria-haspopup="listbox" class={ferramentasActive ? 'active' : ''}>Ferramentas</summary>
+          <summary aria-haspopup="listbox" class={ferramentasActive ? 'active' : ''}>Dados e ferramentas</summary>
           <ul role="listbox">
             {ferramentasLinks.map(link => (
               <li><a href={link.href} class={isActive(link.href) ? 'active' : ''}>{link.label}</a></li>
@@ -124,7 +124,7 @@ const ferramentasActive = [...ferramentasLinks, ...recursosLinks].some(l => isAc
               <li><a href={link.href} class={isActive(link.href) ? 'active' : ''}>{link.label}</a></li>
             ))}
             <li role="separator" class="drawer-divider" aria-hidden="true"></li>
-            <li class="menu-title">Ferramentas</li>
+            <li class="menu-title">Dados e ferramentas</li>
             {ferramentasLinks.map(link => (
               <li><a href={link.href} class={isActive(link.href) ? 'active' : ''}>{link.label}</a></li>
             ))}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -52,12 +52,11 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   <header class="hero" aria-labelledby="hero-title">
     <div class="hero__inner">
       <div class="hero__tiles" aria-hidden="true" id="hero-tiles"></div>
-      <span class="kicker">§ Busca pública · sem cadastro · cota DJEN transparente</span>
-      <h1 class="mega" id="hero-title">Procure<br/>no <em>DJEN.</em></h1>
+      <span class="kicker">§ Busca pública · sem cadastro · fontes oficiais reunidas</span>
+      <h1 class="mega" id="hero-title">Consulte processos.<br/>Pesquise <em>publicações.</em></h1>
       <p class="hero__lede">
-        {fmt(totalZips)} ZIPs de diários arquivados (pares tribunal × dia){sinceYear ? ` desde ${sinceYear}` : ''}, vindos de {tribunalsWithData} tribunais brasileiros.
-        Cole um número de processo CNJ, uma inscrição na OAB, o nome de uma parte —
-        ou pesquise por palavra-chave. A consulta online respeita a cota pública da API DJEN; quando ela limitar requisições, você ainda pode recorrer ao arquivo histórico preservado.
+        Cole um número CNJ para abrir o dossiê consolidado do processo, reconciliado entre DJEN, JURIS (TJRO), STJ e DataJud.
+        Pesquise também por OAB, parte ou palavra-chave nas publicações do DJEN e no acervo preservado — {fmt(totalZips)} ZIPs de diários arquivados (pares tribunal × dia){sinceYear ? ` desde ${sinceYear}` : ''}, de {tribunalsWithData} tribunais brasileiros.
       </p>
       <form class="hero__search" action={BASE + 'publicacoes'} method="get" role="search" data-processo-href={BASE + 'processo'}>
         <fieldset role="group">
@@ -68,7 +67,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
             type="search"
             placeholder="0001234-56.2024.8.26.0100  ·  OAB/SP 245.812  ·  texto livre"
             autocomplete="off"
-            aria-label="Buscar no DJEN"
+            aria-label="Consultar processo ou buscar publicações"
           />
           <button class="btn btn--accent" type="submit">Buscar →</button>
         </fieldset>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -56,7 +56,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
       <h1 class="mega" id="hero-title">Consulte processos.<br/>Pesquise <em>publicações.</em></h1>
       <p class="hero__lede">
         Cole um número CNJ para abrir o dossiê consolidado do processo, reconciliado entre DJEN, JURIS (TJRO), STJ e DataJud.
-        Pesquise também por OAB, parte ou palavra-chave nas publicações do DJEN e no acervo preservado — {fmt(totalZips)} ZIPs de diários arquivados (pares tribunal × dia){sinceYear ? ` desde ${sinceYear}` : ''}, de {tribunalsWithData} tribunais brasileiros.
+        Pesquise também por OAB, parte ou palavra-chave nas publicações do DJEN. O acervo preservado reúne {fmt(totalZips)} ZIPs de diários arquivados (pares tribunal × dia){sinceYear ? ` desde ${sinceYear}` : ''}, de {tribunalsWithData} tribunais brasileiros.
       </p>
       <form class="hero__search" action={BASE + 'publicacoes'} method="get" role="search" data-processo-href={BASE + 'processo'}>
         <fieldset role="group">


### PR DESCRIPTION
## Description

Follow-up to #822. That PR changed what the product *does* — a CNJ search now opens the reconciled dossier at `/processo` instead of a DJEN-only search — but the interface still described and prioritized the old DJEN-search-only product. This PR is scoped narrowly to fixing that mismatch: hero copy and primary-navigation hierarchy. No new pages, no renaming beyond the labels below.

**Homepage hero**
- Headline: `Procure no DJEN.` → `Consulte processos. Pesquise publicações.`
- Kicker: `cota DJEN transparente` → `fontes oficiais reunidas` (the DJEN-quota framing no longer describes the primary action).
- Lede: rewritten to lead with "cole um CNJ → dossiê reconciliado (DJEN + JURIS + STJ + DataJud)", then OAB/parte/texto → publications, keeping the real ZIP/tribunal counts.
- Search input's accessible label: `Buscar no DJEN` → `Consultar processo ou buscar publicações`.

**Global navigation (`PageHeader.astro`, desktop dropdown + mobile drawer)**
- Primary links reordered to: Consultar processo, Publicações (renamed from "Jurisprudência" — that page searches DJEN communications generally, not just jurisprudence), Metodologia.
- Explorador moved out of primary into the secondary menu, alongside Advogados and Comparar tribunais.
- Secondary menu renamed "Ferramentas" → "Dados e ferramentas" to match its now more clearly secondary/technical contents.

**Command palette**
- Reordered shortcuts to lead with "Consultar processo".
- Relabeled "Buscar no DJEN" → "Buscar publicações" for the same reason as the homepage input.

## Testing

- `npm run lint`, `npm run typecheck`, `npm test` (203 tests) all pass.
- `npm run build` succeeds (stubbed `web/public/data/*.json`, same stubs CI uses).
- Drove the built site with Playwright/Chromium:
  - Homepage: verified new H1/kicker/lede text and input aria-label; verified the CNJ → `/processo` redirect from #822 still works unchanged.
  - Interior page (`/sobre`): desktop primary nav shows Consultar processo / Publicações / Metodologia; dropdown summary reads "Dados e ferramentas" with Explorador/Advogados/Comparar tribunais/Changelog inside.
  - Mobile drawer: section headings read "Principal" / "Dados e ferramentas" / "Recursos" in that order.
  - Command palette (`Ctrl+/`): "Consultar processo" now appears before "Ir para publicações".

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] N/A — this PR does not modify workflow CLI flags.

---
Note: an earlier push in this session accidentally went to a differently-named branch (`claude/causaganha-product-hierarchy`) before I corrected it to reuse this repo's designated branch name per its follow-up-work convention. That branch has no PR against it and can be deleted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdFSt5ngvbxYjXH7WnmSc)_