### PR TITLE
chore(ci): standardize Python dependency installs

### DIFF
--- a/.github/actions/download-state/action.yml
+++ b/.github/actions/download-state/action.yml
@@ -13,8 +13,7 @@ runs:
         # generate_catalog.py) still read, unchanged.
         if curl -sSfL -o data/sync-manifest.parquet \
           "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"; then
-          pip install --quiet duckdb
-          python3 -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
+          uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
             || echo "$HEADER" > data/sync-manifest.csv
         else
           echo "$HEADER" > data/sync-manifest.csv

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Install dev dependencies (default: true)"
     required: false
     default: "true"
+  groups:
+    description: "Comma-separated dependency groups to install in addition to the default project dependencies"
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -14,9 +18,26 @@ runs:
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: .uv
-        key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+        key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}-${{ inputs.dev }}-${{ inputs.groups }}
     - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: latest
-    - run: uv sync ${{ inputs.dev == 'true' && '--dev' || '--no-dev' }}
+    - run: |
+        set -euo pipefail
+        args=()
+        if [ "${{ inputs.dev }}" = "true" ]; then
+          args+=(--dev)
+        else
+          args+=(--no-dev)
+        fi
+        if [ -n "${{ inputs.groups }}" ]; then
+          IFS=',' read -ra groups <<< "${{ inputs.groups }}"
+          for group in "${groups[@]}"; do
+            group="${group//[[:space:]]/}"
+            if [ -n "$group" ]; then
+              args+=(--group "$group")
+            fi
+          done
+        fi
+        uv sync "${args[@]}"
       shell: bash

--- a/.github/workflows/backfill-probe.yml
+++ b/.github/workflows/backfill-probe.yml
@@ -36,14 +36,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: ./.github/actions/setup
+        with:
+          dev: "false"
 
       - name: Run probe (writes report)
         id: probe
         continue-on-error: true
         run: |
           set +e
-          uv run --no-dev --with httpx python scripts/backfill_probe.py | tee probe-report.txt
+          uv run --no-dev python scripts/backfill_probe.py | tee probe-report.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Append report to job summary

--- a/.github/workflows/bootstrap-corpus.yml
+++ b/.github/workflows/bootstrap-corpus.yml
@@ -58,11 +58,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           dev: "true"
-
-      - name: Install opf + transformers
-        run: |
-          uv pip install --python .venv/bin/python \
-            "opf @ git+https://github.com/openai/privacy-filter.git"
+          groups: "opf"
 
       - name: Cache OPF base checkpoint
         uses: actions/cache@v4
@@ -142,7 +138,6 @@ jobs:
       - name: Upload intermediate to IA
         if: success()
         run: |
-          uv pip install --python .venv/bin/python internetarchive
           uv run ia upload causaganha-segmenter-data \
             data/intermediate.jsonl \
             --metadata="collection:opensource" \

--- a/.github/workflows/bootstrap-corpus.yml
+++ b/.github/workflows/bootstrap-corpus.yml
@@ -75,7 +75,7 @@ jobs:
           fi
           for attempt in 1 2 3 4; do
             echo "Download attempt $attempt..."
-            if uv run python -c "from opf._common.checkpoint_download import ensure_default_checkpoint; ensure_default_checkpoint()"; then
+            if uv run --no-sync python -c "from opf._common.checkpoint_download import ensure_default_checkpoint; ensure_default_checkpoint()"; then
               echo "Checkpoint downloaded successfully"
               exit 0
             fi
@@ -103,7 +103,7 @@ jobs:
 
       - name: Run OPF + heuristic (Stage 1)
         run: |
-          uv run python scripts/bootstrap_training_corpus.py \
+          uv run --no-sync python scripts/bootstrap_training_corpus.py \
             --input data/bootstrap_texts/train.jsonl \
             --target ${{ inputs.target || '500' }} \
             --device -1 \

--- a/.github/workflows/consolidate-parquet.yml
+++ b/.github/workflows/consolidate-parquet.yml
@@ -85,8 +85,7 @@ jobs:
           HEADER='tribunal,date,ia_status,djen_status,djen_raw,updated_at'
           if curl -sSfL -o data/sync-manifest.parquet \
             "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"; then
-            pip install --quiet duckdb
-            python3 -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
+            uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
               || echo "$HEADER" > data/sync-manifest.csv
           else
             echo "$HEADER" > data/sync-manifest.csv

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -35,9 +35,9 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: ./.github/actions/setup
         with:
-          python-version: '3.12'
+          dev: "false"
 
       - name: Restore pipeline cache (for last_run stats)
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -66,8 +66,6 @@ jobs:
 
       - name: Generate web data from query contracts
         run: |
-          pip install uv
-          uv sync --no-dev
           mkdir -p web/public/cache web/public/data
           # Render .qmd query contracts → JSON in web/public/data/
           # --strict (RFC 0007): a required contract that fails to render

--- a/.github/workflows/drain-unknowns.yml
+++ b/.github/workflows/drain-unknowns.yml
@@ -48,7 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: ./.github/actions/setup
+        with:
+          dev: "false"
 
       - name: Drain
         run: uv run --no-dev python scripts/drain_unknowns.py

--- a/.github/workflows/render-manifest-parquet.yml
+++ b/.github/workflows/render-manifest-parquet.yml
@@ -33,5 +33,7 @@ jobs:
       IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: ./.github/actions/setup
+        with:
+          dev: "false"
       - run: uv run --no-dev python scripts/render_manifest_parquet.py

--- a/.github/workflows/roundtrip-check.yml
+++ b/.github/workflows/roundtrip-check.yml
@@ -54,8 +54,7 @@ jobs:
           # fallback (matches prior behavior: fail hard if unavailable).
           curl -sSfL -o data/sync-manifest.parquet \
             "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"
-          pip install --quiet duckdb
-          python3 -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")"
+          uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")"
           echo "Manifest rows: $(tail -n +2 data/sync-manifest.csv | wc -l)"
 
       - name: Run roundtrip equivalence check

--- a/.github/workflows/upload-backlog.yml
+++ b/.github/workflows/upload-backlog.yml
@@ -24,6 +24,8 @@ jobs:
       IA_UPLOAD_RATE_LIMIT: "48"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: ./.github/actions/setup
+        with:
+          dev: "false"
       - name: Drain pending uploads (download + upload to IA)
         run: uv run --no-dev djen-backup drain --workers 24 --batch-size 200 --deadline-minutes 55 --use-proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
 ]
 
 [dependency-groups]
+opf = [
+    # OpenAI Privacy Filter bootstrap workflow (Stage 1 CPU labeling).
+    "opf @ git+https://github.com/openai/privacy-filter.git",
+]
 classify = [
     # LLM abstraction layer used by analysis/llm_analyzer.py
     "litellm>=1.40.0",


### PR DESCRIPTION
### Motivation
- Tornar consistentes as instalações Python nos workflows, evitando `pip install` soltos que ignoram o lock/declaração do projeto. 
- Permitir que workflows peçam grupos de dependências reproduzíveis ao compartilhar um setup comum. 
- Reduzir instalações ad-hoc em jobs que impactam deploy ou dados de produção e melhorar cacheabilidade do ambiente `uv`.

### Description
- Estende a action compartilhada `/.github/actions/setup/action.yml` com um input `groups`, inclui `inputs` na chave de cache e monta `uv sync` para aceitar `--dev`/`--no-dev` e `--group` conforme necessário. 
- Declara o grupo de dependências `opf` em `pyproject.toml` para mover a instalação OPF do bootstrap para um `uv sync --group`. 
- Substitui usos diretos de `astral-sh/setup-uv` e instalações inline (`pip install`, `uv pip install`) por chamadas à action compartilhada (`uses: ./.github/actions/setup`) com `dev: "false"` ou `groups: "opf"` e converte comandos dispersos para `uv run --no-dev python -c` quando apropriado. 
- Remove `pip install uv`/`uv sync` inline do deploy e elimina instalações avulsas de `duckdb`/`internetarchive` nos workflows que agora dependem do ambiente sincronizado.

### Testing
- Validei que `pyproject.toml` é um TOML válido com `tomllib.load` e a verificação retornou sucesso. 
- Validei que todos os `*.yml` e `*/action.yml` em `.github` parseiam com `yaml.safe_load` e não há erros de sintaxe. 
- Rodei `git diff --check` para checagem de style/tabs e as verificações automáticas incluídas no rollout passaram sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a577f47aa5c832598d8d6bbd73dff83)