### PR TITLE
feat(training): checkpoint-chained staged training (RFC 0011 §15-bis.3, Runs B/D)

### DIFF
--- a/scripts/opf_shared.py
+++ b/scripts/opf_shared.py
@@ -38,8 +38,18 @@ def build_opf_train_cmd(
     epochs: int,
     batch_size: int,
     python: str = sys.executable,
+    checkpoint: Path | None = None,
 ) -> list[str]:
-    return [
+    """Build the ``opf train`` command.
+
+    ``checkpoint`` (RFC 0011 §15-bis.3): resume from an existing checkpoint
+    directory instead of opf's default base model — verified against
+    ``opf/_train/args.py``'s own ``--checkpoint`` flag, which accepts any
+    valid checkpoint directory, not just the default. ``None`` (the
+    previous, only behavior) omits the flag entirely, so every existing
+    caller is unaffected.
+    """
+    cmd = [
         python,
         "-m",
         "opf",
@@ -58,6 +68,9 @@ def build_opf_train_cmd(
         "--batch-size",
         str(batch_size),
     ]
+    if checkpoint is not None:
+        cmd.extend(["--checkpoint", str(checkpoint)])
+    return cmd
 
 
 def build_opf_eval_cmd(
@@ -147,6 +160,8 @@ def train_and_eval(
     batch_size: int,
     env: dict,
     on_metric: Callable[[dict], None] | None = None,
+    checkpoint: Path | None = None,
+    train_jsonl: Path | None = None,
 ) -> dict:
     """Run opf train then eval; return a report dict, never raises on opf failure.
 
@@ -155,10 +170,23 @@ def train_and_eval(
     a 16GB T4, see train_on_colab.sh). ``on_metric`` is called with each parsed
     live metric dict during training (e.g. to stream to a tracker).
 
+    ``checkpoint`` (RFC 0011 §15-bis.3): resume training from an existing
+    checkpoint directory instead of opf's base model — the piece
+    ``run_staged_training.py`` needs to chain stages. ``None`` (default)
+    preserves every existing caller's current behavior exactly.
+
+    ``train_jsonl`` overrides ``data_dir / "train.jsonl"`` — the per-stage
+    composed mix a staged run uses (RFC 0011 §15-bis.3: each stage has its
+    own ``compose_mix()`` output). ``val.jsonl``/``label_space.json``/
+    ``test.jsonl`` always come from ``data_dir`` regardless — they are
+    never per-stage (RFC 0011 §12.1: val/test never pass through
+    ``compose_mix.py``, staged or not).
+
     Returns ``{"train_rc": int, "eval_rc": int | None, "metrics": dict | None}``.
     ``eval_rc``/``metrics`` are None if training failed (no checkpoint exists).
     """
     ckpt = out_dir / "best"
+    resolved_train_jsonl = train_jsonl if train_jsonl is not None else data_dir / "train.jsonl"
 
     def _on_line(line: str) -> None:
         if on_metric is not None:
@@ -168,13 +196,14 @@ def train_and_eval(
 
     train_rc = run_streamed(
         build_opf_train_cmd(
-            data_dir / "train.jsonl",
+            resolved_train_jsonl,
             data_dir / "val.jsonl",
             data_dir / "label_space.json",
             ckpt,
             device=device,
             epochs=epochs,
             batch_size=batch_size,
+            checkpoint=checkpoint,
         ),
         out_dir / "train.log",
         env,

--- a/scripts/run_staged_training.py
+++ b/scripts/run_staged_training.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Staged/curriculum training orchestrator (RFC 0011 §15-bis.3, Runs B/D).
+
+A single static mix (``compose_mix.py``) is enough for Runs C/E/F/G — one
+``train.jsonl``, one ``opf train`` call, no driver changes. It is **not**
+enough for Runs B (pretrain-on-synthetic then fine-tune-on-real) or D
+(adversarial curriculum: broad-structural -> adversarial -> real-heavy):
+those need multiple ``opf train`` calls in sequence, each continuing from
+the previous stage's checkpoint via ``--checkpoint`` (verified supported
+by opf itself, just not previously wired through
+``opf_shared.build_opf_train_cmd``/``train_and_eval`` — see the
+``checkpoint``/``train_jsonl`` parameters added there alongside this
+script).
+
+This script does **not** call ``compose_mix.py`` itself — mix composition
+for each stage is the caller's responsibility, done ahead of time (e.g.
+via ``scripts/synthetic_segmenter/compose_mix.py``, RFC 0011 §15-bis.3).
+A stage config just points at an already-materialized ``train_jsonl`` per
+stage. Keeping this orchestrator's own dependency footprint to
+``opf_shared`` + stdlib means it composes with whatever produced those
+files without needing to import them, and stays testable without a live
+mix-generation dependency.
+
+``val.jsonl``/``test.jsonl``/``label_space.json`` are never per-stage —
+every stage reads the same ones from ``data_dir`` (RFC 0011 §12.1: val/
+test never pass through mix composition, staged or not).
+
+Stage config JSON shape::
+
+    {
+      "run_id": "run_D_seed_3",
+      "data_dir": "data/segmenter_splits",
+      "output_dir": "models/staged_run",
+      "device": "cuda",
+      "stages": [
+        {"name": "structural_broad", "train_jsonl": "...", "epochs": 2, "batch_size": 4},
+        {"name": "adversarial_heavy", "train_jsonl": "...", "epochs": 2, "batch_size": 4},
+        {"name": "real_finetune", "train_jsonl": "data/segmenter_splits/train.jsonl",
+         "epochs": 1, "batch_size": 2}
+      ]
+    }
+
+Usage::
+
+    uv run python scripts/run_staged_training.py --config staged_run.json
+
+Aborts the chain (does not attempt later stages) if any stage's training
+fails — chaining ``--checkpoint`` onto a stage that never produced one is
+a corrupted-lineage bug, not something to paper over by skipping ahead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+
+import structlog
+
+from scripts.opf_shared import train_and_eval
+
+
+logger = structlog.get_logger()
+
+
+def run_staged_training(config: dict, *, env: dict | None = None) -> dict:
+    """Run every stage in ``config["stages"]`` in order, chaining checkpoints.
+
+    Returns the full run report: ``{"run_id", "stages": [...]}`` — one
+    entry per stage attempted (a failed stage's entry is still included;
+    stages after it are omitted, not attempted). Also written to
+    ``output_dir/run_manifest.json`` for W&B/reproducibility lineage (RFC
+    0011 §15-bis.3: "o manifest do mix ... é logado junto").
+    """
+    run_id = config["run_id"]
+    data_dir = Path(config["data_dir"])
+    output_dir = Path(config["output_dir"])
+    device = config["device"]
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    run_env = dict(env if env is not None else os.environ)
+    report: dict = {"run_id": run_id, "stages": []}
+    previous_checkpoint: Path | None = None
+
+    for stage in config["stages"]:
+        stage_name = stage["name"]
+        stage_out_dir = output_dir / stage_name
+        stage_out_dir.mkdir(parents=True, exist_ok=True)
+        train_jsonl = Path(stage["train_jsonl"])
+
+        logger.info(
+            "staged_training_stage_start",
+            run_id=run_id,
+            stage=stage_name,
+            train_jsonl=str(train_jsonl),
+            checkpoint_from=str(previous_checkpoint) if previous_checkpoint else None,
+        )
+
+        result = train_and_eval(
+            data_dir,
+            stage_out_dir,
+            device=device,
+            epochs=stage["epochs"],
+            batch_size=stage["batch_size"],
+            env=run_env,
+            checkpoint=previous_checkpoint,
+            train_jsonl=train_jsonl,
+        )
+
+        stage_report = {
+            "name": stage_name,
+            "train_jsonl": str(train_jsonl),
+            "epochs": stage["epochs"],
+            "batch_size": stage["batch_size"],
+            "checkpoint_from": str(previous_checkpoint) if previous_checkpoint else None,
+            "checkpoint_dir": str(stage_out_dir / "best"),
+            **result,
+        }
+        report["stages"].append(stage_report)
+        (output_dir / "run_manifest.json").write_text(
+            json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        if result["train_rc"] != 0:
+            logger.error(
+                "staged_training_stage_failed",
+                run_id=run_id,
+                stage=stage_name,
+                train_rc=result["train_rc"],
+            )
+            break
+
+        logger.info(
+            "staged_training_stage_complete",
+            run_id=run_id,
+            stage=stage_name,
+            eval_rc=result["eval_rc"],
+        )
+        previous_checkpoint = stage_out_dir / "best"
+
+    return report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Path to the stage-config JSON file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    config = json.loads(Path(args.config).read_text(encoding="utf-8"))
+    report = run_staged_training(copy.deepcopy(config))
+
+    failed = any(stage["train_rc"] != 0 for stage in report["stages"])
+    attempted = len(report["stages"])
+    total = len(config["stages"])
+    if failed or attempted < total:
+        logger.error(
+            "staged_training_incomplete",
+            run_id=report["run_id"],
+            attempted=attempted,
+            total=total,
+        )
+        return 1
+    logger.info("staged_training_complete", run_id=report["run_id"], stages=attempted)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_opf_shared.py
+++ b/tests/test_opf_shared.py
@@ -1,0 +1,129 @@
+"""Tests for scripts.opf_shared — command construction and checkpoint chaining.
+
+RFC 0011 §15-bis.3: ``run_staged_training.py`` (Runs B/D) needs
+``train_and_eval``/``build_opf_train_cmd`` to accept a ``checkpoint``
+directory and a per-stage ``train_jsonl`` override. These tests lock in
+both the new behavior and the pre-existing default (no test file existed
+for this module before).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.opf_shared import build_opf_train_cmd, train_and_eval
+
+
+def test_build_opf_train_cmd_omits_checkpoint_by_default() -> None:
+    cmd = build_opf_train_cmd(
+        Path("train.jsonl"),
+        Path("val.jsonl"),
+        Path("label_space.json"),
+        Path("out"),
+        device="cpu",
+        epochs=1,
+        batch_size=1,
+    )
+    assert "--checkpoint" not in cmd
+
+
+def test_build_opf_train_cmd_includes_checkpoint_when_given() -> None:
+    cmd = build_opf_train_cmd(
+        Path("train.jsonl"),
+        Path("val.jsonl"),
+        Path("label_space.json"),
+        Path("out"),
+        device="cpu",
+        epochs=1,
+        batch_size=1,
+        checkpoint=Path("/models/stage1/best"),
+    )
+    idx = cmd.index("--checkpoint")
+    assert cmd[idx + 1] == str(Path("/models/stage1/best"))
+
+
+def test_train_and_eval_defaults_to_data_dir_train_jsonl(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    with (
+        patch("scripts.opf_shared.run_streamed", return_value=1) as mock_run,
+        patch("scripts.opf_shared.build_opf_train_cmd", return_value=["fake"]) as mock_build,
+    ):
+        train_and_eval(data_dir, out_dir, device="cpu", epochs=1, batch_size=1, env={})
+
+    mock_build.assert_called_once()
+    call_kwargs = mock_build.call_args
+    assert call_kwargs.args[0] == data_dir / "train.jsonl"
+    assert mock_run.called
+
+
+def test_train_and_eval_uses_train_jsonl_override(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    stage_mix = tmp_path / "stage1_mix" / "train.jsonl"
+
+    with (
+        patch("scripts.opf_shared.run_streamed", return_value=1),
+        patch("scripts.opf_shared.build_opf_train_cmd", return_value=["fake"]) as mock_build,
+    ):
+        train_and_eval(
+            data_dir,
+            out_dir,
+            device="cpu",
+            epochs=1,
+            batch_size=1,
+            env={},
+            train_jsonl=stage_mix,
+        )
+
+    assert mock_build.call_args.args[0] == stage_mix
+    # val/test/label_space always come from data_dir, never the per-stage override.
+    assert mock_build.call_args.args[1] == data_dir / "val.jsonl"
+    assert mock_build.call_args.args[2] == data_dir / "label_space.json"
+
+
+def test_train_and_eval_passes_checkpoint_through_to_build_cmd(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    prior_checkpoint = tmp_path / "stage1" / "best"
+
+    with (
+        patch("scripts.opf_shared.run_streamed", return_value=1),
+        patch("scripts.opf_shared.build_opf_train_cmd", return_value=["fake"]) as mock_build,
+    ):
+        train_and_eval(
+            data_dir,
+            out_dir,
+            device="cpu",
+            epochs=1,
+            batch_size=1,
+            env={},
+            checkpoint=prior_checkpoint,
+        )
+
+    assert mock_build.call_args.kwargs["checkpoint"] == prior_checkpoint
+
+
+def test_train_and_eval_short_circuits_on_train_failure(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    with (
+        patch("scripts.opf_shared.run_streamed", return_value=1) as mock_run,
+        patch("scripts.opf_shared.build_opf_train_cmd", return_value=["fake"]),
+    ):
+        result = train_and_eval(data_dir, out_dir, device="cpu", epochs=1, batch_size=1, env={})
+
+    assert result == {"train_rc": 1, "eval_rc": None, "metrics": None}
+    # eval is never attempted after a failed train — only one run_streamed call.
+    assert mock_run.call_count == 1

--- a/tests/test_run_staged_training.py
+++ b/tests/test_run_staged_training.py
@@ -1,0 +1,128 @@
+"""Tests for scripts.run_staged_training — checkpoint-chained multi-stage orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.run_staged_training import run_staged_training
+
+
+def _config(tmp_path: Path, *, n_stages: int = 3) -> dict:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    stage_names = ["structural_broad", "adversarial_heavy", "real_finetune"][:n_stages]
+    return {
+        "run_id": "run_D_seed_3",
+        "data_dir": str(data_dir),
+        "output_dir": str(tmp_path / "out"),
+        "device": "cpu",
+        "stages": [
+            {
+                "name": name,
+                "train_jsonl": str(tmp_path / f"{name}.jsonl"),
+                "epochs": 1,
+                "batch_size": 1,
+            }
+            for name in stage_names
+        ],
+    }
+
+
+def _fake_result(train_rc: int = 0) -> dict:
+    return {"train_rc": train_rc, "eval_rc": 0 if train_rc == 0 else None, "metrics": {}}
+
+
+def test_first_stage_has_no_checkpoint(tmp_path: Path) -> None:
+    config = _config(tmp_path, n_stages=1)
+    with patch(
+        "scripts.run_staged_training.train_and_eval", return_value=_fake_result()
+    ) as mock_te:
+        run_staged_training(config)
+
+    assert mock_te.call_args.kwargs["checkpoint"] is None
+
+
+def test_second_stage_chains_from_first_stage_checkpoint(tmp_path: Path) -> None:
+    config = _config(tmp_path, n_stages=2)
+    with patch(
+        "scripts.run_staged_training.train_and_eval", return_value=_fake_result()
+    ) as mock_te:
+        run_staged_training(config)
+
+    assert mock_te.call_count == 2
+    first_call, second_call = mock_te.call_args_list
+    assert first_call.kwargs["checkpoint"] is None
+    expected_ckpt = Path(config["output_dir"]) / "structural_broad" / "best"
+    assert second_call.kwargs["checkpoint"] == expected_ckpt
+
+
+def test_stage_uses_its_own_train_jsonl_not_data_dir_default(tmp_path: Path) -> None:
+    config = _config(tmp_path, n_stages=1)
+    with patch(
+        "scripts.run_staged_training.train_and_eval", return_value=_fake_result()
+    ) as mock_te:
+        run_staged_training(config)
+
+    assert mock_te.call_args.kwargs["train_jsonl"] == Path(config["stages"][0]["train_jsonl"])
+
+
+def test_aborts_chain_on_stage_failure(tmp_path: Path) -> None:
+    config = _config(tmp_path, n_stages=3)
+    with patch(
+        "scripts.run_staged_training.train_and_eval",
+        side_effect=[_fake_result(train_rc=0), _fake_result(train_rc=1)],
+    ) as mock_te:
+        report = run_staged_training(config)
+
+    # Only 2 of 3 stages attempted: stage 2 failed, stage 3 never runs.
+    assert mock_te.call_count == 2
+    assert len(report["stages"]) == 2
+    assert report["stages"][0]["train_rc"] == 0
+    assert report["stages"][1]["train_rc"] == 1
+
+
+def test_run_manifest_written_to_output_dir(tmp_path: Path) -> None:
+    config = _config(tmp_path, n_stages=2)
+    with patch("scripts.run_staged_training.train_and_eval", return_value=_fake_result()):
+        run_staged_training(config)
+
+    manifest_path = Path(config["output_dir"]) / "run_manifest.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["run_id"] == "run_D_seed_3"
+    assert len(manifest["stages"]) == 2
+    assert manifest["stages"][0]["name"] == "structural_broad"
+    assert manifest["stages"][1]["checkpoint_from"] == str(
+        Path(config["output_dir"]) / "structural_broad" / "best"
+    )
+
+
+def test_run_manifest_written_incrementally_even_on_failure(tmp_path: Path) -> None:
+    """A partial manifest after a mid-chain failure is more useful than none —
+    confirms the manifest reflects the attempted stage, not just successes.
+    """
+    config = _config(tmp_path, n_stages=2)
+    with patch(
+        "scripts.run_staged_training.train_and_eval",
+        side_effect=[_fake_result(train_rc=1)],
+    ):
+        run_staged_training(config)
+
+    manifest_path = Path(config["output_dir"]) / "run_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert len(manifest["stages"]) == 1
+    assert manifest["stages"][0]["train_rc"] == 1
+
+
+def test_data_dir_shared_across_all_stages(tmp_path: Path) -> None:
+    """val/test/label_space are never per-stage — only train_jsonl varies."""
+    config = _config(tmp_path, n_stages=3)
+    with patch(
+        "scripts.run_staged_training.train_and_eval", return_value=_fake_result()
+    ) as mock_te:
+        run_staged_training(config)
+
+    data_dirs = {call.args[0] for call in mock_te.call_args_list}
+    assert data_dirs == {Path(config["data_dir"])}


### PR DESCRIPTION
## Summary

Closes the gap RFC 0011 §15-bis.3 (compose_mix.py, #832) explicitly calls out as out of scope: `opf train` already supports `--checkpoint <dir>` to resume from any checkpoint (verified against `opf/_train/args.py`), but `opf_shared.py`'s `build_opf_train_cmd`/`train_and_eval` never exposed it and made exactly one training call. Runs B (pretrain-on-synthetic → finetune-on-real) and D (adversarial curriculum) from the RFC's experimental protocol (§12) need multiple `opf train` calls in sequence, each continuing from the previous stage's checkpoint — this PR adds that.

- **`scripts/opf_shared.py`**: `build_opf_train_cmd()` gains `checkpoint: Path | None` (appends `--checkpoint <dir>` when given; `None` preserves every existing caller's behavior exactly). `train_and_eval()` gains `checkpoint` (threaded through) and `train_jsonl` (overrides `data_dir/train.jsonl` for a per-stage composed mix — `val.jsonl`/`test.jsonl`/`label_space.json` always come from `data_dir` regardless, per §12.1: val/test never pass through mix composition).
- **`scripts/run_staged_training.py`**: new orchestrator. Deliberately does **not** import `compose_mix.py` — mix composition per stage is the caller's job, done ahead of time; a stage config just points at an already-materialized `train_jsonl`. Keeps this script's dependency footprint to `opf_shared` + stdlib, independently mergeable without depending on the not-yet-merged `synthetic_segmenter` package (#832). Chains `--checkpoint` from each stage's `out_dir/best` to the next; **aborts** the remaining chain if any stage's training fails (continuing onto a stage with no real checkpoint would silently corrupt lineage). Writes a run manifest after every stage (not just at the end), so a mid-chain failure still leaves a useful partial record.

## Test plan

- [x] 13 new tests (`tests/test_opf_shared.py`, `tests/test_run_staged_training.py` — `opf_shared.py` had no test coverage before this PR), all passing
- [x] Full existing repo test suite unaffected (one pre-existing, unrelated `aiohttp`-dependency collection error in `test_catalog_parsing.py`, not touched here)
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bkv4zhU39ABgJsKEKtUTns
