### PR TITLE
test: add data contract coverage

### DIFF
--- a/tests/consolidate/test_data_contract_zip_parquet.py
+++ b/tests/consolidate/test_data_contract_zip_parquet.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import ibis
+import pyarrow.parquet as pq
+
+from causaganha.consolidate.exporter import export_table_sync
+from causaganha.consolidate.schema_registry import CURRENT_VERSION, get_current_schema
+from causaganha.consolidate.transforms import TABLES, init_tables, load_and_transform
+from causaganha.consolidate.zip_processor import stream_zip_to_ndjson
+
+
+def _minimal_record() -> dict[str, object]:
+    return {
+        "id": "pub-1",
+        "texto": "JULGO PROCEDENTE o pedido.",
+        "numeroProcesso": "0001234-56.2026.8.26.0100",
+        "dataDisponibilizacao": "2026-04-01",
+        "tipoComunicacao": "Intimação",
+        "nomeOrgao": "1ª Vara Cível",
+        "meio": "Eletrônico",
+        "link": "https://example.test/pub-1",
+        "tipoDocumento": "Sentença",
+        "nomeClasse": "Procedimento Comum",
+        "codigoClasse": "7",
+        "numeroComunicacao": "001",
+        "hash": "abc123",
+        "destinatarios": [{"nome": "JOÃO DA SILVA", "polo": "Ativo"}],
+        "destinatarioadvogados": [
+            {"advogado": {"nome": "DRA MARIA OLIVEIRA", "numeroOAB": "12345", "ufOAB": "SP"}}
+        ],
+    }
+
+
+def test_minimal_zip_to_consolidated_parquet_schema_contract(tmp_path: Path) -> None:
+    zip_path = tmp_path / "djen-2026-04-01-TJSP.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("comunicacoes.json", json.dumps({"items": [_minimal_record()]}))
+
+    ndjson_dir = tmp_path / "ndjson"
+    ndjson_dir.mkdir()
+    ndjson_path = ndjson_dir / "TJSP__djen-2026-04-01-TJSP.ndjson"
+    assert stream_zip_to_ndjson(zip_path, ndjson_path, "TJSP") == 1
+
+    con = ibis.duckdb.connect()
+    init_tables(con)
+    counts = load_and_transform(con, ndjson_dir, item_id="djen-tjsp-2026")
+    assert counts == dict.fromkeys(TABLES, 1)
+
+    parquet_dir = tmp_path / "parquet"
+    parquet_dir.mkdir()
+    exported = export_table_sync("comunicacoes", con, parquet_dir, item_id="djen-tjsp-2026")
+    assert exported is not None
+
+    parquet_path, _size_mb, row_count = exported
+    assert row_count == 1
+    arrow_schema = pq.read_schema(parquet_path)
+    expected = get_current_schema().tables["comunicacoes"]
+    assert arrow_schema.names == list(expected.names)
+    assert arrow_schema.metadata is not None
+    assert arrow_schema.metadata[b"causaganha.schema_version"].decode() == CURRENT_VERSION
+    assert arrow_schema.metadata[b"causaganha.item_id"].decode() == "djen-tjsp-2026"

--- a/tests/fixtures/manifest_contract_rows.csv
+++ b/tests/fixtures/manifest_contract_rows.csv
@@ -1,0 +1,7 @@
+tribunal,date,ia_status,djen_status,djen_raw,updated_at
+TJSP,2026-04-01,uploaded,available,200,2026-04-01T12:00:00+00:00
+TJSP,2026-04-02,,absent,404,2026-04-02T12:00:00+00:00
+TJSP,2026-04-03,,,403,2026-04-03T12:00:00+00:00
+TJRO,2026-04-01,,available,200:https://example.test/djen.zip,2026-04-01T13:00:00+00:00
+TJRO,2026-04-02,,absent,no_publications,2026-04-02T13:00:00+00:00
+TJRO,2026-04-03,,,,

--- a/tests/test_data_contract_manifest.py
+++ b/tests/test_data_contract_manifest.py
@@ -45,6 +45,29 @@ def test_manifest_fixture_load_counts_and_queries() -> None:
     assert transient.djen_status == ""
 
 
+def test_absent_status_with_bare_200_raw_is_rewritten_to_no_publications() -> None:
+    """Self-consistency guard (plan §5 Fase 1): an ``absent`` verdict paired
+    with a bare ``200`` raw contradicts itself, since ``interpret_djen_raw``
+    would otherwise re-derive ``200`` as ``available``. This is the exact
+    bug class that produced ~79K false-available legacy rows — a checker
+    that read only the HTTP 200 and never inspected the body.
+    """
+    manifest = SyncManifest()
+    manifest.apply_event(
+        "TJRO",
+        date(2026, 4, 5),
+        djen_status="absent",
+        djen_raw="200",
+        updated_at="2026-04-05T10:00:00+00:00",
+    )
+
+    entry = manifest.get_status("TJRO", date(2026, 4, 5))
+    assert entry is not None
+    assert entry.djen_raw == "no_publications"
+    assert entry.djen_status == "absent"
+    assert interpret_djen_raw(entry.djen_raw) == "absent"
+
+
 def test_segment_merge_is_field_level_last_write_wins() -> None:
     manifest = SyncManifest()
     manifest.load_from_csv(FIXTURE.read_text(encoding="utf-8"), overwrite=True)

--- a/tests/test_data_contract_manifest.py
+++ b/tests/test_data_contract_manifest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from djen_backup.manifest import SyncManifest, interpret_djen_raw
+
+
+FIXTURE = Path("tests/fixtures/manifest_contract_rows.csv")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", ""),
+        ("200", "available"),
+        ("200:https://example.test/djen.zip", "available"),
+        ("404", "absent"),
+        ("400", "absent"),
+        ("no_publications", "absent"),
+        ("403", ""),
+        ("500", ""),
+        ("timeout", ""),
+        ("network", ""),
+    ],
+)
+def test_interpret_djen_raw_contract(raw: str, expected: str) -> None:
+    assert interpret_djen_raw(raw) == expected
+
+
+def test_manifest_fixture_load_counts_and_queries() -> None:
+    manifest = SyncManifest()
+    loaded = manifest.load_from_csv(FIXTURE.read_text(encoding="utf-8"), overwrite=True)
+
+    assert loaded == 6
+    assert manifest.counts() == (6, 1, 1, 2, 2)
+    assert manifest.has_uploaded_entries("tjsp", 2026) is True
+    assert manifest.entries_needing_upload()
+
+    transient = manifest.get_status("TJSP", date(2026, 4, 3))
+    assert transient is not None
+    assert transient.djen_raw == "403"
+    assert transient.djen_status == ""
+
+
+def test_segment_merge_is_field_level_last_write_wins() -> None:
+    manifest = SyncManifest()
+    manifest.load_from_csv(FIXTURE.read_text(encoding="utf-8"), overwrite=True)
+
+    segment = """tribunal,date,ia_status,djen_status,djen_raw,updated_at
+TJSP,2026-04-03,,absent,404,2026-04-03T11:00:00+00:00
+TJSP,2026-04-02,uploaded,,,2026-04-02T11:00:00+00:00
+TJRO,2026-04-03,,confirmed,200,2026-04-03T14:00:00+00:00"""
+    applied = manifest.apply_segment_csv(segment)
+
+    assert applied == 3
+    assert manifest.counts() == (6, 2, 2, 1, 1)
+    assert manifest.get_status("TJSP", date(2026, 4, 3)).djen_raw == "403"  # type: ignore[union-attr]
+    assert manifest.get_status("TJSP", date(2026, 4, 2)).ia_status == "uploaded"  # type: ignore[union-attr]
+    assert manifest.get_status("TJRO", date(2026, 4, 3)).djen_status == "available"  # type: ignore[union-attr]

--- a/web/src/lib/data/__fixtures__/contractPayloads.ts
+++ b/web/src/lib/data/__fixtures__/contractPayloads.ts
@@ -1,0 +1,23 @@
+import type { ContractName } from '../contracts';
+
+export const validContractPayloads = {
+  consolidation_status: { total_dates_with_uploads: 1, dates_fully_uploaded: 1, dates_partially_uploaded: 0, earliest_date: '2026-04-01', latest_date: '2026-04-01' },
+  court_reliability: [{ court: 'TJSP', collected: 1, absent: 0, total: 1, rate: 1 }],
+  daily_uploads: [{ date: '2026-04-01', count: 1 }],
+  datajud_classes: [{ classe_nome: 'Procedimento Comum', total: 1 }],
+  datajud_totals: { total_processos: 1, total_registros: 1, total_tribunais: 1, ultima_atualizacao: '2026-04-01' },
+  juris_classes: [{ classe_judicial: null, total: 1 }],
+  juris_orgaos: [{ orgao: null, total: 1 }],
+  juris_totals: { total_documentos: 1, total_tipos: 1, total_orgaos: 1, data_mais_recente: '2026-04-01' },
+  lawyer_leaderboard: [{ lawyer_name: 'DRA MARIA OLIVEIRA', oab_number: '12345', oab_state: 'SP', rating: 25, mu: 25, sigma: 8.333, total_cases: 1, wins: 1, losses: 0, win_rate: 1 }],
+  processos_multi_fonte: [{ nr_processo: '00012345620268260100', nr_processo_mascara: '0001234-56.2026.8.26.0100', n_fontes: 1, fontes: ['djen'], djen_n_publicacoes: 1, djen_primeira_pub: '2026-04-01', djen_ultima_pub: '2026-04-01', juris_n_documentos: null, juris_classe: null, juris_orgao: null, juris_relator: null, juris_data_julgamento: null, juris_url: null, stj_tema: null, stj_classe: null, stj_relator: null, stj_data_decisao: null, tem_datajud: false, classe_oficial: null }],
+  site_status: { generated_at: '2026-04-01T12:00:00Z', sources: { djen: { zips_archived: 1, pairs_total: 3, tribunals_with_data: 1, tribunals_total: 1, coverage_pct: 33.3, earliest_tracked_date: '2026-04-01', earliest_upload_date: '2026-04-01', latest_upload_date: '2026-04-01', absent_confirmed: 1, pending_real: 1, errors_transient: 0, never_checked: 0, last_attempt_at: '2026-04-01T12:00:00Z', last_success_at: '2026-04-01T12:00:00Z' } } },
+  stats_coverage: { avg_coverage: 50, best_count: 2, best_day: '2026-04-01', worst_count: 1, worst_day: '2026-04-02' },
+  stj_relatores: [{ ministroRelator: null, total: 1 }],
+  stj_temas: [{ tema: null, total: 1 }],
+  stj_totals: { total: 1, total_temas: 1, ultima_decisao: '2026-04-01' },
+  totals: { total: 3, uploaded: 1, pending: 1, absent: 1, unknown: 0, coverage_pct: 33.3, tribunals_total: 1, tribunals_with_data: 1 },
+  tribunal_calendar: [{ tribunal: 'TJSP', date: '2026-04-01', status: 'uploaded' }],
+  tribunal_coverage: [{ tribunal: 'TJSP', uploaded: 1, pending: 1, absent: 1, unknown: 0, total: 3, coverage_pct: 33.3, earliest_upload: '2026-04-01', latest_upload: '2026-04-01' }],
+  weekly_pattern: [{ day_idx: 3, name: 'Qua', avg: 1, days_count: 1 }],
+} satisfies Record<ContractName, unknown>;

--- a/web/src/lib/data/contracts.test.ts
+++ b/web/src/lib/data/contracts.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { contracts } from './contracts';
+import { validContractPayloads } from './__fixtures__/contractPayloads';
+
+describe('web/public/data contract schemas', () => {
+  it('accept every representative generated JSON payload', () => {
+    for (const [name, contract] of Object.entries(contracts)) {
+      const result = contract.schema.safeParse(validContractPayloads[name as keyof typeof validContractPayloads]);
+      expect(result.success, `${name}: ${result.success ? '' : result.error.message}`).toBe(true);
+    }
+  });
+
+  it('keeps the schema registry and test fixtures in lockstep', () => {
+    expect(Object.keys(validContractPayloads).sort()).toEqual(Object.keys(contracts).sort());
+  });
+});


### PR DESCRIPTION
### Motivation

- Garantir contratos de dados entre módulos principais (manifest, consolidação Parquet e frontend) com testes mínimos representativos;
- Detectar regressões no parsing/merge do manifesto e na exportação Parquet (schema e metadados) antes de deploy do dashboard; 
- Validar que os JSONs gerados para `web/public/data/` obedecem aos Zod schemas em `web/src/lib/data/contracts.ts`.

### Description

- Adiciona uma fixture CSV reduzida cobrindo combinações de `ia_status`, `djen_status`, `djen_raw` e `updated_at` em `tests/fixtures/manifest_contract_rows.csv`.
- Implementa testes para `src/djen_backup/manifest.py` verificando `interpret_djen_raw`, `load_from_csv`/merge, `counts()` e replay de segmentos com semântica last-write-wins em `tests/test_data_contract_manifest.py`.
- Adiciona teste de pipeline mínimo ZIP → NDJSON → Ibis/DuckDB → Parquet que valida presença/ordem de colunas e metadados KV footer (`causaganha.schema_version` e `causaganha.item_id`) em `tests/consolidate/test_data_contract_zip_parquet.py`.
- Inclui payloads representativos para todos os contratos `web/public/data/` e um teste Vitest que valida cada payload contra os schemas Zod em `web/src/lib/data/__fixtures__/contractPayloads.ts` e `web/src/lib/data/contracts.test.ts`.

### Testing

- Executado: `uv run pytest tests/test_data_contract_manifest.py tests/consolidate/test_data_contract_zip_parquet.py -q`; resultado: passou.
- Executado: `npm test -- --run src/lib/data/contracts.test.ts` dentro de `web/`; resultado: passou.
- Executado: `uv run ruff check` e `uv run ruff format --check` sobre os novos testes; resultado: passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a577f50f74c8325aafecef52e653a02)