### PR TITLE
fix(web): describe dossier source coverage without false completeness

### DIFF
--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -10,7 +10,7 @@
     buildProcessoDocumentosSql,
     buildProcessoUnificadoSql,
     classifyCnjInput,
-    completude,
+    fontesPresenca,
     formatCnj,
     isDocumentosVazio,
     mapDocumentoRow,
@@ -45,7 +45,7 @@
   // instead of overwriting newer state (see search()/loadDocumentos()).
   let searchGeneration = 0;
 
-  const fontesResumo = $derived(processo ? completude(processo.fontes) : null);
+  const fontesResumo = $derived(processo ? fontesPresenca(processo.fontes) : null);
   const documentosVazio = $derived(
     status === 'found' && documentosStatus === 'ready' && isDocumentosVazio(documentos, 0) && documentosOffset === 0,
   );
@@ -276,7 +276,7 @@
       <header class="processo-dossie__header">
         <h2>{processo.nrProcessoMascara}</h2>
         <p class="meta-text">
-          {fontesResumo.presentes.length} de {ALL_FONTES.length} fontes ({fontesResumo.pct}% de completude) ·
+          Registros encontrados em {fontesResumo.presentes.length} das {ALL_FONTES.length} fontes consultadas ·
           dataset gerado em {datasetGeneratedAtLabel}
         </p>
       </header>
@@ -286,7 +286,7 @@
         <div class="processo-dossie__fontes">
           {#each ALL_FONTES as fonte}
             <span class="badge" data-tone={processo.fontes.includes(fonte) ? 'success' : 'muted'}>
-              {FONTE_LABELS[fonte]} {processo.fontes.includes(fonte) ? '✓' : '— ausente'}
+              {FONTE_LABELS[fonte]} {processo.fontes.includes(fonte) ? '✓' : '— sem registro'}
             </span>
           {/each}
         </div>
@@ -323,7 +323,7 @@
       </article>
 
       <section aria-labelledby="documentos-title">
-        <h3 id="documentos-title">Documentos (JURIS / STJ)</h3>
+        <h3 id="documentos-title">Documentos de decisões — JURIS / STJ</h3>
 
         {#if documentosStatus === 'loading' && documentos.length === 0}
           <p aria-busy="true">Carregando documentos…</p>
@@ -337,7 +337,10 @@
         {/if}
 
         {#if documentosVazio}
-          <p class="meta-text" data-tone="muted">Processo localizado, mas sem documentos associados.</p>
+          <p class="meta-text" data-tone="muted">
+            Nenhum documento de decisão encontrado no JURIS ou no STJ para este processo.
+            As publicações do DJEN, quando existentes, aparecem no resumo acima.
+          </p>
         {/if}
 
         {#if documentos.length > 0}

--- a/web/src/components/ProcessoLookup.test.ts
+++ b/web/src/components/ProcessoLookup.test.ts
@@ -179,3 +179,68 @@ describe('ProcessoLookup — race between two searches', () => {
     expect(queryByText(CNJ_A, { exact: false })).toBeNull();
   });
 });
+
+describe('ProcessoLookup — source presence copy (no false completeness score)', () => {
+  async function searchAndResolve(cnj: string, processoOverrides: Record<string, unknown>, documentoRows: Record<string, unknown>[]) {
+    const { conn, processoDeferreds, documentosDeferreds } = makeControllableConn();
+    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+
+    const { getByLabelText, getByText, container } = render(ProcessoLookup);
+    const input = (await waitFor(() => getByLabelText(/Número do processo/i))) as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: cnj } });
+    await fireEvent.click(getByText('Buscar'));
+    await waitFor(() => expect(processoDeferreds.has(cnj)).toBe(true));
+    processoDeferreds.get(cnj)!.resolve(arrowResult([{ ...processoRow(cnj), ...processoOverrides }]));
+    await waitFor(() => expect(documentosDeferreds.has(cnj)).toBe(true));
+    documentosDeferreds.get(cnj)!.resolve(arrowResult(documentoRows));
+
+    return container;
+  }
+
+  it('shows the source count without a percentage when one source is present', async () => {
+    const cnj = '00000030420248220003';
+    const container = await searchAndResolve(cnj, {}, []);
+
+    await waitFor(() => expect(container.textContent).toContain('Registros encontrados em 1 das 4 fontes consultadas'));
+    expect(container.textContent).not.toContain('% de completude');
+  });
+
+  it('shows the correct source count when multiple sources are present', async () => {
+    const cnj = '00000040520248220004';
+    const container = await searchAndResolve(
+      cnj,
+      { fontes: ['djen', 'juris'], n_fontes: 2, juris_n_documentos: 2 },
+      [documentoRow(cnj, 'DOC-MULTI')],
+    );
+
+    await waitFor(() => expect(container.textContent).toContain('Registros encontrados em 2 das 4 fontes consultadas'));
+  });
+
+  it('labels an absent source as "sem registro", never "ausente"', async () => {
+    const cnj = '00000050620248220005';
+    const container = await searchAndResolve(cnj, {}, []);
+
+    await waitFor(() => expect(container.textContent).toContain('STJ — sem registro'));
+    expect(container.textContent).not.toContain('ausente');
+  });
+
+  it('explains an empty documents section without contradicting the DJEN publications shown above', async () => {
+    const cnj = '00000060720248220006';
+    const container = await searchAndResolve(cnj, { djen_n_publicacoes: 3 }, []);
+
+    await waitFor(() => expect(container.textContent).toContain('Nenhum documento de decisão encontrado no JURIS ou no STJ'));
+    expect(container.textContent).not.toContain('sem documentos associados');
+  });
+
+  it('shows the same empty-documents message when there are no DJEN publications either', async () => {
+    const cnj = '00000070820248220007';
+    const container = await searchAndResolve(
+      cnj,
+      { fontes: ['juris'], djen_n_publicacoes: null, juris_n_documentos: 0 },
+      [],
+    );
+
+    await waitFor(() => expect(container.textContent).toContain('Nenhum documento de decisão encontrado no JURIS ou no STJ'));
+  });
+});

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -6,7 +6,7 @@ import {
   buildProcessoDocumentosSql,
   buildProcessoUnificadoSql,
   classifyCnjInput,
-  completude,
+  fontesPresenca,
   formatCnj,
   isDocumentosVazio,
   isValidCnj,
@@ -346,24 +346,23 @@ describe('mapDocumentoRow', () => {
   });
 });
 
-describe('completude', () => {
-  it('reports all 4 sources present at 100%', () => {
-    const c = completude(['djen', 'juris', 'stj', 'datajud']);
+describe('fontesPresenca', () => {
+  it('groups all 4 sources as present, none absent', () => {
+    const c = fontesPresenca(['djen', 'juris', 'stj', 'datajud']);
     expect(c.presentes).toEqual(ALL_FONTES);
     expect(c.ausentes).toEqual([]);
-    expect(c.pct).toBe(100);
   });
 
-  it('reports a single source at 25%, listing the other three as absent', () => {
-    const c = completude(['djen']);
+  it('groups a single present source, listing the other three as without a record — no percentage', () => {
+    const c = fontesPresenca(['djen']);
     expect(c.presentes).toEqual(['djen']);
     expect(c.ausentes).toEqual(['juris', 'stj', 'datajud']);
-    expect(c.pct).toBe(25);
+    expect(c).not.toHaveProperty('pct');
   });
 
-  it('reports zero sources at 0%', () => {
-    const c = completude([]);
-    expect(c.pct).toBe(0);
+  it('groups zero present sources, all four without a record', () => {
+    const c = fontesPresenca([]);
+    expect(c.presentes).toEqual([]);
     expect(c.ausentes).toEqual(ALL_FONTES);
   });
 });

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -348,7 +348,7 @@ export function fontesPresenca(fontes: Fonte[]): FontesPresenca {
   return { presentes, ausentes };
 }
 
-/** "Processo localizado, mas sem documentos associados" — distinto de "não encontrado". */
+/** Processo localizado, mas sem documentos JURIS/STJ — distinto de CNJ não encontrado. */
 export function isDocumentosVazio(items: unknown[], offset: number): boolean {
   return offset === 0 && items.length === 0;
 }

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -330,17 +330,22 @@ export function mapDocumentoRow(raw: Record<string, unknown>): ProcessoDocumento
   };
 }
 
-export interface Completude {
+export interface FontesPresenca {
   presentes: Fonte[];
   ausentes: Fonte[];
-  pct: number;
 }
 
-/** Grau de completude: quantas das 4 fontes possíveis contribuíram para este CNJ. */
-export function completude(fontes: Fonte[]): Completude {
+/**
+ * Agrupa as 4 fontes possíveis entre as que contribuíram para este CNJ e as
+ * que não têm registro no dataset. Não expõe um percentual: as 4 fontes
+ * cobrem categorias diferentes de informação (ex.: nem todo processo passa
+ * pelo STJ), então a ausência de uma não é "incompletude" — é a fonte não
+ * tendo o que consultar.
+ */
+export function fontesPresenca(fontes: Fonte[]): FontesPresenca {
   const presentes = ALL_FONTES.filter((f) => fontes.includes(f));
   const ausentes = ALL_FONTES.filter((f) => !fontes.includes(f));
-  return { presentes, ausentes, pct: Math.round((presentes.length / ALL_FONTES.length) * 100) };
+  return { presentes, ausentes };
 }
 
 /** "Processo localizado, mas sem documentos associados" — distinto de "não encontrado". */


### PR DESCRIPTION
## Description

Follow-up from a real-production-data audit of `/processo` (queried the live `processos_unificados.parquet`/`processo_documentos.parquet` directly against archive.org, not fixtures). Two related findings, both about the frontend turning absence-of-a-record into a false impression of incompleteness or data loss:

**1. False completeness score**

`stj_id` is NULL for all 5,725,654 rows in `processos_unificados.parquet` — STJ has never once populated. DataJud only ever appears alongside another source (0 standalone rows; only 1 row in the entire dataset has `tem_datajud=true`). So "X de 4 fontes (Y% de completude)" showed a fabricated denominator on effectively every real dossier — the four sources cover different categories of information, not four mandatory copies of the same record.

- Renamed `completude()`/`Completude` → `fontesPresenca()`/`FontesPresenca` in `lib/processoCnj.ts`, dropped the `pct` field entirely.
- Header: `N de 4 fontes (Y% de completude)` → `Registros encontrados em N das 4 fontes consultadas`.
- Badges: `STJ — ausente` → `STJ — sem registro` (describes the dataset, not the process).

**2. Empty-documents message contradicted the DJEN block directly above it**

`processo_documentos.parquet` only ever contains `fonte='juris'` rows (359,237 of them, zero DJEN). Joining against `processos_unificados` confirms **5,538,457 of 5,725,654 processes (96.7%)** are DJEN-only with publications but zero JURIS/STJ document rows. So the page would show `Publicações: N` in the DJEN summary, then immediately below, `Processo localizado, mas sem documentos associados` — reading as a bug or data loss rather than "no JURIS/STJ decision on file."

- Section title: `Documentos (JURIS / STJ)` → `Documentos de decisões — JURIS / STJ`.
- Empty state: `Processo localizado, mas sem documentos associados.` → `Nenhum documento de decisão encontrado no JURIS ou no STJ para este processo. As publicações do DJEN, quando existentes, aparecem no resumo acima.` (same message works whether or not DJEN publications exist — it's accurate either way, so no branching needed).

## Out of scope (per the audit)

- The reconciliation/JURIS pipeline itself.
- A finding from the same audit that the largest real dossier (`0000903-22.2018.8.22.0000`, 219 JURIS documents) is an administrative/omnibus TJRO presidency docket covering ~219 unrelated individuals' petitions, not one lawsuit's history — that's a data-modeling question for whoever owns JURIS reconciliation, not a frontend fix.
- Pagination/ordering changes.
- Removing STJ/DataJud from the source list — showing them as rarely-populated-but-listed is accurate, not a bug.
- Any dossier redesign.

## Testing

- `npm run lint`, `npm run typecheck`, `npm test` (208 tests, 5 new) all pass.
- `npm run build` succeeds.
- New component tests in `ProcessoLookup.test.ts` cover: one source present without a percentage, multiple sources present, an absent source rendered as "sem registro", DJEN-with-publications-but-zero-JURIS/STJ-documents, zero-documents-with-no-DJEN-publications-either, and the absence of the retired strings `% de completude`, `— ausente`, `sem documentos associados`.
- `fontesPresenca()` unit tests in `processoCnj.test.ts` updated (no `pct` field, `sem registro` semantics).
- Note: this sandbox's browser cannot reach any external host (confirmed via multiple domains, not archive.org-specific), so I could not visually drive the deployed page — verification here is via the jsdom-based component test suite (the repo's existing pattern for this component) plus direct DuckDB queries against the real production parquet files to ground the numbers above.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] N/A — this PR does not modify workflow CLI flags.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdFSt5ngvbxYjXH7WnmSc)_