### PR TITLE
Support DataJud API key override and document public key rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ JINA_API_KEY=your_jina_api_key_here
 IA_ACCESS_KEY=your_ia_access_key_here
 IA_SECRET_KEY=your_ia_secret_key_here
 
+
+# =============================================================================
+# DATAJUD API CONFIGURATION
+# =============================================================================
+# Optional override for the `datajud` CLI and DataJud enrichment jobs.
+# Production has a public default in src/causaganha/config.py.
+# Get the current public API key from docs/datajud-api-keys.md or the CNJ DataJud wiki:
+# https://datajud-wiki.cnj.jus.br/api-publica/acesso/
+# Rotate this value in local .env files and CI secrets whenever CNJ updates it.
+DATAJUD_API_KEY=your_datajud_api_key_here
+
 # =============================================================================
 # HTTP RELAY (STJ / TJRO — bypasses GitHub-runner IP blocks in CI)
 # =============================================================================
@@ -103,6 +114,9 @@ ANALYTICS_DB_PATH=data/analytics.duckdb
 #
 # Required for basic functionality:
 # - GEMINI_API_KEY (for PDF extraction)
+#
+# Optional override for DataJud enrichment / `datajud` CLI:
+# - DATAJUD_API_KEY (from docs/datajud-api-keys.md or the CNJ DataJud wiki)
 #
 # Required for Internet Archive upload:
 # - IA_ACCESS_KEY (for archival)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ All modes persist the manifest to IA every 10 minutes. See `uv run djen-backup -
 
 Parquet consolidation is a module CLI (`python -m causaganha.consolidate`), not a registered console script.
 
+
+### `datajud` — CNJ process metadata enrichment
+
+The `datajud` CLI uses the configured public key default in `src/causaganha/config.py`; set `DATAJUD_API_KEY` in local, production, or CI environments when you need to override/rotate it without a deploy. Obtain the current public key from the CNJ DataJud access page: https://datajud-wiki.cnj.jus.br/api-publica/acesso/ or from the committed rotation log in `docs/datajud-api-keys.md`.
+
+When the CNJ rotates the key (usually visible as HTTP 401 responses), add the new public key to `docs/datajud-api-keys.md`, update local `.env` files, and rotate the CI/production secret named `DATAJUD_API_KEY`; no code change is needed. The production default lives in `src/causaganha/config.py`; the environment variable takes precedence for emergency rotation.
+
+```bash
+# Example local run with .env populated from .env.example
+uv run --env-file .env datajud enrich --tribunal tjro --skip-upload
+```
+
+
 ## Web frontend
 
 The frontend lives in [web](web) and uses:

--- a/docs/datajud-api-keys.md
+++ b/docs/datajud-api-keys.md
@@ -1,0 +1,14 @@
+# DataJud public API key history
+
+The DataJud API key is public and published by CNJ. Production code keeps the
+current key as the configured default in `src/causaganha/config.py`, while
+`DATAJUD_API_KEY` remains the runtime override for rotations without deploys.
+
+Use this file as the committed rotation log. When CNJ publishes a new key at
+<https://datajud-wiki.cnj.jus.br/api-publica/acesso/>, add a new row at the top,
+update local `.env` files and rotate the `DATAJUD_API_KEY` secret in CI/production.
+Keep old rows so operators can tell which key was active in historical runs.
+
+| First seen | Source | Status | Public API key |
+|---|---|---|---|
+| 2026-07-15 | CNJ DataJud wiki / previously embedded client default | Current known working key | `cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw==` |

--- a/src/causaganha/config.py
+++ b/src/causaganha/config.py
@@ -127,6 +127,15 @@ TRIBUNAIS: list[str] = [
     "TRE-TO",
 ]
 
+# DataJud public API key defaults.
+#
+# The CNJ publishes this API key publicly for DataJud access. Keep the runtime
+# override in DATAJUD_API_KEY for rotation without deploys, but retain the
+# current public key here as the production default so DataJud keeps working
+# when no override is provided. When CNJ rotates the key, update this constant
+# and append the old/new values to docs/datajud-api-keys.md.
+DATAJUD_PUBLIC_API_KEY_DEFAULT = "cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw=="
+
 # DJEN URLs: direct is the default for local runs in Brazil; proxy is opt-in.
 DJEN_DIRECT_URL = os.environ.get("DJEN_DIRECT_URL", "https://comunicaapi.pje.jus.br")
 DJEN_PROXY_URL = os.environ.get("DJEN_PROXY_URL", "https://djen-proxy-mhgmawcn3a-rj.a.run.app")

--- a/src/datajud/client.py
+++ b/src/datajud/client.py
@@ -12,8 +12,8 @@ Traps handled here (mapped in production by the owner's CLI client):
 - ``track_total_hits: true`` always (otherwise totals saturate at 10000).
 - Textual fields need ``.keyword`` in sort/term/agg (the raw field is
   ``text`` and returns HTTP 400).
-- HTTP 401 → :class:`DataJudAuthError` with rotation instructions (the CNJ
-  may rotate the public key; override via the ``DATAJUD_API_KEY`` env var).
+- HTTP 401 → :class:`DataJudAuthError` with rotation instructions. Production
+  and CI usage can override the configured public default via the ``DATAJUD_API_KEY`` env var.
 - Batch CNJ lookup (``terms`` on ``numeroProcesso``, paginated) — never one
   request per CNJ. Internal rate limiting (aiolimiter) plus a pause between
   batches keeps the CNJ's ES queue happy.
@@ -31,6 +31,7 @@ import structlog
 import tenacity
 from aiolimiter import AsyncLimiter
 
+from causaganha.config import DATAJUD_PUBLIC_API_KEY_DEFAULT
 from datajud.models import normalizar_cnj
 
 
@@ -43,10 +44,6 @@ log = structlog.get_logger()
 
 BASE_URL = "https://api-publica.datajud.cnj.jus.br"
 
-# Public CNJ key — the same for everyone, documented on the DataJud wiki.
-# If it starts returning 401, fetch the current one from WIKI_ACESSO_URL and
-# set the DATAJUD_API_KEY environment variable (rotation without a deploy).
-PUBLIC_API_KEY = "cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw=="
 API_KEY_ENV = "DATAJUD_API_KEY"
 WIKI_ACESSO_URL = "https://datajud-wiki.cnj.jus.br/api-publica/acesso/"
 
@@ -87,7 +84,7 @@ class DataJudError(RuntimeError):
 
 
 class DataJudAuthError(DataJudError):
-    """HTTP 401 — the public API key was probably rotated by the CNJ."""
+    """Missing/rejected DataJud API key or a key rotated by the CNJ."""
 
 
 class DataJudRateLimitError(DataJudError):
@@ -99,8 +96,13 @@ class _TransientRejectionError(Exception):
 
 
 def get_api_key() -> str:
-    """Return the API key: ``DATAJUD_API_KEY`` env override or the public default."""
-    return os.environ.get(API_KEY_ENV, "") or PUBLIC_API_KEY
+    """Return the DataJud API key from env or the configured public default.
+
+    ``DATAJUD_API_KEY`` is the rotation override for CI/production. The fallback
+    lives in ``causaganha.config`` with the committed key history documented in
+    ``docs/datajud-api-keys.md``.
+    """
+    return os.environ.get(API_KEY_ENV, "").strip() or DATAJUD_PUBLIC_API_KEY_DEFAULT
 
 
 def search_endpoint(tribunal: str) -> str:
@@ -321,9 +323,9 @@ def _raise_for_status_flavor(resp: httpx.Response) -> None:
     """Classify the response status into the client's error taxonomy."""
     if resp.status_code == HTTP_UNAUTHORIZED:
         msg = (
-            "HTTP 401 from DataJud: the public API key was probably rotated "
-            f"by the CNJ. Fetch the current key at {WIKI_ACESSO_URL} and set "
-            f"the {API_KEY_ENV} environment variable."
+            "HTTP 401 from DataJud: the configured API key was rejected "
+            f"or rotated by the CNJ. Fetch the current key at {WIKI_ACESSO_URL} "
+            f"and set the {API_KEY_ENV} environment variable."
         )
         raise DataJudAuthError(msg)
     if resp.status_code == HTTP_TOO_MANY_REQUESTS:

--- a/tests/datajud/test_datajud_client.py
+++ b/tests/datajud/test_datajud_client.py
@@ -198,6 +198,11 @@ def test_api_key_env_override(monkeypatch):
     assert get_api_key() == "rotated-key"
 
 
+def test_api_key_whitespace_only_env_uses_configured_public_default(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV, "   ")
+    assert get_api_key() == DATAJUD_PUBLIC_API_KEY_DEFAULT
+
+
 async def test_authorization_header_uses_apikey_scheme():
     with respx.mock() as router:
         route = router.post(ENDPOINT).respond(200, json=OK_BODY)

--- a/tests/datajud/test_datajud_client.py
+++ b/tests/datajud/test_datajud_client.py
@@ -15,9 +15,9 @@ import pytest
 import respx
 import tenacity
 
+from causaganha.config import DATAJUD_PUBLIC_API_KEY_DEFAULT
 from datajud.client import (
     API_KEY_ENV,
-    PUBLIC_API_KEY,
     DataJudAuthError,
     DataJudClient,
     DataJudError,
@@ -31,6 +31,7 @@ from datajud.client import (
 
 
 ENDPOINT = search_endpoint("tjro")
+TEST_API_KEY = "test-datajud-api-key"
 
 CNJ_A = "00000010220248220001"
 CNJ_B = "00000020320248220002"
@@ -55,6 +56,7 @@ OK_BODY = {"hits": {"total": {"value": 0, "relation": "eq"}, "hits": []}}
 def _client(**kwargs: object) -> DataJudClient:
     defaults: dict = {
         "tribunal": "tjro",
+        "api_key": TEST_API_KEY,
         "backoff_base": 0.0,
         "batch_pause": 0.0,
         "requests_per_minute": 100_000,
@@ -186,9 +188,9 @@ async def test_401_raises_nominal_auth_error_without_retry():
 # ── API key resolution ───────────────────────────────────────────────────
 
 
-def test_api_key_defaults_to_public_constant(monkeypatch):
+def test_api_key_absent_uses_configured_public_default(monkeypatch):
     monkeypatch.delenv(API_KEY_ENV, raising=False)
-    assert get_api_key() == PUBLIC_API_KEY
+    assert get_api_key() == DATAJUD_PUBLIC_API_KEY_DEFAULT
 
 
 def test_api_key_env_override(monkeypatch):
@@ -196,15 +198,14 @@ def test_api_key_env_override(monkeypatch):
     assert get_api_key() == "rotated-key"
 
 
-async def test_authorization_header_uses_apikey_scheme(monkeypatch):
-    monkeypatch.delenv(API_KEY_ENV, raising=False)
+async def test_authorization_header_uses_apikey_scheme():
     with respx.mock() as router:
         route = router.post(ENDPOINT).respond(200, json=OK_BODY)
         async with _client() as client:
             await client.search({"query": {"match_all": {}}})
 
     request = route.calls.last.request
-    assert request.headers["Authorization"] == f"APIKey {PUBLIC_API_KEY}"
+    assert request.headers["Authorization"] == f"APIKey {TEST_API_KEY}"
 
 
 # ── Batch CNJ lookup + pagination ────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Allow runtime override of the public CNJ DataJud API key without a deploy and document the public key rotation process.
- Keep a committed production default for the public DataJud API key so the service continues to work when no override is provided.

### Description

- Add `DATAJUD_API_KEY` to `.env.example` and document it as an optional override for the `datajud` CLI.
- Add `DATAJUD_PUBLIC_API_KEY_DEFAULT` to `src/causaganha/config.py` and use it as the fallback in `datajud.client.get_api_key()` so the environment override via `DATAJUD_API_KEY` takes precedence.
- Update `src/datajud/client.py` to import and use the configured public default, clarify auth error messaging, and keep the existing retry/rewind logic for rate-limit and ES rejections.
- Add `docs/datajud-api-keys.md` to track the public DataJud API key history and update `README.md` with usage and rotation instructions for the `datajud` CLI.
- Update tests in `tests/datajud/test_datajud_client.py` to use the configured default and a test API key override for assertions.

### Testing

- Ran the `tests/datajud/test_datajud_client.py` unit tests with `pytest` and the modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a577f3dace08325a9617d22664c8d75)