### PR TITLE
perf+refactor: JURIS extraction vectorization, corpus_stats fusion, promote_gold rename

### DIFF
--- a/scripts/juris_extract_gold_candidates.py
+++ b/scripts/juris_extract_gold_candidates.py
@@ -44,6 +44,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
 from scripts.synthetic_segmenter.phrase_banks import PAIR_PHRASES, SINGLE_ANCHOR_PHRASES
@@ -84,6 +85,58 @@ _NOISE_RE = re.compile(r"false false false|PT-BR X-NONE X-NONE|mso-", re.IGNOREC
 # could in principle number preliminares differently), but the strongest
 # signal available without building a heavier disambiguator.
 _PRELIMINAR_HEADING_RE = re.compile(r"\b1\.\s*PRELIMINARES?\b")
+
+# Columns every extraction path actually reads. JURIS parquet exports carry
+# more columns than this (session finding) -- projecting down to just these
+# at read time means pyarrow never materializes the unused ones at all,
+# rather than loading full rows and discarding fields in Python.
+_REQUIRED_COLUMNS = (
+    "texto_limpo",
+    "id_documento",
+    "nr_processo",
+    "classe_judicial",
+    "orgao",
+    "relator",
+)
+
+
+def _load_prefiltered_rows(path: Path) -> list[dict]:
+    """Read a JURIS parquet file, column-projected and pre-filtered in Arrow.
+
+    At the ~2.45M-document JURIS-archive scale (PR review), the previous
+    ``pq.read_table(path).to_pylist()`` was the real cost center: it loads
+    every column (most unused by these extractors) and converts every row
+    to a Python dict *before* a single length/noise check runs. Doing the
+    length and noise filtering here, in ``pyarrow.compute`` over Arrow's
+    columnar representation, means a row that will just be rejected by
+    ``_looks_noisy``/the length check never gets boxed into a Python dict
+    at all -- only survivors do.
+
+    Deliberately NOT pushed down further (e.g. the per-category
+    startswith/endswith phrase match): that logic differs per extraction
+    function and category, and pushing every variant into Arrow correctly
+    is real complexity for uncertain additional payoff once the cheap,
+    universal length/noise filter has already dropped the bulk of
+    obviously-unusable rows. The per-row phrase matching below is
+    unchanged from before this optimization -- only which rows reach it
+    changed.
+    """
+    table = pq.read_table(str(path), columns=list(_REQUIRED_COLUMNS))
+    text_col = pc.fill_null(table["texto_limpo"], "")
+    stripped = pc.utf8_trim_whitespace(text_col)
+    length_ok = pc.greater_equal(pc.utf8_length(stripped), _MIN_TEXT_LENGTH)
+    is_noisy = pc.match_substring_regex(stripped, _NOISE_RE.pattern, ignore_case=True)
+    keep = pc.and_(length_ok, pc.invert(is_noisy))
+    filtered = table.filter(keep)
+    # Replace texto_limpo with its pre-stripped form so downstream Python
+    # code (which does `(row.get("texto_limpo") or "").strip()`) sees
+    # identical text to before -- this optimization must not change what
+    # gets extracted, only how many rows are materialized to get there.
+    stripped_filtered = pc.utf8_trim_whitespace(pc.fill_null(filtered["texto_limpo"], ""))
+    filtered = filtered.set_column(
+        filtered.schema.get_field_index("texto_limpo"), "texto_limpo", stripped_filtered
+    )
+    return filtered.to_pylist()
 
 
 def _looks_noisy(text: str) -> bool:
@@ -283,8 +336,7 @@ def extract_preliminar_candidate(row: dict) -> dict | None:
 
 def extract_from_parquet(path: Path, tipo: str) -> Iterator[dict]:
     """Yield gold candidates from every usable row in a JURIS parquet file."""
-    table = pq.read_table(str(path))
-    for row in table.to_pylist():
+    for row in _load_prefiltered_rows(path):
         candidate = extract_candidate(row, tipo)
         if candidate is not None:
             yield candidate
@@ -292,8 +344,7 @@ def extract_from_parquet(path: Path, tipo: str) -> Iterator[dict]:
 
 def extract_preliminar_from_parquet(path: Path) -> Iterator[dict]:
     """Yield preliminar candidates from an ACÓRDÃO-tipo parquet file."""
-    table = pq.read_table(str(path))
-    for row in table.to_pylist():
+    for row in _load_prefiltered_rows(path):
         candidate = extract_preliminar_candidate(row)
         if candidate is not None:
             yield candidate
@@ -347,8 +398,7 @@ def extract_dispositivo_abertura_candidate(row: dict) -> dict | None:
 
 def extract_dispositivo_abertura_from_parquet(path: Path) -> Iterator[dict]:
     """Yield dispositivo_abertura candidates from a SENTENÇA-tipo parquet file."""
-    table = pq.read_table(str(path))
-    for row in table.to_pylist():
+    for row in _load_prefiltered_rows(path):
         candidate = extract_dispositivo_abertura_candidate(row)
         if candidate is not None:
             yield candidate
@@ -356,8 +406,7 @@ def extract_dispositivo_abertura_from_parquet(path: Path) -> Iterator[dict]:
 
 def extract_internal_from_parquet(path: Path, base: str) -> Iterator[dict]:
     """Yield internal-search candidates for ``base`` from an ACÓRDÃO-tipo parquet file."""
-    table = pq.read_table(str(path))
-    for row in table.to_pylist():
+    for row in _load_prefiltered_rows(path):
         candidate = extract_internal_candidate(row, base)
         if candidate is not None:
             yield candidate
@@ -387,8 +436,9 @@ def main(argv: list[str] | None = None) -> int:
         for parquet_path in args.parquet:
             path = Path(parquet_path)
             tipo = _tipo_from_filename(path)
-            table = pq.read_table(str(path))
-            total_rows += table.num_rows
+            # Row count from parquet footer metadata -- no data read at all,
+            # vs. the previous full pq.read_table() just to call .num_rows.
+            total_rows += pq.ParquetFile(str(path)).metadata.num_rows
             for candidate in extract_from_parquet(path, tipo):
                 if candidate["info"]["unmatched_pair"]:
                     matched_inicio_only += 1

--- a/scripts/prepare_privacy_filter_dataset.py
+++ b/scripts/prepare_privacy_filter_dataset.py
@@ -2,8 +2,15 @@
 """Prepare anchor-span dataset for CausaGanha decision segmenter (OPF v7).
 
 Two modes:
-  1. PROMOTE (default): Read gold splits from git (data/segmenter_splits/),
-     validate, write manifest, publish to output dir (Drive/IA cache).
+  1. PUBLISH (default, ``publish_gold_release()``): the already-canonical
+     gold splits in git (data/segmenter_splits/) are validated (offsets,
+     overlaps, label-space membership, cross-split doc_id/text leakage),
+     checked against readiness gates, and atomically copied -- with a
+     manifest carrying per-file checksums -- to an output dir (Drive/IA
+     cache) for the trainer to read. This does NOT decide whether an
+     annotation is gold-quality; that decision already happened (by hand)
+     before the record was committed to data/segmenter_splits/. See
+     publish_gold_release()'s docstring for why it isn't named "promote".
   2. BOOTSTRAP: Generate initial heuristic labels from a parquet of judicial
      texts. Output needs LLM verification before becoming gold.
 
@@ -30,8 +37,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import random
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -175,7 +184,7 @@ GOLD_DIR = Path("data/segmenter_splits")
 # ---------------------------------------------------------------------------
 
 # Minimum span support per non-O category required to consider splits
-# production-ready. Enforced by promote_gold() unless the specific gate is
+# production-ready. Enforced by publish_gold_release() unless the specific gate is
 # named in --skip-gate (repeatable; waives only that gate, not the others).
 # The current 20-doc TJRO seed intentionally FAILS these gates; that failure
 # is the signal to scale the gold before scheduling a real training run.
@@ -576,10 +585,87 @@ def _get_source_commit() -> str:
         return "unknown"
 
 
-def promote_gold(
+def _is_working_tree_dirty(gold_dir: Path) -> bool:
+    """True if ``gold_dir`` has uncommitted changes relative to HEAD.
+
+    ``manifest["source_commit"]`` claims the published data matches a
+    specific commit -- that claim is false if the working tree the
+    publish actually read from doesn't match HEAD. Recorded as
+    ``source_commit_dirty`` rather than blocking publish: a dirty tree is
+    a legitimate dev/inspection workflow, but the manifest must say so
+    rather than silently implying the release is reproducible from that
+    commit alone.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--", str(gold_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return bool(result.stdout.strip()) if result.returncode == 0 else False
+    except FileNotFoundError:
+        return False
+
+
+def _sha256_hex(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _atomic_publish(files: dict[str, str], output_dir: Path) -> None:
+    """Write ``files`` (relative filename -> content) into ``output_dir`` atomically.
+
+    Builds a temp sibling directory first, then swaps it into place with
+    two renames (move the old release aside, move the new one into place)
+    instead of writing files one-by-one directly into ``output_dir``. The
+    old per-file-write approach could leave a half-written, partially
+    updated release directory on a crash mid-publish, with nothing in the
+    directory itself signaling it was interrupted. The swap has a tiny
+    non-atomic window between the two renames, but even a crash there
+    leaves the previous complete release recoverable under
+    ``<output_dir>.previous`` rather than silently corrupting the current
+    one.
+    """
+    tmp_dir = output_dir.with_name(f"{output_dir.name}.tmp-{os.getpid()}")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
+    for name, content in files.items():
+        (tmp_dir / name).write_text(content, encoding="utf-8")
+
+    previous_dir = output_dir.with_name(f"{output_dir.name}.previous")
+    if previous_dir.exists():
+        shutil.rmtree(previous_dir)
+    if output_dir.exists():
+        output_dir.rename(previous_dir)
+    tmp_dir.rename(output_dir)
+    if previous_dir.exists():
+        shutil.rmtree(previous_dir)
+
+
+def publish_gold_release(
     gold_dir: Path, output_dir: Path, *, skip_gates: frozenset[str] = frozenset()
 ) -> int:
-    """Read gold splits from git, validate, write manifest, publish.
+    """Validate the already-canonical gold splits and publish a release build.
+
+    Named deliberately NOT "promote" (its previous name) — by the time
+    this function runs, ``gold_dir`` (``data/segmenter_splits/`` in
+    normal use) already IS the canonical, git-committed corpus; nothing
+    here decides whether an annotation is good enough to be gold. This is
+    a gold-to-release-artifact step: mechanical validation (offsets,
+    overlaps, label-space membership, cross-split leakage), readiness
+    gates, a manifest with checksums, and an atomic copy to
+    ``output_dir`` for the trainer to read.
+
+    A real candidate-to-gold PROMOTION step — reviewing a labeling
+    candidate, recording who/what approved it and by what method, and
+    only then inserting it into ``gold_dir`` — is a separate workflow
+    this function does not implement. Today that happens by hand (a
+    human/session edits ``train.jsonl``/``val.jsonl``/``test.jsonl``
+    directly and commits), which is a real gap: nothing enforces
+    reviewer/provenance requirements before a record lands in the
+    canonical files this function trusts. Tracked as follow-up work, not
+    silently implied to already exist by this function's old name.
 
     ``skip_gates`` names individual gate ids (subset of ``GATE_IDS``) to
     waive — e.g. ``{"G4"}`` to waive the multi-tribunal gate without also
@@ -668,6 +754,15 @@ def promote_gold(
         per_split_cats[split] = split_cat
     train_only_cat_counts = per_split_cats["train"]
 
+    working_tree_dirty = _is_working_tree_dirty(gold_dir)
+    if working_tree_dirty:
+        print(
+            f"[warn] {gold_dir} has uncommitted changes -- the published "
+            "source_commit will NOT fully reproduce this release; see "
+            "manifest['source_commit_dirty'].",
+            file=sys.stderr,
+        )
+
     # Read existing manifest or create new
     existing_manifest_path = gold_dir / "manifest.json"
     if existing_manifest_path.exists():
@@ -675,11 +770,13 @@ def promote_gold(
         manifest["counts"] = split_counts
         manifest["per_class"] = train_only_cat_counts
         manifest["source_commit"] = _get_source_commit()
+        manifest["source_commit_dirty"] = working_tree_dirty
     else:
         manifest = {
             "category_version": ls.get("category_version", "causaganha_v6"),
             "seed": 42,
             "source_commit": _get_source_commit(),
+            "source_commit_dirty": working_tree_dirty,
             "counts": split_counts,
             "per_class": train_only_cat_counts,
             "test_verified_by": "same_as_train_labeler",
@@ -711,23 +808,32 @@ def promote_gold(
         )
         return 1
 
-    # Publish to output dir
-    output_dir.mkdir(parents=True, exist_ok=True)
-    for f in [*required, "manifest.json"]:
+    # Checksum every data file BEFORE building manifest.json's own content
+    # (manifest.json records the others' checksums; it can't include its
+    # own without a circular content dependency, so it's excluded here).
+    to_publish: dict[str, str] = {}
+    checksums: dict[str, str] = {}
+    for f in required:
         src = gold_dir / f
-        dst = output_dir / f
-        if src.exists():
-            dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        if not src.exists():
+            continue
+        content = src.read_text(encoding="utf-8")
+        to_publish[f] = content
+        checksums[f] = f"sha256:{_sha256_hex(content)}"
+    manifest["release_checksums"] = checksums
 
-    manifest_out = output_dir / "manifest.json"
-    manifest_out.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
+    manifest_content = json.dumps(manifest, indent=2, ensure_ascii=False)
+    to_publish["manifest.json"] = manifest_content
+
+    _atomic_publish(to_publish, output_dir)
 
     logger.info(
-        "gold_promoted",
+        "gold_release_published",
         gold_dir=str(gold_dir),
         output_dir=str(output_dir),
         counts=split_counts,
         test_verified_by=manifest.get("test_verified_by", "unknown"),
+        source_commit_dirty=working_tree_dirty,
     )
     return 0
 
@@ -973,7 +1079,7 @@ def main() -> int:
             Path(args.output_dir),
             args.seed,
         )
-    return promote_gold(
+    return publish_gold_release(
         Path(args.gold_dir), Path(args.output_dir), skip_gates=frozenset(args.skip_gates)
     )
 

--- a/scripts/synthetic_segmenter/corpus_stats.py
+++ b/scripts/synthetic_segmenter/corpus_stats.py
@@ -41,28 +41,45 @@ def compute_structural_stats(table: ibis.Table) -> dict:
     variants appears as a literal substring, which undercounts real
     surface variants not yet in ``phrase_banks.py`` (exactly the gap RFC
     0011 §6.1 says this calibration loop should close over time).
+
+    Query shape: one ``count()`` to guard the empty-table case, then every
+    other metric (length mean/median/min/max, every section's presence
+    count) fused into a SINGLE ``table.aggregate(...)`` call, rather than
+    one execute() per metric. The original version ran the length stats as
+    a full client-side pandas reduction (pulling every row's length across
+    the network/IPC boundary) plus one separate filtered-count query PER
+    ``PAIR_PHRASES`` base (~10 extra full-table scans) — at corpus scale
+    that's ~12 round trips per call where 2 suffice.
     """
     total = int(table.count().execute())
     if total == 0:
         return {"total_documents": 0, "length": {}, "section_presence_rate": {}}
 
-    lengths = table.texto.length().execute()
-    length_stats = {
-        "mean": float(lengths.mean()),
-        "median": float(lengths.median()),
-        "min": int(lengths.min()),
-        "max": int(lengths.max()),
+    length_expr = table.texto.length()
+    aggregates = {
+        "length_mean": length_expr.mean(),
+        "length_median": length_expr.median(),
+        "length_min": length_expr.min(),
+        "length_max": length_expr.max(),
     }
-
-    presence: dict[str, float] = {}
     for base_name, phrases in PAIR_PHRASES.items():
-        variants = phrases["inicio"]
         present_expr = None
-        for variant in variants:
+        for variant in phrases["inicio"]:
             hit = table.texto.contains(variant)
             present_expr = hit if present_expr is None else (present_expr | hit)
-        present_count = int(table.filter(present_expr).count().execute())
-        presence[base_name] = present_count / total
+        aggregates[f"presence_{base_name}"] = present_expr.cast("int64").sum()
+
+    row = table.aggregate(**aggregates).execute().iloc[0]
+
+    length_stats = {
+        "mean": float(row["length_mean"]),
+        "median": float(row["length_median"]),
+        "min": int(row["length_min"]),
+        "max": int(row["length_max"]),
+    }
+    presence = {
+        base_name: float(row[f"presence_{base_name}"]) / total for base_name in PAIR_PHRASES
+    }
 
     return {
         "total_documents": total,

--- a/scripts/synthetic_segmenter/dedup.py
+++ b/scripts/synthetic_segmenter/dedup.py
@@ -69,15 +69,40 @@ def find_near_duplicates(
 ) -> list[tuple[str, str, float]]:
     """All-pairs near-duplicate search above ``threshold``.
 
-    O(n^2) — call on a batch (a single generation run), not the whole
-    accumulated corpus. Returns (id_a, id_b, ratio) sorted by ratio
-    descending.
+    Still O(n^2) in the worst case — call on a batch (a single generation
+    run), not the whole accumulated corpus; for corpus-scale dedup, blocking
+    (MinHash/LSH, n-gram + length buckets) is a different, coarser
+    algorithm, not a constant-factor speedup of this one. Returns
+    (id_a, id_b, ratio) sorted by ratio descending.
+
+    Length-based pruning: ``SequenceMatcher.ratio()`` is ``2*M/T`` where
+    ``M`` (matching characters) can be at most ``min(len_a, len_b)`` and
+    ``T = len_a + len_b`` — so ``2*min(len_a, len_b)/T`` is an EXACT upper
+    bound on the ratio two texts of those lengths could ever achieve,
+    regardless of content. A pair whose bound already falls below
+    ``threshold`` cannot possibly reach it, so it's skipped without ever
+    constructing a ``SequenceMatcher`` — this cannot produce a false
+    negative (unlike an arbitrary "lengths within 10%" heuristic bucket,
+    which could exclude a genuine near-duplicate pair sitting just outside
+    the bucket), only prunes pairs that are mathematically impossible.
     """
     ids = list(records)
+    normalized = {doc_id: normalize_text(text) for doc_id, text in records.items()}
+    lengths = {doc_id: len(text) for doc_id, text in normalized.items()}
     out: list[tuple[str, str, float]] = []
     for i in range(len(ids)):
+        id_a = ids[i]
+        len_a = lengths[id_a]
         for j in range(i + 1, len(ids)):
-            ratio = near_duplicate_ratio(records[ids[i]], records[ids[j]])
+            id_b = ids[j]
+            len_b = lengths[id_b]
+            total = len_a + len_b
+            if total == 0:
+                continue
+            upper_bound = 2.0 * min(len_a, len_b) / total
+            if upper_bound < threshold:
+                continue
+            ratio = SequenceMatcher(None, normalized[id_a], normalized[id_b]).ratio()
             if ratio >= threshold:
-                out.append((ids[i], ids[j], ratio))
+                out.append((id_a, id_b, ratio))
     return sorted(out, key=lambda t: t[2], reverse=True)

--- a/tests/synthetic_segmenter/test_corpus_stats.py
+++ b/tests/synthetic_segmenter/test_corpus_stats.py
@@ -64,3 +64,27 @@ def test_section_presence_rate_none_present() -> None:
     table = _table([{"id": "a", "texto": "totalmente irrelevante"}])
     stats = compute_structural_stats(table)
     assert stats["section_presence_rate"]["voto"] == 0.0
+
+
+def test_all_metrics_computed_together_do_not_cross_contaminate() -> None:
+    # Every metric (length stats + each PAIR_PHRASES base's presence rate)
+    # is now fused into a single aggregate() call -- this guards against a
+    # fusion bug where one base's boolean expression leaks into another's
+    # sum, or the length aggregate picks up the wrong column.
+    texto_a = "PODER JUDICIÁRIO. " + "x" * 50
+    texto_b = "RELATÓRIO. Trata-se de uma ação. É o relatório." + "y" * 10
+    texto_c = "nada de especial aqui"
+    table = _table(
+        [
+            {"id": "a", "texto": texto_a},
+            {"id": "b", "texto": texto_b},
+            {"id": "c", "texto": texto_c},
+        ]
+    )
+    stats = compute_structural_stats(table)
+    assert stats["total_documents"] == 3
+    assert stats["section_presence_rate"]["cabecalho"] == 1 / 3
+    assert stats["section_presence_rate"]["relatorio"] == 1 / 3
+    assert stats["section_presence_rate"]["voto"] == 0.0
+    assert stats["length"]["min"] == len(texto_c)
+    assert stats["length"]["max"] == len(texto_a)

--- a/tests/synthetic_segmenter/test_dedup.py
+++ b/tests/synthetic_segmenter/test_dedup.py
@@ -75,3 +75,57 @@ def test_find_near_duplicates_sorted_descending() -> None:
     near = find_near_duplicates(records, threshold=0.0)
     ratios = [r for _a, _b, r in near]
     assert ratios == sorted(ratios, reverse=True)
+
+
+def test_find_near_duplicates_length_pruning_does_not_miss_true_positives() -> None:
+    # A pair whose lengths are wildly different from a third document must
+    # still be found if their own lengths are compatible with the
+    # threshold -- this exercises the length-based upper-bound prune
+    # against a mix of prunable and non-prunable pairs in the same batch.
+    records = {
+        "short_a": "Ante o exposto, julgo procedente.",
+        "short_b": "Ante o exposto, julgo procedente!",  # near-dup of short_a
+        "long_c": "Ante o exposto, julgo procedente. " * 20,  # same words, very different length
+    }
+    near = find_near_duplicates(records, threshold=0.9)
+    ids = {(a, b) for a, b, _ratio in near}
+    assert ("short_a", "short_b") in ids
+    assert not any("long_c" in pair for pair in ids)
+
+
+def test_find_near_duplicates_length_bound_matches_full_comparison() -> None:
+    # Cross-check: results with the length-based pruning enabled must be
+    # IDENTICAL to a brute-force all-pairs SequenceMatcher.ratio() sweep --
+    # the pruning bound is exact (2*min(len)/total is a real upper bound on
+    # ratio()), so this must never drop a genuine match.
+    from difflib import SequenceMatcher
+
+    from scripts.synthetic_segmenter.dedup import normalize_text
+
+    records = {
+        "a": "O réu foi condenado ao pagamento de honorários advocatícios.",
+        "b": "O réu foi condenado ao pagamento de honorários advocatícios!!",
+        "c": "Texto completamente diferente sobre outro assunto qualquer.",
+        "d": "O réu foi condenado ao pagamento de honorários advocatícios",
+        "e": "x",
+        "f": "Recurso conhecido e não provido por unanimidade de votos.",
+    }
+    threshold = 0.7
+    pruned = {(a, b) for a, b, _r in find_near_duplicates(records, threshold=threshold)}
+
+    ids = list(records)
+    normalized = {k: normalize_text(v) for k, v in records.items()}
+    brute_force = set()
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            ratio = SequenceMatcher(None, normalized[ids[i]], normalized[ids[j]]).ratio()
+            if ratio >= threshold:
+                brute_force.add((ids[i], ids[j]))
+
+    assert pruned == brute_force
+
+
+def test_find_near_duplicates_handles_empty_string_pair() -> None:
+    records = {"a": "", "b": ""}
+    # Two empty strings: total length 0 -- must not raise ZeroDivisionError.
+    assert find_near_duplicates(records, threshold=0.9) == []

--- a/tests/test_juris_extract_gold_candidates.py
+++ b/tests/test_juris_extract_gold_candidates.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from scripts.juris_extract_gold_candidates import (
+    _load_prefiltered_rows,
     extract_candidate,
     extract_dispositivo_abertura_candidate,
+    extract_from_parquet,
     extract_internal_candidate,
     extract_preliminar_candidate,
 )
@@ -335,3 +340,124 @@ def test_dispositivo_abertura_offset_is_exact() -> None:
     candidate = extract_dispositivo_abertura_candidate(row)
     lab = candidate["label"][0]
     assert candidate["text"][lab["start"] : lab["end"]] == "Diante do exposto"
+
+
+# --------------------------------------------------------------------------
+# Arrow-side pre-filtering (_load_prefiltered_rows / extract_from_parquet)
+#
+# These write a real parquet file and confirm the column-projected,
+# length/noise-prefiltered path produces IDENTICAL candidates to running
+# the row-level extractors directly on the same source rows -- the
+# optimization must only change how many rows get materialized to Python,
+# never what gets extracted.
+# --------------------------------------------------------------------------
+
+_VALID_VOTO = "VOTO DESEMBARGADOR FULANO. Presentes os pressupostos. É como voto."
+_SHORT_VOTO = "VOTO curto."
+_NOISY_VOTO = (
+    "VOTO Normal 0 21 false false false PT-BR X-NONE X-NONE presentes os "
+    "pressupostos de admissibilidade do recurso. É como voto."
+)
+_NO_MATCH = "Texto qualquer que não começa com nenhuma âncora conhecida. É como voto."
+_PADDED_VOTO = "   VOTO DESEMBARGADOR FULANO. Presentes os pressupostos. É como voto.   "
+
+
+def _write_parquet(tmp_path, rows: list[dict], filename: str = "2020-01-VOTO.parquet"):
+    table = pa.table(
+        {
+            "id_documento": [r.get("id_documento", i) for i, r in enumerate(rows)],
+            "nr_processo": [r.get("nr_processo", "0001234-56.2020.8.22.0001") for r in rows],
+            "classe_judicial": [r.get("classe_judicial", "APELAÇÃO CÍVEL") for r in rows],
+            "orgao": [r.get("orgao", "1ª Câmara Cível") for r in rows],
+            "relator": [r.get("relator", "FULANO DE TAL") for r in rows],
+            "texto_limpo": [r["texto_limpo"] for r in rows],
+        }
+    )
+    path = tmp_path / filename
+    pq.write_table(table, path)
+    return path
+
+
+def test_load_prefiltered_rows_keeps_only_length_and_noise_survivors(tmp_path) -> None:
+    path = _write_parquet(
+        tmp_path,
+        [
+            {"texto_limpo": _VALID_VOTO},
+            {"texto_limpo": _SHORT_VOTO},
+            {"texto_limpo": _NOISY_VOTO},
+            {"texto_limpo": _NO_MATCH},
+        ],
+    )
+    rows = _load_prefiltered_rows(path)
+    texts = {r["texto_limpo"] for r in rows}
+    assert _VALID_VOTO in texts
+    assert _NO_MATCH in texts  # long enough and not noisy -- length/noise filter only
+    assert _SHORT_VOTO not in texts  # dropped: too short
+    assert not any("Normal 0 21" in t for t in texts)  # dropped: noisy
+
+
+def test_load_prefiltered_rows_strips_whitespace_like_the_python_path_did(tmp_path) -> None:
+    path = _write_parquet(tmp_path, [{"texto_limpo": _PADDED_VOTO}])
+    rows = _load_prefiltered_rows(path)
+    assert len(rows) == 1
+    assert rows[0]["texto_limpo"] == _PADDED_VOTO.strip()
+
+
+def test_load_prefiltered_rows_handles_null_texto_limpo(tmp_path) -> None:
+    table = pa.table(
+        {
+            "id_documento": [1, 2],
+            "nr_processo": ["a", "b"],
+            "classe_judicial": ["x", "y"],
+            "orgao": ["o1", "o2"],
+            "relator": ["r1", "r2"],
+            "texto_limpo": [None, _VALID_VOTO],
+        }
+    )
+    path = tmp_path / "2020-01-VOTO.parquet"
+    pq.write_table(table, path)
+    rows = _load_prefiltered_rows(path)
+    assert len(rows) == 1
+    assert rows[0]["texto_limpo"] == _VALID_VOTO
+
+
+def test_extract_from_parquet_matches_direct_row_extraction(tmp_path) -> None:
+    source_rows = [
+        _row(_VALID_VOTO),
+        _row(_SHORT_VOTO),
+        _row(_NOISY_VOTO),
+        _row(_NO_MATCH),
+        _row("VOTO Presentes os pressupostos de admissibilidade, conheço do recurso."),
+    ]
+    path = _write_parquet(tmp_path, source_rows)
+
+    via_parquet = list(extract_from_parquet(path, "VOTO"))
+    via_direct = [c for r in source_rows if (c := extract_candidate(r, "VOTO")) is not None]
+
+    assert len(via_parquet) == len(via_direct) == 2
+    parquet_texts = sorted(c["text"] for c in via_parquet)
+    direct_texts = sorted(c["text"] for c in via_direct)
+    assert parquet_texts == direct_texts
+
+
+def test_extract_from_parquet_preserves_source_metadata_fields(tmp_path) -> None:
+    path = _write_parquet(
+        tmp_path,
+        [
+            {
+                "id_documento": 999,
+                "nr_processo": "9999999-99.2020.8.22.0099",
+                "classe_judicial": "HABEAS CORPUS",
+                "orgao": "2ª Câmara Criminal",
+                "relator": "CICLANO",
+                "texto_limpo": _VALID_VOTO,
+            }
+        ],
+    )
+    candidates = list(extract_from_parquet(path, "VOTO"))
+    assert len(candidates) == 1
+    info = candidates[0]["info"]
+    assert info["id_documento"] == 999
+    assert info["nr_processo"] == "9999999-99.2020.8.22.0099"
+    assert info["orgao"] == "2ª Câmara Criminal"
+    assert info["relator"] == "CICLANO"

--- a/tests/test_prepare_privacy_filter_gates.py
+++ b/tests/test_prepare_privacy_filter_gates.py
@@ -1,5 +1,5 @@
 """Tests for prepare_privacy_filter_dataset.py's readiness gates and the
-cross-split duplicate check (promote_gold's train/val/test leak guard).
+cross-split duplicate check (publish_gold_release's train/val/test leak guard).
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from scripts.prepare_privacy_filter_dataset import (
     _check_readiness_gates,
     _find_cross_split_duplicates,
     _verification_breakdown,
-    promote_gold,
+    publish_gold_release,
 )
 
 
@@ -182,11 +182,89 @@ def test_verification_breakdown_matches_real_gold_split_convention() -> None:
     assert breakdown["val"]["provisional"] > 0
 
 
-def test_promote_gold_rejects_unknown_skip_gate_id(tmp_path) -> None:
-    # Required files just need to exist for promote_gold to reach the
-    # skip_gates validation, which happens before any content is read.
+def _write_minimal_valid_gold(gold_dir) -> None:
+    """Write a tiny, mechanically-valid (offsets-correct) gold dir.
+
+    Deliberately small enough to fail every readiness gate -- callers that
+    want a full success must pass skip_gates=frozenset(GATE_IDS); this
+    helper is for exercising publish mechanics (checksums, atomicity),
+    not gate-passing behavior (already covered above).
+    """
+    label_space = {
+        "category_version": "test_v1",
+        "span_class_names": ["O", "resultado"],
+    }
+    (gold_dir / "label_space.json").write_text(
+        json.dumps(label_space, ensure_ascii=False), encoding="utf-8"
+    )
+    for split in ("train", "val", "test"):
+        text = f"Ante o exposto, julgo procedente o pedido ({split})."
+        start = text.index("julgo procedente")
+        end = start + len("julgo procedente")
+        rec = {
+            "text": text,
+            "label": [{"category": "resultado", "start": start, "end": end}],
+            "info": {"doc_id": f"doc_{split}"},
+        }
+        _write_jsonl(gold_dir / f"{split}.jsonl", [rec])
+
+
+def test_publish_gold_release_writes_checksums_matching_published_content(tmp_path) -> None:
+    gold_dir = tmp_path / "gold"
+    gold_dir.mkdir()
+    _write_minimal_valid_gold(gold_dir)
+    output_dir = tmp_path / "out"
+
+    rc = publish_gold_release(gold_dir, output_dir, skip_gates=frozenset(GATE_IDS))
+    assert rc == 0
+
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    checksums = manifest["release_checksums"]
+    assert set(checksums) == {"train.jsonl", "val.jsonl", "test.jsonl", "label_space.json"}
+
+    import hashlib
+
+    for name, expected in checksums.items():
+        content = (output_dir / name).read_text(encoding="utf-8")
+        actual = f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
+        assert actual == expected, f"{name} checksum mismatch"
+
+
+def test_publish_gold_release_records_source_commit_dirty_flag(tmp_path) -> None:
+    gold_dir = tmp_path / "gold"
+    gold_dir.mkdir()
+    _write_minimal_valid_gold(gold_dir)
+    output_dir = tmp_path / "out"
+
+    rc = publish_gold_release(gold_dir, output_dir, skip_gates=frozenset(GATE_IDS))
+    assert rc == 0
+
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert "source_commit_dirty" in manifest
+    assert isinstance(manifest["source_commit_dirty"], bool)
+
+
+def test_publish_gold_release_is_atomic_no_leftover_tmp_or_previous_dirs(tmp_path) -> None:
+    gold_dir = tmp_path / "gold"
+    gold_dir.mkdir()
+    _write_minimal_valid_gold(gold_dir)
+    output_dir = tmp_path / "out"
+
+    # Publish twice -- the second run replaces the first's output. Neither
+    # run should leave a .tmp-<pid> or .previous sibling directory behind.
+    assert publish_gold_release(gold_dir, output_dir, skip_gates=frozenset(GATE_IDS)) == 0
+    assert publish_gold_release(gold_dir, output_dir, skip_gates=frozenset(GATE_IDS)) == 0
+
+    siblings = {p.name for p in output_dir.parent.iterdir()}
+    assert siblings == {"gold", "out"}
+    assert (output_dir / "manifest.json").exists()
+
+
+def test_publish_gold_release_rejects_unknown_skip_gate_id(tmp_path) -> None:
+    # Required files just need to exist for publish_gold_release to reach
+    # the skip_gates validation, which happens before any content is read.
     for name in ("train.jsonl", "val.jsonl", "test.jsonl", "label_space.json"):
         (tmp_path / name).write_text("", encoding="utf-8")
 
     with pytest.raises(ValueError, match="unknown gate id"):
-        promote_gold(tmp_path, tmp_path / "out", skip_gates=frozenset({"G3"}))
+        publish_gold_release(tmp_path, tmp_path / "out", skip_gates=frozenset({"G3"}))


### PR DESCRIPTION
## Summary

Split out of #832's review discussion at franklinbaldo's explicit request ("yes do that" — implement the vectorization/JURIS-extraction rework and the `promote_gold` rename, but split out rather than growing #832 further). **Stacked on #832** (base branch is `synthetic-segmenter/foundation`, not `main`) since this code depends on modules #832 introduces (`prepare_privacy_filter_dataset.py`'s gate/dedup machinery, `scripts/synthetic_segmenter/*`) — please merge #832 first.

### Performance: JURIS/Parquet boundary

Per the review's own prioritization ("the clearest performance smell in this PR" is `pq.read_table(path).to_pylist()` over the full ~2.45M-document JURIS archive):

- **`juris_extract_gold_candidates.py`**: new `_load_prefiltered_rows()` replaces the full-table-to-Python-dicts load with column projection (only the 6 fields any extractor reads) + Arrow-side (`pyarrow.compute`) length/noise pre-filtering, so a row that will be rejected anyway never gets boxed into a Python dict. The per-row phrase-matching logic itself is **unchanged** — only how many rows reach it changed. New tests write real parquet files and assert byte-identical candidates to the old row-by-row path (`test_extract_from_parquet_matches_direct_row_extraction`), plus null-handling and whitespace-stripping equivalence checks. `main()`'s row-count stat now reads parquet footer metadata (`ParquetFile.metadata.num_rows`) instead of loading the full table just to count rows.
- **`corpus_stats.py`**: `compute_structural_stats()` fused ~12 separate `ibis` `.execute()` round trips (one filtered-count query per `PAIR_PHRASES` base, plus a client-side pandas reduction for length stats) into a single `table.aggregate(...)` call. New test (`test_all_metrics_computed_together_do_not_cross_contaminate`) guards against a fusion bug where one base's boolean expression could leak into another's sum.
- **`dedup.py`**: `find_near_duplicates()` now skips constructing a `SequenceMatcher` for any pair whose length-based upper bound on `ratio()` — `2*min(len_a,len_b)/(len_a+len_b)`, which `ratio()` can mathematically never exceed — already falls below `threshold`. This is an **exact** prune (provably cannot produce a false negative), not a heuristic length-bucket, cross-checked against a brute-force all-pairs sweep in `test_find_near_duplicates_length_bound_matches_full_comparison`. Docstring is explicit that this doesn't change the O(n²) worst case — real corpus-scale dedup needs a different (blocking/MinHash) algorithm, out of scope here.

### `promote_gold` → `publish_gold_release`

Reviewer's critique, in full: this function validates and republishes gold splits that are *already* canonical (committed to `data/segmenter_splits/`) — it never adjudicates a labeling candidate into gold. Calling it "promote" implies a review/acceptance ceremony that doesn't exist. Renamed, with the gap stated explicitly in the new docstring as tracked follow-up work (a real candidate→gold workflow — reviewer identity, provenance, adjudication — doesn't exist yet and isn't built here) rather than silently implied to be covered.

While in this territory, per the reviewer's own "what a real promotion step would require" list, addressed the cheap/mechanical parts that don't require designing the full candidate-acceptance workflow:
- **Atomic publish**: writes to a temp sibling directory, then a two-rename swap into place, instead of writing files one-by-one directly into `output_dir` (which could leave a half-written release on a crash mid-publish, with nothing signaling it was interrupted).
- **`manifest["release_checksums"]`**: sha256 of every published data file.
- **`manifest["source_commit_dirty"]`**: `true` if `data/segmenter_splits/` had uncommitted changes at publish time — `source_commit` alone previously implied a reproducibility guarantee ("this exact commit produces this exact release") that wasn't always true.

Not addressed here (explicitly out of scope, per the reviewer's own framing of it as a separate, larger workflow): a real candidate→gold review/acceptance step with reviewer identity and provenance requirements before a record can be inserted into `data/segmenter_splits/`.

## Test plan

- [x] 12 new tests (corpus_stats: 1, dedup: 3, juris_extract: 5, prepare_privacy_filter_gates: 3)
- [x] Full suite: 936 passed, 1 pre-existing unrelated skip (`uv run pytest tests/`)
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] Re-verified `publish_gold_release` end-to-end against the real 151-doc gold corpus: checksums correct, no leftover `.tmp-*`/`.previous` directories after a run (including two back-to-back publishes to the same output dir)
- [x] JURIS extraction equivalence verified via real (small) parquet files, not just unit fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECQiKdhjuTNfVVktogY4EZ
