### PR TITLE
fix(tjro-juris): incremental manifest saves, page-level resume, configurable page size

### DIFF
--- a/src/tjro_juris/__main__.py
+++ b/src/tjro_juris/__main__.py
@@ -52,6 +52,7 @@ log = structlog.get_logger()
 app = typer.Typer(name="tjro-juris", help="TJRO JURIS scraping and archival.")
 
 _MANIFEST_NAME = "tjro-juris-manifest.csv"
+_PARTIAL_CACHE_DIRNAME = ".partial-cache"
 _MIN_DATE_LEN = 10
 
 _PARQUET_SCHEMA = pa.schema(
@@ -76,6 +77,16 @@ _MES_RE = re.compile(r"\d{4}-(0[1-9]|1[0-2])")
 
 def _manifest_path(data_dir: Path) -> Path:
     return data_dir / _MANIFEST_NAME
+
+
+def _partial_cache_dir(data_dir: Path) -> Path:
+    """Staging area for in-progress pagination (see crawler._fetch_pages).
+
+    Lives under data_dir so it survives between crawl invocations of the
+    same --ano; never uploaded to IA, never read by anything except a
+    resumed crawl of the same window.
+    """
+    return data_dir / _PARTIAL_CACHE_DIRNAME
 
 
 def _load_manifest(data_dir: Path) -> ManifestJuris:
@@ -248,7 +259,18 @@ def crawl(
 
     Windows already uploaded to IA (per the manifest, restored from IA when
     no local copy exists) are skipped, except the current month, which is
-    always re-crawled to pick up newly published documents.
+    always re-crawled to pick up newly published documents. Windows whose
+    parquet is already on local disk (e.g. a prior attempt this same year
+    got partway through before failing) are also skipped — see
+    ``_already_crawled_locally``.
+
+    The manifest is saved after EVERY window, not just once at the end: a
+    long --ano/--desde-ano crawl that dies partway through (observed live —
+    TJRO's STIC anti-abuse system can block a sustained crawl mid-year)
+    previously lost all of that year's progress from the manifest even
+    though the parquet files were already safely on disk, forcing a full
+    re-fetch of every tipo on the next attempt. Saving incrementally means
+    a retry only has to redo whatever wasn't finished yet.
     """
     manifest = _load_manifest(data_dir)
     tipos_to_crawl = tipo or TIPOS
@@ -257,7 +279,12 @@ def crawl(
     current_ym = now.strftime("%Y-%m")
     start_year, end_year_month, start_year_month = _crawl_bounds(ano, mes, desde_ano, now)
 
+    def _already_crawled_locally(tipo_name: str, year_month: str) -> bool:
+        return _parquet_path(data_dir, tipo_name, year_month).exists()
+
     def _skip(tipo_name: str, year_month: str) -> bool:
+        if _already_crawled_locally(tipo_name, year_month):
+            return True
         return _should_skip_window(manifest, current_ym, tipo_name, year_month)
 
     for tipo_name, year_month, docs in crawl_all(
@@ -266,6 +293,7 @@ def crawl(
         tipos=tipos_to_crawl,
         start_year_month=start_year_month,
         skip=_skip,
+        cache_dir=_partial_cache_dir(data_dir),
     ):
         if not docs:
             continue
@@ -282,8 +310,8 @@ def crawl(
             n_docs=len(docs),
         )
         manifest.upsert(entry)
+        manifest.save_local(_manifest_path(data_dir))
 
-    manifest.save_local(_manifest_path(data_dir))
     log.info("crawl_done")
 
 

--- a/src/tjro_juris/client.py
+++ b/src/tjro_juris/client.py
@@ -22,6 +22,7 @@ API contract (reverse-engineered from the portal's Next.js bundles, 2026-07):
 from __future__ import annotations
 
 import html as htmllib
+import os
 import random
 import re
 import time
@@ -52,7 +53,27 @@ TIPOS = [
 
 ENDPOINT = "https://juris-back.tjro.jus.br/search/varios_parametros/"
 AGGREGATIONS_ENDPOINT = "https://juris-back.tjro.jus.br/search/agregacoes"
-PAGE_SIZE = 400
+
+# Live-tested (2026-07-15): 400 (old default), 2000 and 5000 all return
+# clean 200s; 2000 is fast, 5000 takes ~26s/request (risky against client
+# timeouts), 10000 (the full ES window in one shot) 500s server-side.
+# JURIS_PAGE_SIZE env var lets this be tuned without a code change — e.g.
+# to back off to a smaller page size if bigger ones start tripping rate
+# limits/blocks.
+_DEFAULT_PAGE_SIZE = 2000
+
+
+def _resolve_page_size(env: dict[str, str]) -> int:
+    """Pure parsing helper — kept separate from the module-level read below.
+
+    Tests exercise this directly instead of reloading the module (a reload
+    rebuilds the shared httpx.Client and breaks respx interception for
+    every other test in the same session).
+    """
+    return int(env.get("JURIS_PAGE_SIZE", str(_DEFAULT_PAGE_SIZE)))
+
+
+PAGE_SIZE = _resolve_page_size(os.environ)
 
 # Elasticsearch max_result_window: requests with from + size beyond this 500.
 MAX_RESULT_WINDOW = 10_000

--- a/src/tjro_juris/crawler.py
+++ b/src/tjro_juris/crawler.py
@@ -15,8 +15,10 @@ successfully but lost documents" is worse than failing.
 from __future__ import annotations
 
 import calendar
+import json
 import time
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 
@@ -132,15 +134,73 @@ def _split_range(date_start: str, date_end: str) -> tuple[str, str]:
     return mid.isoformat(), (mid + timedelta(days=1)).isoformat()
 
 
+def _partial_cache_path(
+    cache_dir: Path, tipo: str, date_start: str, date_end: str, extra_fields: dict | None
+) -> Path:
+    """Staging file for in-progress pagination of one (tipo, date window).
+
+    Keyed by tipo + date range + extra_fields so bisected sub-windows (and
+    órgão-julgador sub-splits, which share a date range but differ by
+    extra_fields) never collide.
+    """
+    safe_tipo = tipo.replace(" ", "_").replace("/", "_")
+    suffix = ""
+    if extra_fields:
+        raw_key = "_".join(f"{k}={v}" for k, v in sorted(extra_fields.items()))
+        suffix = "_" + "".join(c if c.isalnum() else "-" for c in raw_key)[:60]
+    return cache_dir / safe_tipo / f"{date_start}_{date_end}{suffix}.jsonl"
+
+
+def _load_partial_cache(path: Path) -> list[dict]:
+    """Docs already fetched for this window in a prior, interrupted attempt."""
+    if not path.exists():
+        return []
+    docs = []
+    with path.open(encoding="utf-8") as fh:
+        for raw_line in fh:
+            stripped = raw_line.strip()
+            if stripped:
+                docs.append(json.loads(stripped))
+    return docs
+
+
+def _append_partial_cache(path: Path, docs: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for doc in docs:
+            fh.write(json.dumps(doc, ensure_ascii=False) + "\n")
+
+
 def _fetch_pages(
     tipo: str,
     date_start: str,
     date_end: str,
     extra_fields: dict | None = None,
+    cache_dir: Path | None = None,
 ) -> list[dict]:
-    """Paginate one date window, never exceeding the ES result window."""
-    results: list[dict] = []
-    from_ = 0
+    """Paginate one date window, never exceeding the ES result window.
+
+    When *cache_dir* is given, each page is appended to a staging file as
+    soon as it's fetched — so a mid-window failure (STIC block, transport
+    error) loses at most one page's worth of work on retry, not the whole
+    window. ``from_`` resumes from ``len(cached docs)`` regardless of what
+    PAGE_SIZE was used to reach that offset (ES pagination is just a count).
+    The staging file is deleted only once the window is PROVABLY complete
+    (server returned a short/empty page) — a window that errors out always
+    leaves its cache behind, on purpose, rather than risk it being mistaken
+    for a finished fetch.
+    """
+    cache_path = (
+        _partial_cache_path(cache_dir, tipo, date_start, date_end, extra_fields)
+        if cache_dir is not None
+        else None
+    )
+    results: list[dict] = _load_partial_cache(cache_path) if cache_path is not None else []
+    from_ = len(results)
+    if from_:
+        log.info(
+            "fetch_page_resumed_from_cache", tipo=tipo, date_start=date_start, resumed_from=from_
+        )
     while from_ < MAX_RESULT_WINDOW:
         size = min(PAGE_SIZE, MAX_RESULT_WINDOW - from_)
         time.sleep(_REQUEST_INTERVAL)
@@ -155,13 +215,18 @@ def _fetch_pages(
         hits = _hits(data)
         if not hits:
             break
-        results.extend(_extract_doc(raw) for raw in hits)
+        page_docs = [_extract_doc(raw) for raw in hits]
+        results.extend(page_docs)
+        if cache_path is not None:
+            _append_partial_cache(cache_path, page_docs)
         log.debug(
             "fetch_window_page", tipo=tipo, date_start=date_start, from_=from_, page_hits=len(hits)
         )
         if len(hits) < size:
             break
         from_ += size
+    if cache_path is not None:
+        cache_path.unlink(missing_ok=True)
     return results
 
 
@@ -177,7 +242,9 @@ def _orgao_buckets(tipo: str) -> list[str]:
     return [str(b["key"]) for b in buckets if b.get("key")]
 
 
-def _fetch_day_by_orgao(tipo: str, day: str, day_total: int) -> list[dict]:
+def _fetch_day_by_orgao(
+    tipo: str, day: str, day_total: int, cache_dir: Path | None = None
+) -> list[dict]:
     """Subdivide a single-day window by órgão julgador buckets.
 
     Every bucket must individually fit the ES result window, and the bucket
@@ -210,7 +277,7 @@ def _fetch_day_by_orgao(tipo: str, day: str, day_total: int) -> list[dict]:
         if value == 0:
             continue
         covered += value
-        docs.extend(_fetch_pages(tipo, day, day, extra_fields=extra))
+        docs.extend(_fetch_pages(tipo, day, day, extra_fields=extra, cache_dir=cache_dir))
 
     if covered != day_total:
         msg = (
@@ -222,7 +289,9 @@ def _fetch_day_by_orgao(tipo: str, day: str, day_total: int) -> list[dict]:
     return docs
 
 
-def fetch_tipo_window(tipo: str, date_start: str, date_end: str) -> list[dict]:
+def fetch_tipo_window(
+    tipo: str, date_start: str, date_end: str, cache_dir: Path | None = None
+) -> list[dict]:
     """Fetch all docs of ``tipo`` with dtjulgamento in [date_start, date_end].
 
     Probes the window total first (1-doc request); windows larger than the
@@ -230,6 +299,9 @@ def fetch_tipo_window(tipo: str, date_start: str, date_end: str) -> list[dict]:
     day that still exceeds the window is subdivided by órgão julgador; if
     that cannot provably cover the day, :class:`JurisWindowOverflowError`
     is raised (a truncated window must NEVER be recorded as complete).
+
+    *cache_dir*, when given, enables page-level resume (see ``_fetch_pages``)
+    for the leaf window this call bottoms out at.
     """
     time.sleep(_REQUEST_INTERVAL)
     probe = search(tipo, from_=0, size=1, date_start=date_start, date_end=date_end)
@@ -247,8 +319,8 @@ def fetch_tipo_window(tipo: str, date_start: str, date_end: str) -> list[dict]:
                 total=total,
                 relation=relation,
             )
-            left = fetch_tipo_window(tipo, date_start, mid)
-            right = fetch_tipo_window(tipo, mid_next, date_end)
+            left = fetch_tipo_window(tipo, date_start, mid, cache_dir=cache_dir)
+            right = fetch_tipo_window(tipo, mid_next, date_end, cache_dir=cache_dir)
             return left + right
         log.warning(
             "juris_window_overflow_single_day",
@@ -257,14 +329,14 @@ def fetch_tipo_window(tipo: str, date_start: str, date_end: str) -> list[dict]:
             total=total,
             relation=relation,
         )
-        return _fetch_day_by_orgao(tipo, date_start, total)
-    return _fetch_pages(tipo, date_start, date_end)
+        return _fetch_day_by_orgao(tipo, date_start, total, cache_dir=cache_dir)
+    return _fetch_pages(tipo, date_start, date_end, cache_dir=cache_dir)
 
 
-def fetch_tipo_month(tipo: str, year_month: str) -> list[dict]:
+def fetch_tipo_month(tipo: str, year_month: str, cache_dir: Path | None = None) -> list[dict]:
     """Fetch all docs of a given tipo julgados in ``year_month`` (AAAA-MM)."""
     date_start, date_end = _month_bounds(year_month)
-    docs = fetch_tipo_window(tipo, date_start, date_end)
+    docs = fetch_tipo_window(tipo, date_start, date_end, cache_dir=cache_dir)
     log.info("fetch_tipo_month_done", tipo=tipo, year_month=year_month, total=len(docs))
     return docs
 
@@ -287,6 +359,7 @@ def crawl_all(
     tipos: list[str] | None = None,
     start_year_month: str | None = None,
     skip: Callable[[str, str], bool] | None = None,
+    cache_dir: Path | None = None,
 ) -> Iterator[tuple[str, str, list[dict]]]:
     """Yield (tipo, year_month, docs), fetching each month with date filters.
 
@@ -296,7 +369,10 @@ def crawl_all(
     ``start_year_month`` (AAAA-MM) narrows the start below year granularity
     (months before it are not yielded). ``skip(tipo, year_month)`` returning
     True short-circuits a window BEFORE any request is made — used to skip
-    windows the manifest already records as complete.
+    windows the manifest already records as complete. ``cache_dir``, when
+    given, persists in-progress pagination per window so a mid-month failure
+    (STIC block, transport error) resumes from the last completed page on
+    retry instead of restarting the whole month — see ``_fetch_pages``.
     """
     if end_year_month is None:
         end_year_month = datetime.now(UTC).strftime("%Y-%m")
@@ -308,4 +384,4 @@ def crawl_all(
             if skip is not None and skip(tipo, year_month):
                 log.info("crawl_window_skipped", tipo=tipo, year_month=year_month)
                 continue
-            yield tipo, year_month, fetch_tipo_month(tipo, year_month)
+            yield tipo, year_month, fetch_tipo_month(tipo, year_month, cache_dir=cache_dir)

--- a/tests/tjro_juris/test_juris_client.py
+++ b/tests/tjro_juris/test_juris_client.py
@@ -36,6 +36,28 @@ def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(client_mod, "_sleep", lambda _s: None)
 
 
+# ── PAGE_SIZE (JURIS_PAGE_SIZE env override) ──────────────────────────────
+
+
+def test_page_size_defaults_to_2000_without_env_override() -> None:
+    assert PAGE_SIZE == client_mod._DEFAULT_PAGE_SIZE == 2000
+
+
+def test_resolve_page_size_defaults_when_env_var_unset() -> None:
+    assert client_mod._resolve_page_size({}) == 2000
+
+
+def test_resolve_page_size_reads_juris_page_size_override() -> None:
+    """Live-tested ceiling (2026-07-15): 2000 is fast/clean, 5000 is slow,
+    10000 500s server-side — JURIS_PAGE_SIZE lets this be tuned without a
+    code change if the backend's tolerance shifts. Tests the pure parsing
+    helper directly rather than reloading the module (a reload rebuilds
+    the shared httpx.Client and breaks respx interception for every other
+    test in this file).
+    """
+    assert client_mod._resolve_page_size({"JURIS_PAGE_SIZE": "777"}) == 777
+
+
 # ── clean_html ───────────────────────────────────────────────────────────
 
 

--- a/tests/tjro_juris/test_juris_crawler.py
+++ b/tests/tjro_juris/test_juris_crawler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -12,14 +13,21 @@ from tjro_juris.crawler import (
     JurisWindowOverflowError,
     _exceeds_window,
     _extract_doc,
+    _fetch_pages,
     _iter_year_months,
+    _load_partial_cache,
     _month_bounds,
+    _partial_cache_path,
     _split_range,
     _total,
     crawl_all,
     fetch_tipo_month,
     fetch_tipo_window,
 )
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -402,13 +410,124 @@ def test_fetch_window_supports_results_key_shape(monkeypatch: pytest.MonkeyPatch
     assert [d["id_documento"] for d in docs] == [1, 2]
 
 
+# ── _fetch_pages page-level resume (cache_dir) ────────────────────────────
+
+
+def test_partial_cache_path_unique_per_extra_fields(tmp_path: Path) -> None:
+    """Bisected/órgão sub-windows sharing a date range must not collide."""
+    p1 = _partial_cache_path(tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-01", None)
+    p2 = _partial_cache_path(
+        tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-01", {"ds_orgao_julgador.raw": ["A"]}
+    )
+    p3 = _partial_cache_path(
+        tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-01", {"ds_orgao_julgador.raw": ["B"]}
+    )
+    assert len({p1, p2, p3}) == 3
+
+
+def test_fetch_pages_deletes_cache_on_successful_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fake(
+        tipo: str,
+        from_: int = 0,
+        size: int = PAGE_SIZE,
+        texto: str = "",
+        *,
+        date_start: str | None = None,
+        date_end: str | None = None,
+        extra_fields: dict | None = None,
+    ) -> dict:
+        if from_ == 0:
+            return _es_response([_hit(1), _hit(2)])
+        return _es_response([])
+
+    monkeypatch.setattr(crawler, "search", _fake)
+    docs = _fetch_pages("ACÓRDÃO", "2024-01-01", "2024-01-31", cache_dir=tmp_path)
+
+    assert [d["id_documento"] for d in docs] == [1, 2]
+    cache_path = _partial_cache_path(tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-31", None)
+    assert not cache_path.exists()  # window PROVABLY complete — staging cleaned up
+
+
+def test_fetch_pages_leaves_cache_behind_on_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure mid-window must leave whatever was fetched so far on disk —
+    never silently discarded, never marked complete.
+    """
+
+    class _BoomError(RuntimeError):
+        pass
+
+    def _fake(
+        tipo: str,
+        from_: int = 0,
+        size: int = PAGE_SIZE,
+        texto: str = "",
+        *,
+        date_start: str | None = None,
+        date_end: str | None = None,
+        extra_fields: dict | None = None,
+    ) -> dict:
+        if from_ == 0:
+            return _es_response([_hit(1)] * size)  # full page — loop continues
+        msg = "simulated STIC block"
+        raise _BoomError(msg)
+
+    monkeypatch.setattr(crawler, "search", _fake)
+    with pytest.raises(_BoomError):
+        _fetch_pages("ACÓRDÃO", "2024-01-01", "2024-01-31", cache_dir=tmp_path)
+
+    cache_path = _partial_cache_path(tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-31", None)
+    cached = _load_partial_cache(cache_path)
+    assert len(cached) == PAGE_SIZE  # exactly the one page that succeeded, not lost
+
+
+def test_fetch_pages_resumes_from_partial_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second attempt picks up at from_=len(cached docs), not from_=0 —
+    the earlier page is never re-fetched.
+    """
+    cache_path = _partial_cache_path(tmp_path, "ACÓRDÃO", "2024-01-01", "2024-01-31", None)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text('{"id_documento": 1, "tipo": "ACÓRDÃO"}\n', encoding="utf-8")
+
+    seen_from: list[int] = []
+
+    def _fake(
+        tipo: str,
+        from_: int = 0,
+        size: int = PAGE_SIZE,
+        texto: str = "",
+        *,
+        date_start: str | None = None,
+        date_end: str | None = None,
+        extra_fields: dict | None = None,
+    ) -> dict:
+        seen_from.append(from_)
+        if from_ == 1:
+            return _es_response([_hit(2)])
+        return _es_response([])
+
+    monkeypatch.setattr(crawler, "search", _fake)
+    docs = _fetch_pages("ACÓRDÃO", "2024-01-01", "2024-01-31", cache_dir=tmp_path)
+
+    assert seen_from[0] == 1  # resumed, did not restart at 0
+    assert [d["id_documento"] for d in docs] == [1, 2]
+    assert not cache_path.exists()  # completed normally — cleaned up
+
+
 # ── fetch_tipo_month ─────────────────────────────────────────────────────
 
 
 def test_fetch_tipo_month_uses_month_bounds(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[tuple[str, str, str]] = []
 
-    def _fake_window(tipo: str, date_start: str, date_end: str) -> list[dict]:
+    def _fake_window(
+        tipo: str, date_start: str, date_end: str, cache_dir: object = None
+    ) -> list[dict]:
         seen.append((tipo, date_start, date_end))
         return [{"id_documento": 5, "tipo": tipo}]
 
@@ -438,7 +557,7 @@ def test_iter_year_months_crosses_year_boundary() -> None:
 def test_crawl_all_fetches_each_tipo_month_once(monkeypatch: pytest.MonkeyPatch) -> None:
     fetched: list[tuple[str, str]] = []
 
-    def _fake_month(tipo: str, year_month: str) -> list[dict]:
+    def _fake_month(tipo: str, year_month: str, cache_dir: object = None) -> list[dict]:
         fetched.append((tipo, year_month))
         if year_month == "2024-01":
             return [{"id_documento": 1, "tipo": tipo}]


### PR DESCRIPTION
## Summary

Found live, mid-backfill: TJRO's STIC anti-abuse system can block a sustained crawl partway through a year. Three compounding gaps meant a single block wasted far more work than necessary:

1. **`crawl()` only saved the manifest once, at the end of all 7 tipos.** A block partway through left already-fetched tipos (real parquet files on disk) completely unrecorded — invisible to the separate `upload()` process, and re-fetched from scratch on retry even though the data was already safely on disk. Now saved after **every** `(tipo, year_month)` window.
2. **Skip logic only skipped manifest-"uploaded" windows**, never a window whose parquet was already written locally in an earlier interrupted attempt. `crawl()` now also skips any window whose parquet file already exists on disk.
3. **No resume within a month's pagination.** A page-3-of-N failure discarded all N-1 already-fetched pages; retry restarted from page 0. Added a `cache_dir`-based JSONL staging file per window that each page appends to; resume picks up at `from_=len(cached)`, and the staging file is deleted **only** when the window is provably complete (a short/empty page) — an error always leaves it behind on purpose.

Also: `PAGE_SIZE` bumped 400 → 2000 (live-tested 2026-07-15: 2000 fast/clean, 5000 slow/risky, 10000 500s server-side), overridable via `JURIS_PAGE_SIZE` without a code change.

## Test plan
- [x] New tests: page-cache round-trip (resume, cleanup-on-success, leave-behind-on-error), cache-path uniqueness across bisected/órgão sub-windows, `PAGE_SIZE` env override (pure-function test, not module reload — reload was found to break respx interception for other tests in the same file)
- [x] Existing crawl/manifest/skip-window tests updated for the new `cache_dir` parameter
- [x] `uv run ruff check && ruff format --check && pytest -q` — all clean, 95/95 tjro_juris tests + full suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cer4wHLPHztUVHhVZuwWJV