### PR TITLE
RFC 0012 PR 1 — segmenter dataset artifact contract, splitter, immutable release builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ djen-backup = "djen_backup.__main__:app"
 stj-acordaos = "stj_acordaos.__main__:app"
 tjro-juris = "tjro_juris.__main__:app"
 datajud = "datajud.__main__:app"
+segmenter-dataset = "segmenter_dataset.__main__:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -114,6 +114,16 @@ ignore = [
 "src/djen_backup/archive.py" = ["C901", "PLC0415", "PLR2004"]
 "src/djen_backup/drain.py" = ["S608", "TRY300"]
 
+# ── segmenter_dataset (RFC 0012) ──────────────────────────────────────────
+# B008/TC003: typer.Option() in default args is the idiomatic Typer pattern
+# — Path stays a live top-level import so Typer can resolve command
+# parameter types at runtime; only non-command helpers defer imports.
+"src/segmenter_dataset/__main__.py" = ["B008", "TC003"]
+# store.py: many small, self-explanatory accessor/writer methods (RFC 0012
+# §8's document/annotation/review/release CRUD) — a docstring on each would
+# just restate the method name.
+"src/segmenter_dataset/store.py" = ["D102", "D107"]
+
 # ── Tests ──────────────────────────────────────────────────────────────────
 # assert is idiomatic pytest; no docstrings/type-hints required; private access
 # and magic-value comparisons are normal in test code.

--- a/src/segmenter_dataset/__init__.py
+++ b/src/segmenter_dataset/__init__.py
@@ -1,0 +1,8 @@
+"""Segmenter dataset lifecycle: candidate/document → annotation → review → release.
+
+Implements RFC 0012 ("Segmentador v8: dataset confiável e baseline honesto
+com dados reais", ``docs/rfc/0012-segmenter-dataset-confiavel-baseline.md``)
+PR 1 — the artifact contract, splitter, and immutable release builder.
+"""
+
+from __future__ import annotations

--- a/src/segmenter_dataset/__main__.py
+++ b/src/segmenter_dataset/__main__.py
@@ -1,0 +1,151 @@
+"""CLI entry point for the segmenter dataset lifecycle (RFC 0012).
+
+Two commands, split at the same seam as RFC 0012 §10/§12:
+
+- ``assign-splits`` — groups documents, applies role eligibility, and writes
+  a ``split_manifest.json`` (RFC 0012 §8's intermediate, not-yet-a-release
+  artifact).
+- ``build-release`` — reads a ``split_manifest.json`` and runs
+  ``build_dataset_release`` (RFC 0012 §12), writing the final immutable
+  release manifest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+from segmenter_dataset.ontology import ONTOLOGY_V8, load_categories
+from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
+from segmenter_dataset.schemas import KnownLimitation
+from segmenter_dataset.splits import (
+    GroupingKeys,
+    SplitAssignment,
+    assign_splits,
+    build_groups,
+    evaluation_eligible_document_ids,
+    train_eligible_document_ids,
+)
+from segmenter_dataset.store import SegmenterDatasetStore
+
+
+if TYPE_CHECKING:
+    # Path stays a live import above — Typer's @app.command parameters below
+    # need a runtime-resolvable annotation to build the CLI schema.
+    # GateResult is only used in a plain helper, not a command, so it's safe
+    # to defer.
+    from segmenter_dataset.gates import GateResult
+
+
+app = typer.Typer(no_args_is_help=True, help="Segmenter dataset lifecycle (RFC 0012).")
+
+
+@app.command("assign-splits")
+def assign_splits_command(
+    data_root: Path = typer.Option(..., exists=True, file_okay=False, help="data/segmenter/"),
+    output: Path = typer.Option(..., help="Where to write split_manifest.json"),
+    train_ratio: float = typer.Option(0.70),
+    val_ratio: float = typer.Option(0.15),
+    seed: int = typer.Option(..., help="Deterministic assignment seed (RFC 0012 §10)"),
+    near_duplicate_threshold: float = typer.Option(0.9),
+) -> None:
+    """Group documents, apply role eligibility, and write a split manifest."""
+    store = SegmenterDatasetStore(data_root)
+    documents = store.list_documents()
+    annotations = store.list_annotations()
+    reviews = store.list_reviews()
+
+    grouping_keys = [GroupingKeys(document_id=doc.document_id) for doc in documents]
+    groups = build_groups(
+        documents, grouping_keys, near_duplicate_threshold=near_duplicate_threshold
+    )
+
+    assignment = assign_splits(
+        groups,
+        train_eligible=train_eligible_document_ids(annotations),
+        evaluation_eligible=evaluation_eligible_document_ids(reviews),
+        train_ratio=train_ratio,
+        val_ratio=val_ratio,
+        seed=seed,
+    )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(
+            {
+                "train_ids": sorted(assignment.train_ids),
+                "val_ids": sorted(assignment.val_ids),
+                "test_ids": sorted(assignment.test_ids),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    typer.echo(
+        f"wrote {output}: train={len(assignment.train_ids)} "
+        f"val={len(assignment.val_ids)} test={len(assignment.test_ids)}"
+    )
+
+
+@app.command("build-release")
+def build_release_command(
+    data_root: Path = typer.Option(..., exists=True, file_okay=False, help="data/segmenter/"),
+    split_manifest: Path = typer.Option(..., exists=True, help="Output of assign-splits"),
+    release_id: str = typer.Option(...),
+    label_space: Path = typer.Option(..., exists=True, help="Path to label_space.json"),
+    source_commit: str = typer.Option(...),
+    dependency_lock_hash: str = typer.Option(...),
+    guideline_version: str = typer.Option(...),
+    iaa_seed: int = typer.Option(...),
+    known_limitations: Path | None = typer.Option(
+        None, exists=True, help="JSON list of {gate, reason}"
+    ),
+    ontology_version: str = typer.Option(ONTOLOGY_V8),
+) -> None:
+    """Build the immutable dataset release (RFC 0012 §12)."""
+    store = SegmenterDatasetStore(data_root)
+    split_data = json.loads(split_manifest.read_text(encoding="utf-8"))
+    assignment = SplitAssignment(
+        train_ids=frozenset(split_data["train_ids"]),
+        val_ids=frozenset(split_data["val_ids"]),
+        test_ids=frozenset(split_data["test_ids"]),
+    )
+
+    limitations: list[KnownLimitation] = []
+    if known_limitations is not None:
+        raw = json.loads(known_limitations.read_text(encoding="utf-8"))
+        limitations = [KnownLimitation(**entry) for entry in raw]
+
+    ontology_categories = load_categories(label_space)
+
+    try:
+        manifest = build_dataset_release(
+            store,
+            release_id=release_id,
+            ontology_version=ontology_version,
+            guideline_version=guideline_version,
+            source_commit=source_commit,
+            dependency_lock_hash=dependency_lock_hash,
+            ontology_categories=ontology_categories,
+            split_assignment=assignment,
+            known_limitations=limitations,
+            iaa_seed=iaa_seed,
+        )
+    except ReleaseBlockedError as exc:
+        _echo_gate_failures(exc.gate_results)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"release {manifest.release_id!r} written: counts={manifest.counts}")
+
+
+def _echo_gate_failures(gate_results: list[GateResult]) -> None:
+    typer.echo("release blocked:", err=True)
+    for gate in gate_results:
+        typer.echo(f"  [{gate.severity.value}] {gate.name}: {gate.detail}", err=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/segmenter_dataset/__main__.py
+++ b/src/segmenter_dataset/__main__.py
@@ -22,6 +22,7 @@ from segmenter_dataset.ontology import ONTOLOGY_V8, load_categories
 from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
 from segmenter_dataset.schemas import KnownLimitation
 from segmenter_dataset.splits import (
+    EmptyEvalSplitError,
     GroupingKeys,
     SplitAssignment,
     assign_splits,
@@ -58,19 +59,23 @@ def assign_splits_command(
     annotations = store.list_annotations()
     reviews = store.list_reviews()
 
-    grouping_keys = [GroupingKeys(document_id=doc.document_id) for doc in documents]
+    grouping_keys = [GroupingKeys.from_document(doc) for doc in documents]
     groups = build_groups(
         documents, grouping_keys, near_duplicate_threshold=near_duplicate_threshold
     )
 
-    assignment = assign_splits(
-        groups,
-        train_eligible=train_eligible_document_ids(annotations),
-        evaluation_eligible=evaluation_eligible_document_ids(reviews),
-        train_ratio=train_ratio,
-        val_ratio=val_ratio,
-        seed=seed,
-    )
+    try:
+        assignment = assign_splits(
+            groups,
+            train_eligible=train_eligible_document_ids(annotations),
+            evaluation_eligible=evaluation_eligible_document_ids(reviews),
+            train_ratio=train_ratio,
+            val_ratio=val_ratio,
+            seed=seed,
+        )
+    except EmptyEvalSplitError as exc:
+        typer.echo(f"assign-splits blocked: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(

--- a/src/segmenter_dataset/dedup.py
+++ b/src/segmenter_dataset/dedup.py
@@ -1,0 +1,79 @@
+"""Duplicate and near-duplicate detection (RFC 0012 §10).
+
+Two tiers, deliberately cheap (stdlib only, no embedding model) — a guard
+against exact/near duplication across splits, not a semantic similarity
+search:
+
+- ``content_hash`` — exact-duplicate detection after normalizing
+  whitespace/case, so two records differing only in incidental formatting
+  still collide.
+- ``near_duplicate_ratio`` — cheap edit-distance-based similarity
+  (``difflib.SequenceMatcher``) for catching near-duplicates a hash won't
+  (e.g. a single mutated word). O(n*m) per pair — fine for auditing a batch
+  against itself or against a small reference set; not intended for
+  corpus-scale all-pairs comparison.
+
+Reused near-verbatim from PR #832's ``scripts/synthetic_segmenter/dedup.py``
+(RFC 0012 §18 — this was already generically correct, no synthetic-specific
+assumptions to strip out).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from difflib import SequenceMatcher
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_text(text: str) -> str:
+    """Collapse whitespace and lowercase — for hashing/comparison only.
+
+    Never for the actual training text (which must preserve original
+    formatting for offset correctness).
+    """
+    return _WHITESPACE_RE.sub(" ", text).strip().lower()
+
+
+def content_hash(text: str) -> str:
+    """SHA-256 of the normalized text — RFC 0012 §10 exact-duplicate detection."""
+    return hashlib.sha256(normalize_text(text).encode("utf-8")).hexdigest()
+
+
+def near_duplicate_ratio(text_a: str, text_b: str) -> float:
+    """SequenceMatcher ratio in [0, 1] on normalized text; 1.0 = identical."""
+    return SequenceMatcher(None, normalize_text(text_a), normalize_text(text_b)).ratio()
+
+
+def find_exact_duplicates(records: dict[str, str]) -> list[tuple[str, str]]:
+    """``records`` maps id -> text. Returns pairs of ids sharing a content_hash."""
+    by_hash: dict[str, list[str]] = {}
+    for doc_id, text in records.items():
+        by_hash.setdefault(content_hash(text), []).append(doc_id)
+    return [
+        (ids[i], ids[j])
+        for ids in by_hash.values()
+        if len(ids) > 1
+        for i in range(len(ids))
+        for j in range(i + 1, len(ids))
+    ]
+
+
+def find_near_duplicates(
+    records: dict[str, str], threshold: float = 0.9
+) -> list[tuple[str, str, float]]:
+    """All-pairs near-duplicate search above ``threshold``.
+
+    O(n^2) — call on a batch, not the whole accumulated corpus. Returns
+    ``(id_a, id_b, ratio)`` sorted by ratio descending.
+    """
+    ids = list(records)
+    out: list[tuple[str, str, float]] = []
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            ratio = near_duplicate_ratio(records[ids[i]], records[ids[j]])
+            if ratio >= threshold:
+                out.append((ids[i], ids[j], ratio))
+    return sorted(out, key=lambda t: t[2], reverse=True)

--- a/src/segmenter_dataset/gates.py
+++ b/src/segmenter_dataset/gates.py
@@ -1,0 +1,135 @@
+"""Readiness gates (RFC 0012 §12.1, §14): rigid vs. advisory, a closed allowlist.
+
+There is no generic ``--skip-gates`` (RFC 0012 §3.5, §12) — and per-gate
+waivers alone are not enough either, because waiving every gate one by one
+is the same antipattern with extra ceremony (§12.1). Every gate belongs to
+exactly one of two fixed classes:
+
+- **rigid** — never waivable, always blocks the release. Fixed by this
+  module, not configurable by a caller: schema validity, unresolved
+  annotation conflicts, split leakage, test contamination, checksum/build
+  integrity, and the IAA floor (§8).
+- **advisory** — a small, closed allowlist (tribunal diversity, source
+  diversity, temporal diversity, representative eval set, external test
+  review — exactly RFC 0012 §14's "exigidos para alegações amplas de
+  produção"). A failing advisory gate blocks the release unless it has a
+  matching :class:`~segmenter_dataset.schemas.KnownLimitation` entry.
+
+A gate name outside both sets is a programming error, not a silently
+permitted waiver — :func:`classify_gate` raises rather than defaulting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import KnownLimitation
+
+
+class GateSeverity(StrEnum):
+    """Which class a gate belongs to (RFC 0012 §12.1)."""
+
+    RIGID = "rigid"
+    ADVISORY = "advisory"
+
+
+# RFC 0012 §14 "Exigidos para treino baseline" — all rigid (§12.1).
+RIGID_GATES: frozenset[str] = frozenset(
+    {
+        "ontology_schema_valid",
+        "split_disjoint_by_group_id_hash",
+        "no_unresolved_annotation_conflicts",
+        "val_test_independently_adjudicated",
+        "iaa_aggregate_floor",
+        "iaa_critical_category_floor",
+        "train_minimum_support_per_category",
+        "val_minimum_support_for_reported_metrics",
+        "release_checksums_generated",
+        "ci_reproducible_build",
+    }
+)
+
+# RFC 0012 §14 "Exigidos para alegações amplas de produção" — the only gates
+# eligible for a known_limitation (§12.1). Closed: nothing outside this set
+# may ever be waived.
+ADVISORY_GATES: frozenset[str] = frozenset(
+    {
+        "multiple_tribunals",
+        "multiple_source_systems",
+        "temporal_diversity",
+        "representative_evaluation_set",
+        "external_test_annotation_review",
+    }
+)
+
+
+class UnknownGateError(ValueError):
+    """A gate name is neither rigid nor advisory — not silently permitted."""
+
+
+def classify_gate(name: str) -> GateSeverity:
+    """Return the fixed severity class of a gate; raises for an unknown name."""
+    if name in RIGID_GATES:
+        return GateSeverity.RIGID
+    if name in ADVISORY_GATES:
+        return GateSeverity.ADVISORY
+    msg = (
+        f"unknown gate {name!r} — not in RIGID_GATES or ADVISORY_GATES; "
+        "adding a new gate requires updating RFC 0012 §12.1/§14, not a CLI flag"
+    )
+    raise UnknownGateError(msg)
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of evaluating one gate."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+    @property
+    def severity(self) -> GateSeverity:
+        """This gate's fixed class — rigid or advisory (RFC 0012 §12.1)."""
+        return classify_gate(self.name)
+
+
+@dataclass(frozen=True)
+class GateEvaluation:
+    """Aggregate outcome of every gate for a release attempt."""
+
+    release_allowed: bool
+    blocking_rigid_failures: tuple[GateResult, ...]
+    blocking_unwaived_advisory_failures: tuple[GateResult, ...]
+    waived_advisory_failures: tuple[GateResult, ...]
+
+
+def evaluate_gates(
+    results: list[GateResult], known_limitations: list[KnownLimitation]
+) -> GateEvaluation:
+    """Combine gate results with recorded known limitations (RFC 0012 §12.1).
+
+    A rigid failure always blocks, regardless of ``known_limitations`` — no
+    known-limitation entry can reference a rigid gate name (RFC 0012 §12.1
+    closes that loophole by construction: only advisory gate names are ever
+    checked against the ``known_limitations`` list here).
+    """
+    waived_gate_names = {kl.gate for kl in known_limitations}
+
+    rigid_failures = tuple(r for r in results if not r.passed and r.severity is GateSeverity.RIGID)
+    advisory_failures = tuple(
+        r for r in results if not r.passed and r.severity is GateSeverity.ADVISORY
+    )
+    waived = tuple(r for r in advisory_failures if r.name in waived_gate_names)
+    unwaived = tuple(r for r in advisory_failures if r.name not in waived_gate_names)
+
+    return GateEvaluation(
+        release_allowed=not rigid_failures and not unwaived,
+        blocking_rigid_failures=rigid_failures,
+        blocking_unwaived_advisory_failures=unwaived,
+        waived_advisory_failures=waived,
+    )

--- a/src/segmenter_dataset/iaa.py
+++ b/src/segmenter_dataset/iaa.py
@@ -1,0 +1,250 @@
+"""Inter-annotator agreement (RFC 0012 §8) — no PR #832 equivalent to reuse.
+
+Implements the exact statistical spec RFC 0012 §8 fixes (after three review
+rounds — the floor is normative, not release-configurable):
+
+- **matching**: exact span match (``start``, ``end``, ``category``
+  identical) between the two independent annotations of a document;
+- **pooling**: per-category true/false positive/negative counts are pooled
+  across every document in the split, not averaged per-document;
+- **support**: a category's support is the size of the union of both
+  annotators' spans for it (``tp + fp + fn``) — the number of distinct
+  spans either annotator proposed;
+- **aggregate gate**: macro-F1 over categories with support >= 5, gated on
+  the **lower bound of a document-level bootstrap 95% CI** >= 0.75
+  (fixed for ``segmenter-real-v8.1`` by RFC 0012 §5, not a release choice);
+- **per-category gate**: floor 0.5, gated on the **lower CI bound** when a
+  category has support >= 15, or on the **point estimate** when support is
+  in [5, 15) — a CI is too wide to discriminate at n=5 (RFC 0012 §8, round
+  3 review fix). Categories with support < 5 are reported but excluded
+  from both the aggregate and the per-category gate (RFC 0012 §5.4).
+
+IAA measures inter-annotator *reliability*, not validity against ground
+truth (RFC 0012 §8's explicit epistemic limit) — passing this gate is
+necessary but not sufficient for a release to call itself ``gold``; the
+sufficient condition is the human-reference validation in RFC 0012 §9.1.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import Label
+
+
+AGGREGATE_FLOOR = 0.75
+PER_CATEGORY_FLOOR = 0.5
+MIN_REPORT_SUPPORT = 5
+MIN_CI_GATE_SUPPORT = 15
+DEFAULT_BOOTSTRAP_RESAMPLES = 1000
+
+
+@dataclass(frozen=True)
+class DocumentAnnotationPair:
+    """Two independent annotations of the same document (RFC 0012 §5.3)."""
+
+    document_id: str
+    labels_a: tuple[Label, ...]
+    labels_b: tuple[Label, ...]
+
+
+def _span_set(labels: tuple[Label, ...], category: str) -> set[tuple[int, int]]:
+    return {(label.start, label.end) for label in labels if label.category == category}
+
+
+def _all_categories(pairs: list[DocumentAnnotationPair]) -> set[str]:
+    categories: set[str] = set()
+    for pair in pairs:
+        categories.update(label.category for label in pair.labels_a)
+        categories.update(label.category for label in pair.labels_b)
+    return categories
+
+
+def pooled_counts(pairs: list[DocumentAnnotationPair]) -> dict[str, tuple[int, int, int]]:
+    """Pool exact-match ``(tp, fp, fn)`` per category across every pair in ``pairs``."""
+    pooled: dict[str, list[int]] = {}
+    for category in _all_categories(pairs):
+        tp = fp = fn = 0
+        for pair in pairs:
+            spans_a = _span_set(pair.labels_a, category)
+            spans_b = _span_set(pair.labels_b, category)
+            tp += len(spans_a & spans_b)
+            fp += len(spans_b - spans_a)
+            fn += len(spans_a - spans_b)
+        pooled[category] = [tp, fp, fn]
+    return {category: (tp, fp, fn) for category, (tp, fp, fn) in pooled.items()}
+
+
+def f1_from_counts(tp: int, fp: int, fn: int) -> float:
+    """F1 from pooled counts; 0.0 when there is no support at all (denominator 0)."""
+    denominator = 2 * tp + fp + fn
+    return (2 * tp / denominator) if denominator > 0 else 0.0
+
+
+def support(counts: tuple[int, int, int]) -> int:
+    """RFC 0012 §8: support = size of the union of both annotators' spans."""
+    tp, fp, fn = counts
+    return tp + fp + fn
+
+
+def per_category_f1(pairs: list[DocumentAnnotationPair]) -> dict[str, float]:
+    """Pooled exact-match F1 per category across ``pairs``."""
+    counts = pooled_counts(pairs)
+    return {category: f1_from_counts(*c) for category, c in counts.items()}
+
+
+def macro_f1(
+    pairs: list[DocumentAnnotationPair], *, min_support: int = MIN_REPORT_SUPPORT
+) -> float | None:
+    """Macro-F1 over categories with support >= ``min_support``; ``None`` if none qualify."""
+    counts = pooled_counts(pairs)
+    f1s = [f1_from_counts(*c) for category, c in counts.items() if support(c) >= min_support]
+    if not f1s:
+        return None
+    return sum(f1s) / len(f1s)
+
+
+def _category_f1(pairs: list[DocumentAnnotationPair], category: str) -> float:
+    counts = pooled_counts(pairs).get(category, (0, 0, 0))
+    return f1_from_counts(*counts)
+
+
+def bootstrap_ci_low(
+    pairs: list[DocumentAnnotationPair],
+    statistic: object,
+    *,
+    resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    seed: int,
+) -> float | None:
+    """Lower bound of a 95% document-level bootstrap CI for ``statistic(pairs)``.
+
+    Resamples **documents** with replacement (never spans directly), per
+    RFC 0012 §8 — resampling spans would break the pooling structure
+    within a document. ``statistic`` is any callable ``list[
+    DocumentAnnotationPair] -> float | None``; returns ``None`` if the
+    point statistic itself is undefined (e.g. zero qualifying support) for
+    every resample.
+    """
+    rng = random.Random(seed)  # noqa: S311 - deterministic statistical resampling, not cryptography
+    n = len(pairs)
+    if n == 0:
+        return None
+    values: list[float] = []
+    for _ in range(resamples):
+        resample = [pairs[rng.randrange(n)] for _ in range(n)]
+        value = statistic(resample)
+        if value is not None:
+            values.append(value)
+    if not values:
+        return None
+    values.sort()
+    low_index = int(0.025 * len(values))
+    return values[low_index]
+
+
+@dataclass(frozen=True)
+class CategoryIaaResult:
+    """Gate outcome for one trainable category."""
+
+    category: str
+    support: int
+    point_estimate: float
+    ci_low: float | None
+    included_in_aggregate: bool
+    passed_gate: bool
+    gate_statistic: str  # "ci_lower_bound" | "point_estimate" | "not_gated_low_support"
+
+
+@dataclass(frozen=True)
+class IaaReport:
+    """Full RFC 0012 §8 IAA report for one split (validation or test)."""
+
+    macro_f1_point: float | None
+    macro_f1_ci_low: float | None
+    aggregate_passed: bool
+    per_category: dict[str, CategoryIaaResult]
+    unreliable_eval_categories: tuple[str, ...]
+
+
+def compute_iaa_report(
+    pairs: list[DocumentAnnotationPair],
+    *,
+    seed: int,
+    resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+) -> IaaReport:
+    """Compute the full RFC 0012 §8 IAA report for one split's annotation pairs."""
+    counts = pooled_counts(pairs)
+    per_category: dict[str, CategoryIaaResult] = {}
+
+    for category, category_counts in sorted(counts.items()):
+        n_support = support(category_counts)
+        point = f1_from_counts(*category_counts)
+
+        if n_support < MIN_REPORT_SUPPORT:
+            per_category[category] = CategoryIaaResult(
+                category=category,
+                support=n_support,
+                point_estimate=point,
+                ci_low=None,
+                included_in_aggregate=False,
+                passed_gate=False,
+                gate_statistic="not_gated_low_support",
+            )
+            continue
+
+        if n_support >= MIN_CI_GATE_SUPPORT:
+            ci_low = bootstrap_ci_low(
+                pairs,
+                lambda sample, cat=category: _category_f1(sample, cat),
+                resamples=resamples,
+                seed=seed,
+            )
+            passed = ci_low is not None and ci_low >= PER_CATEGORY_FLOOR
+            per_category[category] = CategoryIaaResult(
+                category=category,
+                support=n_support,
+                point_estimate=point,
+                ci_low=ci_low,
+                included_in_aggregate=True,
+                passed_gate=passed,
+                gate_statistic="ci_lower_bound",
+            )
+        else:
+            per_category[category] = CategoryIaaResult(
+                category=category,
+                support=n_support,
+                point_estimate=point,
+                ci_low=None,
+                included_in_aggregate=True,
+                passed_gate=point >= PER_CATEGORY_FLOOR,
+                gate_statistic="point_estimate",
+            )
+
+    macro_point = macro_f1(pairs, min_support=MIN_REPORT_SUPPORT)
+    macro_ci_low = bootstrap_ci_low(
+        pairs,
+        lambda sample: macro_f1(sample, min_support=MIN_REPORT_SUPPORT),
+        resamples=resamples,
+        seed=seed,
+    )
+    aggregate_passed = macro_ci_low is not None and macro_ci_low >= AGGREGATE_FLOOR
+
+    unreliable = tuple(
+        sorted(
+            category
+            for category, result in per_category.items()
+            if result.included_in_aggregate and not result.passed_gate
+        )
+    )
+
+    return IaaReport(
+        macro_f1_point=macro_point,
+        macro_f1_ci_low=macro_ci_low,
+        aggregate_passed=aggregate_passed,
+        per_category=per_category,
+        unreliable_eval_categories=unreliable,
+    )

--- a/src/segmenter_dataset/ids.py
+++ b/src/segmenter_dataset/ids.py
@@ -1,0 +1,82 @@
+"""Deterministic, content-addressed IDs for the segmenter dataset lifecycle.
+
+RFC 0012 §3.1, §8: a document/annotation/review is identified by the hash of
+its own content, never by a counter. Two annotations with identical content
+collapse to the same ``annotation_id``; any difference in label, annotator,
+or timestamp produces a new ID, never overwriting the previous one — that is
+what "a document is never promoted, only referenced by new records" (§3.1)
+means at the ID-generation layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def _stable_json(value: object) -> str:
+    """Canonical JSON encoding used as hash input — sorted keys, no whitespace."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def document_id(*, source_system: str, source_uri: str, source_hash: str) -> str:
+    """Content-addressed ID for a document record (RFC 0012 §8).
+
+    Derived only from source identity fields, never from ``text`` directly —
+    ``source_hash`` already commits to the exact bytes fetched from the
+    source system, and keeping the ID formula independent of ``text`` means
+    re-extracting the same source document with a different heuristic
+    extractor (different ``proposed_labels``) still resolves to the same
+    ``document_id``, as RFC 0012 §3.1 requires (the document record is one
+    artifact type; extraction method is a detail of it, not a new identity).
+    """
+    digest = hashlib.sha256(
+        _stable_json(
+            {
+                "source_system": source_system,
+                "source_uri": source_uri,
+                "source_hash": source_hash,
+            }
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"doc_{digest[:32]}"
+
+
+def annotation_id(
+    *,
+    document_id: str,
+    annotator_id: str,
+    completed_at: str,
+    labels: list[dict],
+) -> str:
+    """Content-addressed ID for an annotation record (RFC 0012 §8)."""
+    digest = hashlib.sha256(
+        _stable_json(
+            {
+                "document_id": document_id,
+                "annotator_id": annotator_id,
+                "completed_at": completed_at,
+                "labels": labels,
+            }
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"ann_{digest[:32]}"
+
+
+def review_id(
+    *,
+    document_id: str,
+    input_annotation_ids: list[str],
+    approved_at: str,
+) -> str:
+    """Content-addressed ID for a review/adjudication record (RFC 0012 §8)."""
+    digest = hashlib.sha256(
+        _stable_json(
+            {
+                "document_id": document_id,
+                "input_annotation_ids": sorted(input_annotation_ids),
+                "approved_at": approved_at,
+            }
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"rev_{digest[:32]}"

--- a/src/segmenter_dataset/mechanical.py
+++ b/src/segmenter_dataset/mechanical.py
@@ -12,6 +12,17 @@ see RFC 0012 §18. The pair-base derivation here is generalized to read
 ``_inicio``/``_fim`` suffixes off whatever categories are actually present,
 rather than a hardcoded tuple, so it doesn't silently go stale if the
 ontology changes.
+
+**Known limitation inherited from #832, not newly closed by this module:**
+``validate_pairs`` below pairs ``_inicio``/``_fim`` occurrences by sorted
+start offset (``zip`` over two independently sorted lists), exactly as
+#832's original algorithm did. This is blind to a real inversion when spans
+interleave — e.g. ``_inicio`` at offsets ``[10, 20]`` and ``_fim`` at
+``[15, 100]`` reads as two "valid" pairs (10→15, 20→100) even if the true
+document-order pairing is 20→15 (an inverted, invalid pair). Detecting that
+correctly requires pairing by nesting depth (a stack, matching each
+``_fim`` to the most recently opened unmatched ``_inicio``), which this
+module does not implement. Treat this as an open gap, not a solved problem.
 """
 
 from __future__ import annotations
@@ -68,7 +79,12 @@ def validate_pairs(labels: list[Label], *, declared_unmatched: bool = False) -> 
 
     Catches: orphaned/excess ``_fim`` (no matching ``_inicio``), unbalanced
     counts beyond the single-dangling-``_inicio`` case, and inverted pairs
-    (a ``_fim`` at or before its own ``_inicio``). ``declared_unmatched``
+    (a ``_fim`` at or before its own ``_inicio``) *when pairing by sorted
+    start offset happens to line them up* — see the module docstring's
+    "known limitation inherited from #832" note: interleaved spans
+    (``_inicio`` at ``[10, 20]``, ``_fim`` at ``[15, 100]``) are not
+    detected as inverted, because sorted-offset ``zip`` pairs 10→15 and
+    20→100 instead of the true nesting-order pairing. ``declared_unmatched``
     cross-checks against a record's provenance-declared
     ``unmatched_pair`` flag when the caller has one (§11: "_inicio sem par
     exige razão explícita de allowed-unmatched").

--- a/src/segmenter_dataset/mechanical.py
+++ b/src/segmenter_dataset/mechanical.py
@@ -1,0 +1,173 @@
+"""Mechanical validation (RFC 0012 §11).
+
+Deliberately separate from annotation-quality review (RFC 0012 §3.2): every
+check here is a syntactic/structural property of a ``(text, labels)`` pair —
+offsets, pairing, ontology membership — never a judgment about whether a
+label is the *correct* one. Runs in-process, never via repeated subprocess
+calls to an external validator (§11).
+
+Adapted from PR #832's ``scripts/synthetic_segmenter/transform.py``
+(``check_final_invariants``) and ``validators.py`` (pair/ontology checks) —
+see RFC 0012 §18. The pair-base derivation here is generalized to read
+``_inicio``/``_fim`` suffixes off whatever categories are actually present,
+rather than a hardcoded tuple, so it doesn't silently go stale if the
+ontology changes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import Label
+
+
+_INICIO_SUFFIX = "_inicio"
+_FIM_SUFFIX = "_fim"
+
+
+def check_final_invariants(text: str, labels: list[Label]) -> list[str]:
+    """Offset-bound and overlap checks (RFC 0012 §11).
+
+    ``0 <= start < end <= len(text)``, no overlapping spans. Pydantic
+    already enforces ``start < end`` per-label (``schemas.Label``); this
+    additionally checks the bound against ``text`` and cross-label overlap,
+    which a single label can't self-validate.
+    """
+    problems: list[str] = []
+    text_len = len(text)
+    ordered = sorted(labels, key=lambda label: (label.start, label.end))
+    prev_end = -1
+    for label in ordered:
+        if label.end > text_len:
+            problems.append(f"[{label.category}] end={label.end} exceeds text length {text_len}")
+            continue
+        if label.start < prev_end:
+            problems.append(
+                f"[{label.category}] overlaps previous span "
+                f"(start={label.start} < prev_end={prev_end})"
+            )
+        prev_end = max(prev_end, label.end)
+    return problems
+
+
+def _pair_bases(labels: list[Label]) -> set[str]:
+    """Every ``_inicio``/``_fim`` base name actually present in ``labels``."""
+    bases: set[str] = set()
+    for label in labels:
+        if label.category.endswith(_INICIO_SUFFIX):
+            bases.add(label.category[: -len(_INICIO_SUFFIX)])
+        elif label.category.endswith(_FIM_SUFFIX):
+            bases.add(label.category[: -len(_FIM_SUFFIX)])
+    return bases
+
+
+def validate_pairs(labels: list[Label], *, declared_unmatched: bool = False) -> list[str]:
+    """Pair-balance checks (RFC 0012 §11).
+
+    Catches: orphaned/excess ``_fim`` (no matching ``_inicio``), unbalanced
+    counts beyond the single-dangling-``_inicio`` case, and inverted pairs
+    (a ``_fim`` at or before its own ``_inicio``). ``declared_unmatched``
+    cross-checks against a record's provenance-declared
+    ``unmatched_pair`` flag when the caller has one (§11: "_inicio sem par
+    exige razão explícita de allowed-unmatched").
+    """
+    problems: list[str] = []
+    unmatched_bases_in_text: set[str] = set()
+
+    for base in sorted(_pair_bases(labels)):
+        inicio_starts = sorted(
+            label.start for label in labels if label.category == f"{base}{_INICIO_SUFFIX}"
+        )
+        fim_starts = sorted(
+            label.start for label in labels if label.category == f"{base}{_FIM_SUFFIX}"
+        )
+        n_inicio, n_fim = len(inicio_starts), len(fim_starts)
+
+        if n_fim > n_inicio:
+            problems.append(
+                f"{base}: {n_fim} _fim label(s) but only {n_inicio} _inicio label(s) — "
+                "orphaned or excess _fim"
+            )
+        elif n_inicio - n_fim > 1:
+            problems.append(
+                f"{base}: {n_inicio} _inicio label(s) vs {n_fim} _fim label(s) — unbalanced "
+                "beyond the single-dangling-_inicio case"
+            )
+        elif n_inicio - n_fim == 1:
+            unmatched_bases_in_text.add(base)
+
+        for inicio_start, fim_start in zip(inicio_starts, fim_starts, strict=False):
+            if fim_start <= inicio_start:
+                problems.append(
+                    f"{base}: _fim at offset {fim_start} is not after its _inicio at "
+                    f"offset {inicio_start} — inverted pair"
+                )
+                break
+
+    if unmatched_bases_in_text and not declared_unmatched:
+        problems.append(
+            f"record has unmatched pair(s) {sorted(unmatched_bases_in_text)} but no "
+            "declared allowed-unmatched reason"
+        )
+    if declared_unmatched and not unmatched_bases_in_text:
+        problems.append("declared_unmatched=True but no unmatched pair found in labels")
+
+    return problems
+
+
+def validate_ontology_membership(labels: list[Label], ontology_categories: set[str]) -> list[str]:
+    """Every label's category must be in the trainable ontology (RFC 0012 §11)."""
+    return [
+        f"category {label.category!r} not in ontology"
+        for label in labels
+        if label.category not in ontology_categories
+    ]
+
+
+def validate_single_anchor_duplicates(
+    labels: list[Label], *, allow_multiple: frozenset[str] = frozenset()
+) -> list[str]:
+    """Reject duplicate single-anchor categories unless explicitly permitted (RFC 0012 §11).
+
+    A "single anchor" category is one without an ``_inicio``/``_fim``
+    pairing (e.g. ``dispositivo_abertura``). More than one occurrence in a
+    record is rejected by default — pass its name in ``allow_multiple`` to
+    permit it explicitly.
+    """
+    single_anchor_counts: dict[str, int] = {}
+    for label in labels:
+        if label.category.endswith(_INICIO_SUFFIX) or label.category.endswith(_FIM_SUFFIX):
+            continue
+        single_anchor_counts[label.category] = single_anchor_counts.get(label.category, 0) + 1
+
+    return [
+        f"category {category!r} appears {count} times — single-anchor categories must "
+        "appear at most once unless explicitly permitted"
+        for category, count in sorted(single_anchor_counts.items())
+        if count > 1 and category not in allow_multiple
+    ]
+
+
+def validate_record(
+    text: str,
+    labels: list[Label],
+    ontology_categories: set[str],
+    *,
+    declared_unmatched: bool = False,
+    allow_multiple_single_anchor: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Full RFC 0012 §11 mechanical validation for one ``(text, labels)`` record.
+
+    Composes every check this module offers; returns an empty list iff the
+    record is mechanically valid. Does not check semantic correctness of
+    the labels (§3.2) — only structure.
+    """
+    problems = list(check_final_invariants(text, labels))
+    problems.extend(validate_ontology_membership(labels, ontology_categories))
+    problems.extend(validate_pairs(labels, declared_unmatched=declared_unmatched))
+    problems.extend(
+        validate_single_anchor_duplicates(labels, allow_multiple=allow_multiple_single_anchor)
+    )
+    return problems

--- a/src/segmenter_dataset/ontology.py
+++ b/src/segmenter_dataset/ontology.py
@@ -1,0 +1,121 @@
+"""Ontology versioning and migration-impact classification.
+
+RFC 0012 §5.1: ontology v8 = v7 frozen, versioned by semver
+(``segmenter-ontology-v8.0.0``). Future changes follow an explicit migration
+analysis instead of a blanket "any change invalidates everything":
+
+- adding a category is a **minor** bump — existing annotations stay valid,
+  but (§5.1, §8) they must NOT be read as negative examples for the new
+  category. An annotation only supervises a category if that category is in
+  its own ``covered_categories`` (see ``schemas.AnnotationRecord``);
+- removing a category is **major** — invalidates only that category's
+  labels in existing records, not the whole record;
+- renaming without a semantic change is **minor** — mechanical remap;
+- redefining a category's semantics is **major** — treated as remove+add;
+- a guideline-only change bumps ``guideline_version`` independently of
+  ``ontology_version`` and does not invalidate annotations by default.
+
+This module does not implement the remap/re-annotation workflows themselves
+(that is dataset-maintainer process, §5.1) — it only defines the version
+identity and the impact classification a maintainer must record.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_SEMVER_RE = re.compile(r"^segmenter-ontology-v(\d+)\.(\d+)\.(\d+)$")
+
+# RFC 0012 §5.1: v8 = v7 frozen. ref_normativa stays out of the trainable
+# space (RFC 0001 — regex pre-pass at inference), matching the current
+# data/segmenter_splits/label_space.json on main (25 trainable categories).
+ONTOLOGY_V8 = "segmenter-ontology-v8.0.0"
+
+
+class MigrationImpact(StrEnum):
+    """Semver bump class for an ontology change (RFC 0012 §5.1)."""
+
+    MINOR = "minor"
+    MAJOR = "major"
+
+
+class MigrationKind(StrEnum):
+    """The five change kinds RFC 0012 §5.1 distinguishes."""
+
+    ADD_CATEGORY = "add_category"
+    REMOVE_CATEGORY = "remove_category"
+    RENAME_CATEGORY = "rename_category"
+    REDEFINE_CATEGORY = "redefine_category"
+    GUIDELINE_ONLY = "guideline_only"
+
+
+_IMPACT_BY_KIND: dict[MigrationKind, MigrationImpact] = {
+    MigrationKind.ADD_CATEGORY: MigrationImpact.MINOR,
+    MigrationKind.REMOVE_CATEGORY: MigrationImpact.MAJOR,
+    MigrationKind.RENAME_CATEGORY: MigrationImpact.MINOR,
+    MigrationKind.REDEFINE_CATEGORY: MigrationImpact.MAJOR,
+    MigrationKind.GUIDELINE_ONLY: MigrationImpact.MINOR,
+}
+
+
+@dataclass(frozen=True)
+class OntologyVersion:
+    """A parsed ``segmenter-ontology-vMAJOR.MINOR.PATCH`` identifier."""
+
+    major: int
+    minor: int
+    patch: int
+
+    def __str__(self) -> str:
+        """Render as ``segmenter-ontology-vMAJOR.MINOR.PATCH``."""
+        return f"segmenter-ontology-v{self.major}.{self.minor}.{self.patch}"
+
+    def bump(self, impact: MigrationImpact) -> OntologyVersion:
+        """Next version after a change of the given impact class."""
+        if impact is MigrationImpact.MAJOR:
+            return OntologyVersion(self.major + 1, 0, 0)
+        return OntologyVersion(self.major, self.minor + 1, 0)
+
+
+def parse_ontology_version(value: str) -> OntologyVersion:
+    """Parse ``segmenter-ontology-vMAJOR.MINOR.PATCH``; raises ValueError otherwise."""
+    match = _SEMVER_RE.match(value)
+    if match is None:
+        msg = f"not a valid ontology version string: {value!r}"
+        raise ValueError(msg)
+    major, minor, patch = (int(part) for part in match.groups())
+    return OntologyVersion(major, minor, patch)
+
+
+def classify_migration(kind: MigrationKind) -> MigrationImpact:
+    """Map a migration kind to its semver impact class (RFC 0012 §5.1)."""
+    return _IMPACT_BY_KIND[kind]
+
+
+def requires_rfc_amendment(impact: MigrationImpact) -> bool:
+    """RFC 0012 §5.1: major changes need this RFC (or a successor) amended.
+
+    Minor changes may be decided by the dataset maintainer and recorded in
+    the release manifest instead.
+    """
+    return impact is MigrationImpact.MAJOR
+
+
+def load_categories(label_space_path: Path) -> set[str]:
+    """Load the trainable category set from a ``label_space.json`` file.
+
+    Excludes the reserved ``"O"`` (outside-any-span) pseudo-category —
+    mirrors ``validators.load_label_space_categories`` from PR #832.
+    """
+    data = json.loads(label_space_path.read_text(encoding="utf-8"))
+    names = data.get("span_class_names") or []
+    return {name for name in names if name != "O"}

--- a/src/segmenter_dataset/provenance.py
+++ b/src/segmenter_dataset/provenance.py
@@ -1,0 +1,61 @@
+"""Process-number extraction for RFC 0012 §10 grouping keys.
+
+``GroupingKeys.from_document`` (:mod:`segmenter_dataset.splits`) needs a real
+``normalized_process_number`` to make union-find grouping fire on documents
+that belong to the same processo but aren't near-duplicates of each other
+(the PR #838 review's finding #1 — without this, only exact-content-hash and
+>=0.9 near-dup-ratio unions ever fired in practice). JURIS/DJEN decision text
+routinely states the process number verbatim (e.g. "Número do processo:
+7003365-26.2025.8.22.0018"), so a regex extraction over the document's own
+text/URI is enough to make the grouping key real today, without waiting on a
+future ingestion pipeline to populate structured metadata.
+
+The 20-digit validation rule mirrors ``scripts/reconcile_processos.py``'s
+``normalizar_cnj``/``formatar_cnj`` (same CNJ format), reimplemented here
+rather than imported — ``scripts/`` is a standalone operational script, not a
+package dependency of ``segmenter_dataset``.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# RFC 0012 §8's CNJ number identity — 20 digits (7 sequential + 2 check + 4
+# year + 1 segment + 2 court + 4 origin).
+_CNJ_DIGIT_COUNT = 20
+
+# NNNNNNN-DD.AAAA.J.TR.OOOO — the masked CNJ format as it appears verbatim in
+# decision text and source URIs.
+_CNJ_MASKED_RE = re.compile(r"\d{7}-\d{2}\.\d{4}\.\d{1}\.\d{2}\.\d{4}")
+
+# A bare run of exactly 20 digits, not part of a longer digit run — cheaper
+# to trust in a source_uri (a system-generated string) than in free text,
+# where long unrelated digit runs (document IDs, dates) are common.
+_CNJ_BARE_DIGITS_RE = re.compile(r"(?<!\d)\d{20}(?!\d)")
+
+
+def normalize_cnj(raw: str) -> str | None:
+    """Strip formatting from a CNJ number; ``None`` unless exactly 20 digits remain."""
+    digits = re.sub(r"\D", "", raw)
+    return digits if len(digits) == _CNJ_DIGIT_COUNT else None
+
+
+def extract_normalized_process_number(*, source_uri: str, text: str) -> str | None:
+    """Find a CNJ process number embedded in a document's URI or body text.
+
+    Tries the masked format in ``source_uri`` first (cheapest, least
+    ambiguous), then in ``text``, then falls back to a bare 20-digit run in
+    ``source_uri`` only — free text is too likely to contain an unrelated
+    20-digit sequence for that fallback to be safe there. Returns ``None``
+    if no recognizable CNJ number is found anywhere.
+    """
+    for haystack in (source_uri, text):
+        masked = _CNJ_MASKED_RE.search(haystack)
+        if masked is not None:
+            normalized = normalize_cnj(masked.group())
+            if normalized is not None:
+                return normalized
+
+    bare = _CNJ_BARE_DIGITS_RE.search(source_uri)
+    return bare.group() if bare is not None else None

--- a/src/segmenter_dataset/release.py
+++ b/src/segmenter_dataset/release.py
@@ -1,0 +1,456 @@
+"""``build_dataset_release`` (RFC 0012 §12).
+
+Does not promote candidates — packages records already **annotated**
+(train) or **adjudicated** (validation/test), with split-assignment already
+resolved (RFC 0012 §10), into an immutable, checksummed release:
+
+1. load annotations (train) and reviews (validation/test);
+2. verify split integrity;
+3. validate every resolved record mechanically (RFC 0012 §11);
+4. compute counts, hashes, and IAA (RFC 0012 §8);
+5. check independently classified readiness gates (RFC 0012 §12.1, §14);
+6. write into a temporary directory;
+7. verify the written release;
+8. atomically rename it to the final release ID;
+9. refuse to overwrite an existing release.
+
+``build_gold_release`` is this RFC's provisional name for the same command
+(RFC 0012 §9.1, §12) — reserved for a release that has additionally cleared
+the human-reference gate. This module's public name is
+``build_dataset_release`` because that gate does not exist yet.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from segmenter_dataset import mechanical
+from segmenter_dataset.dedup import content_hash
+from segmenter_dataset.gates import GateResult, evaluate_gates
+from segmenter_dataset.iaa import DocumentAnnotationPair, compute_iaa_report
+from segmenter_dataset.schemas import (
+    AnnotationQuality,
+    AnnotationRecord,
+    DocumentRecord,
+    KnownLimitation,
+    Label,
+    ReleaseManifest,
+    ReviewRecord,
+)
+from segmenter_dataset.splits import SplitAssignment, SplitLeakError, check_disjoint
+from segmenter_dataset.store import ImmutabilityError, SegmenterDatasetStore
+
+
+# RFC 0012 §5.6/§16.2 — categories too structural to isolate; a sub-floor
+# IAA result here escalates from a per-category exclusion to a whole-release
+# rigid failure (RFC 0012 §8).
+CRITICAL_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "dispositivo_abertura",
+        "resultado",
+        "acordao_decisorio_inicio",
+        "acordao_decisorio_fim",
+    }
+)
+
+# RFC 0012 §5.4 — minimum train support per category, minimum val support
+# for reported per-category metrics.
+MIN_TRAIN_SUPPORT_PER_CATEGORY = 10
+MIN_VAL_SUPPORT_PER_CATEGORY = 5
+
+# RFC 0012 §5.3/§9 — an IAA pair needs both independent annotations present.
+MIN_INDEPENDENT_ANNOTATIONS_FOR_IAA = 2
+
+
+class ReleaseBlockedError(RuntimeError):
+    """A rigid gate failed, or an unwaived advisory gate failed (RFC 0012 §12.1)."""
+
+    def __init__(self, message: str, gate_results: list[GateResult]) -> None:
+        """Store the failing ``gate_results`` alongside the summary ``message``."""
+        super().__init__(message)
+        self.gate_results = gate_results
+
+
+@dataclass(frozen=True)
+class ResolvedSplitDocument:
+    """One document's resolved content for a given split, with its lineage ID."""
+
+    document: DocumentRecord
+    labels: list[Label]
+    resolution_id: str  # annotation_id (train) or review_id (val/test)
+
+
+def _latest_accepted_review(reviews: list[ReviewRecord], document_id: str) -> ReviewRecord | None:
+    accepted = [r for r in reviews if r.document_id == document_id and r.status == "accepted"]
+    if not accepted:
+        return None
+    return max(accepted, key=lambda r: r.approved_at)
+
+
+def _latest_annotation(
+    annotations: list[AnnotationRecord], document_id: str
+) -> AnnotationRecord | None:
+    matching = [a for a in annotations if a.document_id == document_id]
+    if not matching:
+        return None
+    return max(matching, key=lambda a: a.completed_at)
+
+
+def resolve_split(
+    role: str,
+    document_ids: frozenset[str],
+    documents_by_id: dict[str, DocumentRecord],
+    annotations: list[AnnotationRecord],
+    reviews: list[ReviewRecord],
+) -> list[ResolvedSplitDocument]:
+    """Resolve each document in a split to the record its role requires (RFC 0012 §10).
+
+    ``role == "train"`` resolves to the latest annotation; ``"val"``/``"test"``
+    resolve to the latest accepted review. Raises if a document lacks the
+    record its role requires — this is what RFC 0012 §12 step 2 ("verifica
+    integridade de splits") ultimately checks.
+    """
+    resolved: list[ResolvedSplitDocument] = []
+    for document_id in sorted(document_ids):
+        document = documents_by_id[document_id]
+        if role == "train":
+            annotation = _latest_annotation(annotations, document_id)
+            if annotation is None:
+                msg = f"train document {document_id!r} has no annotation record"
+                raise SplitLeakError(msg)
+            resolved.append(
+                ResolvedSplitDocument(document, annotation.labels, annotation.annotation_id)
+            )
+        else:
+            review = _latest_accepted_review(reviews, document_id)
+            if review is None:
+                msg = f"{role} document {document_id!r} has no accepted review record"
+                raise SplitLeakError(msg)
+            resolved.append(ResolvedSplitDocument(document, review.final_labels, review.review_id))
+    return resolved
+
+
+def _split_hash(resolved: list[ResolvedSplitDocument]) -> str:
+    joined = "|".join(
+        f"{r.document.document_id}:{r.resolution_id}"
+        for r in sorted(resolved, key=lambda item: item.document.document_id)
+    )
+    return content_hash(joined)
+
+
+def _category_counts(resolved: list[ResolvedSplitDocument]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in resolved:
+        for label in item.labels:
+            counts[label.category] = counts.get(label.category, 0) + 1
+    return counts
+
+
+def _mechanical_gate(
+    train: list[ResolvedSplitDocument],
+    val: list[ResolvedSplitDocument],
+    test: list[ResolvedSplitDocument],
+    ontology_categories: set[str],
+) -> GateResult:
+    problems: list[str] = []
+    for role_name, resolved in (("train", train), ("val", val), ("test", test)):
+        for item in resolved:
+            record_problems = mechanical.validate_record(
+                item.document.text, item.labels, ontology_categories
+            )
+            problems.extend(
+                f"[{role_name}:{item.document.document_id}] {p}" for p in record_problems
+            )
+    return GateResult(
+        name="ontology_schema_valid",
+        passed=not problems,
+        detail="; ".join(problems[:20]) if problems else "all records mechanically valid",
+    )
+
+
+def _support_gates(
+    train: list[ResolvedSplitDocument], val: list[ResolvedSplitDocument]
+) -> tuple[GateResult, GateResult]:
+    train_counts = _category_counts(train)
+    val_counts = _category_counts(val)
+
+    under_train = {c: n for c, n in train_counts.items() if n < MIN_TRAIN_SUPPORT_PER_CATEGORY}
+    under_val = {c: n for c, n in val_counts.items() if n < MIN_VAL_SUPPORT_PER_CATEGORY}
+
+    return (
+        GateResult(
+            name="train_minimum_support_per_category",
+            passed=not under_train,
+            detail=f"below floor: {under_train}" if under_train else "all categories meet floor",
+        ),
+        GateResult(
+            name="val_minimum_support_for_reported_metrics",
+            passed=not under_val,
+            detail=f"below floor: {under_val}" if under_val else "all categories meet floor",
+        ),
+    )
+
+
+def _iaa_gates(
+    val: list[ResolvedSplitDocument],
+    test: list[ResolvedSplitDocument],
+    annotations: list[AnnotationRecord],
+    reviews: list[ReviewRecord],
+    *,
+    iaa_seed: int,
+) -> tuple[GateResult, GateResult, AnnotationQuality]:
+    def pairs_for(resolved: list[ResolvedSplitDocument]) -> list[DocumentAnnotationPair]:
+        out: list[DocumentAnnotationPair] = []
+        for item in resolved:
+            review = _latest_accepted_review(reviews, item.document.document_id)
+            if review is None:
+                continue
+            inputs = [a for a in annotations if a.annotation_id in review.input_annotation_ids]
+            if len(inputs) < MIN_INDEPENDENT_ANNOTATIONS_FOR_IAA:
+                continue
+            out.append(
+                DocumentAnnotationPair(
+                    document_id=item.document.document_id,
+                    labels_a=tuple(inputs[0].labels),
+                    labels_b=tuple(inputs[1].labels),
+                )
+            )
+        return out
+
+    val_report = compute_iaa_report(pairs_for(val), seed=iaa_seed)
+    test_report = compute_iaa_report(pairs_for(test), seed=iaa_seed)
+
+    aggregate_passed = val_report.aggregate_passed and test_report.aggregate_passed
+    critical_failed = {
+        category
+        for report in (val_report, test_report)
+        for category in report.unreliable_eval_categories
+        if category in CRITICAL_CATEGORIES
+    }
+
+    per_category_iaa = {
+        f"val:{cat}": r.point_estimate for cat, r in val_report.per_category.items()
+    } | {f"test:{cat}": r.point_estimate for cat, r in test_report.per_category.items()}
+
+    quality = AnnotationQuality(
+        val_iaa_span_f1=val_report.macro_f1_point,
+        val_iaa_span_f1_ci95_low=val_report.macro_f1_ci_low,
+        test_iaa_span_f1=test_report.macro_f1_point,
+        test_iaa_span_f1_ci95_low=test_report.macro_f1_ci_low,
+        per_category_iaa=per_category_iaa,
+        unreliable_eval_categories=tuple(
+            sorted(
+                set(val_report.unreliable_eval_categories)
+                | set(test_report.unreliable_eval_categories)
+            )
+        ),
+    )
+
+    return (
+        GateResult(
+            name="iaa_aggregate_floor",
+            passed=aggregate_passed,
+            detail=(
+                f"val macro-F1 CI-low={val_report.macro_f1_ci_low}, "
+                f"test macro-F1 CI-low={test_report.macro_f1_ci_low}"
+            ),
+        ),
+        GateResult(
+            name="iaa_critical_category_floor",
+            passed=not critical_failed,
+            detail=f"critical categories below floor: {sorted(critical_failed)}"
+            if critical_failed
+            else "all critical categories meet floor",
+        ),
+        quality,
+    )
+
+
+def build_dataset_release(
+    store: SegmenterDatasetStore,
+    *,
+    release_id: str,
+    ontology_version: str,
+    guideline_version: str,
+    source_commit: str,
+    dependency_lock_hash: str,
+    ontology_categories: set[str],
+    split_assignment: SplitAssignment,
+    known_limitations: list[KnownLimitation] | None = None,
+    iaa_seed: int,
+) -> ReleaseManifest:
+    """Run the full RFC 0012 §12 release procedure; returns the written manifest.
+
+    Raises :class:`ReleaseBlockedError` if any rigid gate fails, or if an
+    advisory gate fails without a matching known limitation.
+    Raises :class:`~segmenter_dataset.store.ImmutabilityError` if
+    ``release_id`` already exists.
+    """
+    known_limitations = known_limitations or []
+    release_dir = store.release_dir(release_id)
+    if release_dir.exists():
+        msg = f"release {release_id!r} already exists at {release_dir} (RFC 0012 §12 step 9)"
+        raise ImmutabilityError(msg)
+
+    # Step 1: load.
+    documents_by_id = {d.document_id: d for d in store.list_documents()}
+    annotations = store.list_annotations()
+    reviews = store.list_reviews()
+
+    # Step 2: verify split integrity.
+    disjoint_problems = check_disjoint(
+        split_assignment.train_ids, split_assignment.val_ids, split_assignment.test_ids
+    )
+    hash_by_split: dict[str, set[str]] = {}
+    for role, ids in (
+        ("train", split_assignment.train_ids),
+        ("val", split_assignment.val_ids),
+        ("test", split_assignment.test_ids),
+    ):
+        for document_id in ids:
+            digest = content_hash(documents_by_id[document_id].text)
+            hash_by_split.setdefault(digest, set()).add(role)
+    cross_split_hash_collisions = [
+        digest for digest, roles in hash_by_split.items() if len(roles) > 1
+    ]
+    split_integrity_passed = not disjoint_problems and not cross_split_hash_collisions
+
+    train = resolve_split(
+        "train", split_assignment.train_ids, documents_by_id, annotations, reviews
+    )
+    val = resolve_split("val", split_assignment.val_ids, documents_by_id, annotations, reviews)
+    test = resolve_split("test", split_assignment.test_ids, documents_by_id, annotations, reviews)
+
+    # Step 3: mechanical validation.
+    mechanical_gate = _mechanical_gate(train, val, test, ontology_categories)
+
+    # Step 4: counts, hashes, IAA.
+    train_support_gate, val_support_gate = _support_gates(train, val)
+    iaa_aggregate_gate, iaa_critical_gate, annotation_quality = _iaa_gates(
+        val, test, annotations, reviews, iaa_seed=iaa_seed
+    )
+    split_hashes = {
+        "train": _split_hash(train),
+        "validation": _split_hash(val),
+        "test": _split_hash(test),
+    }
+    document_resolutions = {
+        "train": {r.document.document_id: r.resolution_id for r in train},
+        "validation": {r.document.document_id: r.resolution_id for r in val},
+        "test": {r.document.document_id: r.resolution_id for r in test},
+    }
+    counts = {"train": len(train), "validation": len(val), "test": len(test)}
+    tribunals: dict[str, int] = {}
+    document_types: dict[str, int] = {}
+    for resolved in (*train, *val, *test):
+        tribunals[resolved.document.source.tribunal] = (
+            tribunals.get(resolved.document.source.tribunal, 0) + 1
+        )
+        document_types[resolved.document.source.document_type] = (
+            document_types.get(resolved.document.source.document_type, 0) + 1
+        )
+
+    # Step 5: gates.
+    hash_collision_details = [f"hash collision: {h}" for h in cross_split_hash_collisions]
+    val_test_adjudicated = len(val) == len(split_assignment.val_ids) and len(test) == len(
+        split_assignment.test_ids
+    )
+    gate_results = [
+        GateResult(
+            name="split_disjoint_by_group_id_hash",
+            passed=split_integrity_passed,
+            detail="; ".join(disjoint_problems + hash_collision_details) or "no leakage found",
+        ),
+        GateResult(
+            name="no_unresolved_annotation_conflicts",
+            passed=True,
+            detail="resolved by latest accepted review per document",
+        ),
+        GateResult(
+            name="val_test_independently_adjudicated",
+            passed=val_test_adjudicated,
+            detail="every val/test document resolved to an accepted review",
+        ),
+        mechanical_gate,
+        iaa_aggregate_gate,
+        iaa_critical_gate,
+        train_support_gate,
+        val_support_gate,
+        GateResult(name="release_checksums_generated", passed=True, detail="computed in step 4"),
+        GateResult(
+            name="ci_reproducible_build",
+            passed=bool(source_commit) and bool(dependency_lock_hash),
+            detail="source_commit and dependency_lock_hash both provided",
+        ),
+    ]
+    evaluation = evaluate_gates(gate_results, known_limitations)
+    if not evaluation.release_allowed:
+        failing = list(evaluation.blocking_rigid_failures) + list(
+            evaluation.blocking_unwaived_advisory_failures
+        )
+        msg = "release blocked by gate failures: " + "; ".join(
+            f"{g.name}: {g.detail}" for g in failing
+        )
+        raise ReleaseBlockedError(msg, failing)
+
+    manifest = ReleaseManifest(
+        release_id=release_id,
+        ontology_version=ontology_version,
+        guideline_version=guideline_version,
+        source_commit=source_commit,
+        dependency_lock_hash=dependency_lock_hash,
+        split_hashes=split_hashes,
+        document_resolutions=document_resolutions,
+        counts=counts,
+        tribunals=tribunals,
+        document_types=document_types,
+        annotation_quality=annotation_quality,
+        known_limitations=tuple(known_limitations),
+        created_at=_iso_now(),
+    )
+
+    # Steps 6-8: write to a temp dir, verify, atomically rename.
+    _atomic_write_release(store, manifest)
+    return manifest
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class _RoundTripError(RuntimeError):
+    """The written release manifest didn't round-trip — refuse to publish it."""
+
+
+def _verify_round_trip(manifest_path: Path, manifest: ReleaseManifest) -> None:
+    reloaded = ReleaseManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+    if reloaded != manifest:
+        msg = "written release manifest does not round-trip — refusing to publish"
+        raise _RoundTripError(msg)
+
+
+def _atomic_write_release(store: SegmenterDatasetStore, manifest: ReleaseManifest) -> None:
+    store.releases_dir.mkdir(parents=True, exist_ok=True)
+    final_dir = store.release_dir(manifest.release_id)
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix=f".{manifest.release_id}.tmp-", dir=store.releases_dir))
+    try:
+        manifest_path = tmp_dir / "manifest.json"
+        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+        # Step 7: verify the written release round-trips.
+        _verify_round_trip(manifest_path, manifest)
+
+        # Step 8: atomic rename. Step 9 (refuse overwrite) was already
+        # checked before any work started; Path.rename still fails loudly
+        # if something raced and created final_dir in the meantime.
+        tmp_dir.rename(final_dir)
+    except BaseException:
+        if tmp_dir.exists():
+            for child in tmp_dir.iterdir():
+                child.unlink()
+            tmp_dir.rmdir()
+        raise

--- a/src/segmenter_dataset/release.py
+++ b/src/segmenter_dataset/release.py
@@ -8,7 +8,9 @@ resolved (RFC 0012 §10), into an immutable, checksummed release:
 2. verify split integrity;
 3. validate every resolved record mechanically (RFC 0012 §11);
 4. compute counts, hashes, and IAA (RFC 0012 §8);
-5. check independently classified readiness gates (RFC 0012 §12.1, §14);
+5. check independently classified readiness gates (RFC 0012 §12.1, §14) —
+   all rigid gates plus 2 of 5 advisory gates (see "advisory gate coverage"
+   below);
 6. write into a temporary directory;
 7. verify the written release;
 8. atomically rename it to the final release ID;
@@ -18,6 +20,22 @@ resolved (RFC 0012 §10), into an immutable, checksummed release:
 (RFC 0012 §9.1, §12) — reserved for a release that has additionally cleared
 the human-reference gate. This module's public name is
 ``build_dataset_release`` because that gate does not exist yet.
+
+**Advisory gate coverage (RFC 0012 §14 "exigidos para alegações amplas de
+produção"):** step 5 evaluates all rigid gates plus 2 of the 5 gates in
+:data:`segmenter_dataset.gates.ADVISORY_GATES` — ``multiple_tribunals`` and
+``multiple_source_systems``, both computable directly from
+``DocumentRecord.source``. The remaining three (``temporal_diversity``,
+``representative_evaluation_set``, ``external_test_annotation_review``) are
+**not evaluated anywhere in this module** — they would need fields this
+schema doesn't carry yet (a publication/judgment date, a human-audit record
+type). A ``known_limitations`` entry naming one of those three is
+schema-valid (``KnownLimitation.gate`` isn't restricted beyond
+:func:`segmenter_dataset.gates.classify_gate` accepting the name) but
+currently inert: nothing ever produces a failing ``GateResult`` for that
+name, so there is nothing for the waiver to apply to. This is a known
+implementation gap, not a design decision — closing it requires extending
+``DocumentRecord``/``SourceInfo`` with the missing fields first.
 """
 
 from __future__ import annotations
@@ -194,6 +212,35 @@ def _support_gates(
     )
 
 
+def _diversity_gates(
+    train: list[ResolvedSplitDocument],
+    val: list[ResolvedSplitDocument],
+    test: list[ResolvedSplitDocument],
+) -> tuple[GateResult, GateResult]:
+    """The 2 of 5 RFC 0012 §14 advisory gates computable from data on hand today.
+
+    See the module docstring's "advisory gate coverage" note for the other
+    three (``temporal_diversity``, ``representative_evaluation_set``,
+    ``external_test_annotation_review``), which this function does not
+    evaluate — the schema has no date or audit-record field for them yet.
+    """
+    resolved = (*train, *val, *test)
+    tribunals = {item.document.source.tribunal for item in resolved}
+    systems = {item.document.source.system for item in resolved}
+    return (
+        GateResult(
+            name="multiple_tribunals",
+            passed=len(tribunals) > 1,
+            detail=f"tribunals observed: {sorted(tribunals)}",
+        ),
+        GateResult(
+            name="multiple_source_systems",
+            passed=len(systems) > 1,
+            detail=f"source systems observed: {sorted(systems)}",
+        ),
+    )
+
+
 def _iaa_gates(
     val: list[ResolvedSplitDocument],
     test: list[ResolvedSplitDocument],
@@ -284,8 +331,12 @@ def build_dataset_release(
 ) -> ReleaseManifest:
     """Run the full RFC 0012 §12 release procedure; returns the written manifest.
 
-    Raises :class:`ReleaseBlockedError` if any rigid gate fails, or if an
-    advisory gate fails without a matching known limitation.
+    Raises :class:`ReleaseBlockedError` if any rigid gate fails, or if
+    ``multiple_tribunals``/``multiple_source_systems`` (the 2 of 5 RFC 0012
+    §14 advisory gates this function evaluates — see the module docstring's
+    "advisory gate coverage" note) fail without a matching known limitation.
+    The other three advisory gates are never evaluated, so they can never
+    block a release and a known limitation naming one is currently inert.
     Raises :class:`~segmenter_dataset.store.ImmutabilityError` if
     ``release_id`` already exists.
     """
@@ -358,6 +409,7 @@ def build_dataset_release(
     val_test_adjudicated = len(val) == len(split_assignment.val_ids) and len(test) == len(
         split_assignment.test_ids
     )
+    multiple_tribunals_gate, multiple_source_systems_gate = _diversity_gates(train, val, test)
     gate_results = [
         GateResult(
             name="split_disjoint_by_group_id_hash",
@@ -385,6 +437,10 @@ def build_dataset_release(
             passed=bool(source_commit) and bool(dependency_lock_hash),
             detail="source_commit and dependency_lock_hash both provided",
         ),
+        # RFC 0012 §14 advisory gates — see the module docstring's "advisory
+        # gate coverage" note: only these 2 of 5 are evaluated today.
+        multiple_tribunals_gate,
+        multiple_source_systems_gate,
     ]
     evaluation = evaluate_gates(gate_results, known_limitations)
     if not evaluation.release_allowed:

--- a/src/segmenter_dataset/schemas.py
+++ b/src/segmenter_dataset/schemas.py
@@ -65,6 +65,28 @@ class SourceInfo(BaseModel):
     source_hash: str
 
 
+class GroupingInfo(BaseModel):
+    """Stable keys that keep a related-document group from crossing splits (RFC 0012 §10).
+
+    All fields are optional and default to unset — an ingestion pipeline
+    with access to structured source metadata (e.g. JURIS/DJEN's own
+    process-linkage fields) populates ``source_process_id``,
+    ``document_family``, and ``parent_document_id`` directly, since none of
+    those are recoverable from the document's own text.
+    ``normalized_process_number`` is the one field this module can also
+    derive on its own when unset — see
+    :func:`segmenter_dataset.provenance.extract_normalized_process_number`
+    and :meth:`segmenter_dataset.splits.GroupingKeys.from_document`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    normalized_process_number: str | None = None
+    source_process_id: str | None = None
+    document_family: str | None = None
+    parent_document_id: str | None = None
+
+
 class ExtractionInfo(BaseModel):
     """Which heuristic extractor produced ``proposed_labels`` (RFC 0012 §8)."""
 
@@ -90,6 +112,7 @@ class DocumentRecord(BaseModel):
     proposed_labels: list[Label] = Field(default_factory=list)
     source: SourceInfo
     extraction: ExtractionInfo
+    grouping: GroupingInfo = Field(default_factory=GroupingInfo)
 
 
 class AnnotatorConfig(BaseModel):

--- a/src/segmenter_dataset/schemas.py
+++ b/src/segmenter_dataset/schemas.py
@@ -1,0 +1,236 @@
+"""Record schemas for the segmenter dataset lifecycle (RFC 0012 §8).
+
+Three artifact types that coexist per document (RFC 0012 §3.1) — a document
+record is never edited or replaced; each annotation and each review is an
+additional record referencing it, never an overwrite:
+
+- :class:`DocumentRecord` — immutable source text + provenance.
+- :class:`AnnotationRecord` — one annotator's complete labeling of a
+  document, plus which ontology categories it actually considered
+  (``covered_categories`` — RFC 0012 §5.1's false-negative guard).
+- :class:`ReviewRecord` — adjudication of one or more annotations,
+  referencing them explicitly by ``annotation_id`` (RFC 0012 §8's lineage
+  fix — a review never just references a bare ``document_id``).
+
+:class:`ReleaseManifest` is the dataset-level artifact (§3.1: split-assigned
+and released are properties of a *build*, not of a document) produced by
+``release.build_dataset_release``.
+
+Pydantic validates shape and type here; the semantic/mechanical invariants
+of RFC 0012 §11 (offset bounds, pair balance, ontology membership, ...) are
+a separate concern in :mod:`segmenter_dataset.mechanical`, per RFC 0012
+§3.2 — mechanical validity is not semantic correctness, and neither layer
+should quietly absorb the other's job.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# RFC 0012 §5.3/§9 — an accepted review must resolve at least two
+# independent annotations.
+MIN_INDEPENDENT_ANNOTATIONS = 2
+
+
+class Label(BaseModel):
+    """One span label — ``text[start:end]`` tagged ``category``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    start: int
+    end: int
+    category: str
+
+    @model_validator(mode="after")
+    def _check_order(self) -> Label:
+        if not (0 <= self.start < self.end):
+            msg = (
+                "label offsets must satisfy 0 <= start < end, got "
+                f"start={self.start} end={self.end}"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class SourceInfo(BaseModel):
+    """Where a document came from (RFC 0012 §8)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    system: str
+    tribunal: str
+    document_type: str
+    source_uri: str
+    source_hash: str
+
+
+class ExtractionInfo(BaseModel):
+    """Which heuristic extractor produced ``proposed_labels`` (RFC 0012 §8)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    method: str
+    version: str
+
+
+class DocumentRecord(BaseModel):
+    """Immutable source-text record (RFC 0012 §8 "Registro de documento").
+
+    Never edited after creation — ``document_id`` is content-addressed
+    (:func:`segmenter_dataset.ids.document_id`) from ``source``, so two
+    extraction passes over the same source document resolve to the same
+    record rather than minting a new identity per extractor run.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    document_id: str
+    text: str
+    proposed_labels: list[Label] = Field(default_factory=list)
+    source: SourceInfo
+    extraction: ExtractionInfo
+
+
+class AnnotatorConfig(BaseModel):
+    """Identity of the annotator run that produced an :class:`AnnotationRecord`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    model_family: str
+    guideline_version: str
+    seeded_with: str = "none"
+
+
+class AnnotationRecord(BaseModel):
+    """One annotator's complete labeling of a document (RFC 0012 §8).
+
+    ``covered_categories`` is the RFC 0012 §5.1 false-negative guard: it is
+    the subset of the ontology this annotator actually considered. A
+    category outside this set must be masked out of training loss/support
+    for this document (§5.1), never read as a negative example.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    annotation_id: str
+    document_id: str
+    annotator_id: str
+    annotator_config: AnnotatorConfig
+    ontology_version: str
+    covered_categories: tuple[str, ...]
+    labels: list[Label] = Field(default_factory=list)
+    completed_at: str
+    annotation_method: str
+
+    @model_validator(mode="after")
+    def _labels_within_covered_categories(self) -> AnnotationRecord:
+        uncovered = {label.category for label in self.labels} - set(self.covered_categories)
+        if uncovered:
+            msg = (
+                f"labels use categories outside covered_categories: {sorted(uncovered)} — "
+                "an annotator cannot produce a label for a category it wasn't asked to consider"
+            )
+            raise ValueError(msg)
+        return self
+
+    def is_independent_capable(self) -> bool:
+        """RFC 0012 §5.3: an annotation counts as independent only if unseeded.
+
+        This checks the necessary local condition (``seeded_with == "none"``)
+        — the full definition also requires distinct model families *or*
+        provably isolated runs across a *pair* of annotations, which is a
+        property of two records together, not one (see
+        :func:`segmenter_dataset.mechanical.annotations_are_independent`).
+        """
+        return self.annotator_config.seeded_with == "none"
+
+
+class ReviewRecord(BaseModel):
+    """Adjudication of one or more annotations (RFC 0012 §8 "Registro de review").
+
+    ``input_annotation_ids`` names exactly which annotation records this
+    review resolved — never just ``document_id``, because a document may
+    accumulate more than two annotations over time and a reconstructed
+    release must be able to tell which pair a given review adjudicated
+    (RFC 0012 §8's lineage fix).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    review_id: str
+    document_id: str
+    input_annotation_ids: tuple[str, ...]
+    status: str
+    final_labels: list[Label] = Field(default_factory=list)
+    reviewers: tuple[str, ...]
+    resolution: str
+    notes: tuple[str, ...] = ()
+    approved_at: str
+
+    @model_validator(mode="after")
+    def _at_least_two_inputs_when_accepted(self) -> ReviewRecord:
+        n_inputs = len(self.input_annotation_ids)
+        if self.status == "accepted" and n_inputs < MIN_INDEPENDENT_ANNOTATIONS:
+            msg = (
+                "an accepted review must resolve at least two independent annotations "
+                f"(RFC 0012 §9); got {n_inputs}"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class KnownLimitation(BaseModel):
+    """A waivable/advisory gate recorded as a lightweight known limitation.
+
+    RFC 0012 §12/§12.1: no formal ``approved_by``/expiry object — the next
+    major release is the natural review point (§13.1), not a hardcoded
+    expiry field.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    gate: str
+    status: str = "known_limitation"
+    reason: str
+
+
+class AnnotationQuality(BaseModel):
+    """IAA evidence required by RFC 0012 §8/§14 — never a bare number."""
+
+    model_config = ConfigDict(frozen=True)
+
+    val_iaa_span_f1: float | None = None
+    val_iaa_span_f1_ci95_low: float | None = None
+    test_iaa_span_f1: float | None = None
+    test_iaa_span_f1_ci95_low: float | None = None
+    per_category_iaa: dict[str, float] = Field(default_factory=dict)
+    unreliable_eval_categories: tuple[str, ...] = ()
+
+
+class ReleaseManifest(BaseModel):
+    """Dataset-level release artifact (RFC 0012 §8, §12).
+
+    Lives at ``dataset-releases/<release_id>/manifest.json`` once
+    ``release.build_dataset_release`` finishes. ``document_resolutions``
+    pins the exact ``annotation_id``/``review_id`` used per document per
+    split — without it, rebuilding from the same ``document_id`` set could
+    silently pick a different annotation if the document was re-annotated
+    between builds (RFC 0012 §8's lineage fix).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    release_id: str
+    ontology_version: str
+    guideline_version: str
+    source_commit: str
+    dependency_lock_hash: str
+    split_hashes: dict[str, str]
+    document_resolutions: dict[str, dict[str, str]]
+    counts: dict[str, int] = Field(default_factory=dict)
+    tribunals: dict[str, int] = Field(default_factory=dict)
+    document_types: dict[str, int] = Field(default_factory=dict)
+    annotation_quality: AnnotationQuality
+    known_limitations: tuple[KnownLimitation, ...] = ()
+    created_at: str

--- a/src/segmenter_dataset/splits.py
+++ b/src/segmenter_dataset/splits.py
@@ -16,6 +16,15 @@ disjointness/leakage primitives are adapted from PR #832's
 synthetic-lineage-specific helpers there (``assign_child_split``,
 ``require_train_only_sources``, ``calibration_eligible_ids``) are left
 behind for PR 4/synthetic to reuse; they aren't RFC 0012's PR 1 concern.
+
+``GroupingKeys.from_document`` is the real wiring, not a stub: it reads
+persisted ``DocumentRecord.grouping`` metadata and falls back to regex
+extraction (:mod:`segmenter_dataset.provenance`) for
+``normalized_process_number`` when ingestion hasn't recorded one, so
+union-find grouping fires on more than exact-content-hash and near-dup
+ratio (PR #838 review finding #1). ``assign_splits`` additionally refuses
+to return an empty val or test split when eval-eligible groups existed
+(finding #2) — see :class:`EmptyEvalSplitError`.
 """
 
 from __future__ import annotations
@@ -25,6 +34,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from segmenter_dataset.dedup import content_hash, find_near_duplicates
+from segmenter_dataset.provenance import extract_normalized_process_number
 
 
 if TYPE_CHECKING:
@@ -33,6 +43,23 @@ if TYPE_CHECKING:
 
 class SplitLeakError(ValueError):
     """A split-integrity invariant (RFC 0012 §10) was violated."""
+
+
+class EmptyEvalSplitError(ValueError):
+    """RFC 0012 §10: eval-eligible groups existed, but ``assign_splits`` starved val or test.
+
+    PR #838 review finding #2: the greedy packing in ``assign_splits`` only
+    places a group into val/test if it fits entirely under the *remaining*
+    target size — there is no fallback to "try a smaller group instead".
+    Once grouping keys are real (finding #1: process number, family,
+    parent/derived), eval-eligible groups routinely have >= 2 members, and a
+    small target (e.g. 1, from a small overall eligible pool) can then
+    silently starve val or test to zero — every group falls through to
+    train with no error, because nothing overlaps (``SplitAssignment``'s
+    disjointness check has nothing to catch). This is not a leakage
+    condition, so it can't be folded into :class:`SplitLeakError`; it is
+    checked directly in ``assign_splits``, right after packing.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +96,36 @@ class GroupingKeys:
     source_process_id: str | None = None
     document_family: str | None = None
     parent_document_id: str | None = None
+
+    @classmethod
+    def from_document(cls, document: DocumentRecord) -> GroupingKeys:
+        """Build real grouping keys for one document (RFC 0012 PR1 review finding #1).
+
+        ``normalized_process_number`` prefers an explicitly recorded value
+        (``document.grouping``, set by an ingestion pipeline with access to
+        structured source metadata) and falls back to regex extraction from
+        the document's own URI/text — see
+        :func:`segmenter_dataset.provenance.extract_normalized_process_number`
+        — when ingestion didn't record one. This is what makes
+        process-number-based union-find grouping fire today, without
+        waiting on a future ingestion PR to populate
+        ``DocumentRecord.grouping``. The remaining keys aren't derivable
+        from text alone and stay whatever ingestion recorded (``None``
+        until it does).
+        """
+        grouping = document.grouping
+        normalized_process_number = grouping.normalized_process_number
+        if normalized_process_number is None:
+            normalized_process_number = extract_normalized_process_number(
+                source_uri=document.source.source_uri, text=document.text
+            )
+        return cls(
+            document_id=document.document_id,
+            normalized_process_number=normalized_process_number,
+            source_process_id=grouping.source_process_id,
+            document_family=grouping.document_family,
+            parent_document_id=grouping.parent_document_id,
+        )
 
 
 class _UnionFind:
@@ -245,11 +302,13 @@ def assign_splits(
     val_target = max(1, round(total_eligible * val_ratio))
     test_target = max(1, round(total_eligible * (1 - train_ratio - val_ratio)))
 
+    any_evaluation_capable_group = False
     for group_id in ordered_group_ids:
         members = groups[group_id] & (train_eligible | evaluation_eligible)
         if not members:
             continue
         evaluation_capable = members <= evaluation_eligible
+        any_evaluation_capable_group = any_evaluation_capable_group or evaluation_capable
 
         if (
             evaluation_capable
@@ -265,6 +324,17 @@ def assign_splits(
             test_ids |= members
         else:
             train_ids |= members
+
+    if any_evaluation_capable_group and (not val_ids or not test_ids):
+        msg = (
+            "eval-eligible groups exist but assign_splits produced an empty "
+            f"val ({len(val_ids)} docs) or test ({len(test_ids)} docs) split — "
+            "every eligible group likely exceeds the remaining target size, "
+            "with no fallback to a smaller group (RFC 0012 §10, PR #838 review "
+            "finding #2); widen val_ratio/test_ratio or grow the pool of "
+            "independent eval-eligible documents before re-running"
+        )
+        raise EmptyEvalSplitError(msg)
 
     return SplitAssignment(frozenset(train_ids), frozenset(val_ids), frozenset(test_ids))
 

--- a/src/segmenter_dataset/splits.py
+++ b/src/segmenter_dataset/splits.py
@@ -1,0 +1,315 @@
+"""Split policy (RFC 0012 §10): grouping, role eligibility, and leakage checks.
+
+Split assignment happens only after a document reaches the state its target
+role requires (RFC 0012 §10, fixed in review round 2 — there is no single
+"after adjudication" rule for all three splits):
+
+- **train** role requires only **annotated** (one complete annotation +
+  mechanical validation; risk spot-review resolution is a maintainer
+  process this module doesn't model — see RFC 0012 §9);
+- **validation**/**test** roles require **adjudicated** (an accepted
+  :class:`~segmenter_dataset.schemas.ReviewRecord`).
+
+Grouping (so a related-document group never crosses splits) and the
+disjointness/leakage primitives are adapted from PR #832's
+``scripts/synthetic_segmenter/split_guard.py`` (RFC 0012 §18) — the
+synthetic-lineage-specific helpers there (``assign_child_split``,
+``require_train_only_sources``, ``calibration_eligible_ids``) are left
+behind for PR 4/synthetic to reuse; they aren't RFC 0012's PR 1 concern.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from segmenter_dataset.dedup import content_hash, find_near_duplicates
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import AnnotationRecord, DocumentRecord, ReviewRecord
+
+
+class SplitLeakError(ValueError):
+    """A split-integrity invariant (RFC 0012 §10) was violated."""
+
+
+# ---------------------------------------------------------------------------
+# Role eligibility
+# ---------------------------------------------------------------------------
+
+
+def train_eligible_document_ids(annotations: list[AnnotationRecord]) -> frozenset[str]:
+    """Documents eligible for the **train** role: at least one annotation exists.
+
+    Mechanical validation of each annotation is assumed to have already
+    happened (``mechanical.validate_record``) before it reaches this
+    function — this only checks presence, not correctness (RFC 0012 §3.2).
+    """
+    return frozenset(a.document_id for a in annotations)
+
+
+def evaluation_eligible_document_ids(reviews: list[ReviewRecord]) -> frozenset[str]:
+    """Documents eligible for the **validation**/**test** role: an accepted review exists."""
+    return frozenset(r.document_id for r in reviews if r.status == "accepted")
+
+
+# ---------------------------------------------------------------------------
+# Grouping — a group never crosses splits (RFC 0012 §10)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GroupingKeys:
+    """Grouping keys for one document, per RFC 0012 §10 (all optional)."""
+
+    document_id: str
+    normalized_process_number: str | None = None
+    source_process_id: str | None = None
+    document_family: str | None = None
+    parent_document_id: str | None = None
+
+
+class _UnionFind:
+    """Minimal union-find for clustering documents that share any grouping key."""
+
+    def __init__(self, ids: list[str]) -> None:
+        self._parent = {doc_id: doc_id for doc_id in ids}
+
+    def find(self, doc_id: str) -> str:
+        while self._parent[doc_id] != doc_id:
+            self._parent[doc_id] = self._parent[self._parent[doc_id]]
+            doc_id = self._parent[doc_id]
+        return doc_id
+
+    def union(self, a: str, b: str) -> None:
+        root_a, root_b = self.find(a), self.find(b)
+        if root_a != root_b:
+            self._parent[root_a] = root_b
+
+    def contains(self, doc_id: str) -> bool:
+        return doc_id in self._parent
+
+
+def _union_shared_values(uf: _UnionFind, id_lists: dict[str, list[str]]) -> None:
+    """Union every group of ids sharing a common key value."""
+    for group_ids in id_lists.values():
+        for other in group_ids[1:]:
+            uf.union(group_ids[0], other)
+
+
+def _union_by_content(
+    uf: _UnionFind, documents: list[DocumentRecord], *, near_duplicate_threshold: float
+) -> None:
+    """Union documents sharing an exact content hash or a near-duplicate ratio."""
+    by_hash: dict[str, list[str]] = {}
+    for doc in documents:
+        by_hash.setdefault(content_hash(doc.text), []).append(doc.document_id)
+    _union_shared_values(uf, by_hash)
+
+    texts = {doc.document_id: doc.text for doc in documents}
+    for id_a, id_b, _ratio in find_near_duplicates(texts, threshold=near_duplicate_threshold):
+        uf.union(id_a, id_b)
+
+
+_GROUPING_KEY_FIELDS = ("normalized_process_number", "source_process_id", "document_family")
+
+
+def _union_by_grouping_keys(uf: _UnionFind, keys: list[GroupingKeys]) -> None:
+    """Union documents sharing a non-null grouping key or a parent/child relationship."""
+    for field in _GROUPING_KEY_FIELDS:
+        by_key: dict[str, list[str]] = {}
+        for key in keys:
+            value = getattr(key, field)
+            if value:
+                by_key.setdefault(value, []).append(key.document_id)
+        _union_shared_values(uf, by_key)
+
+    for key in keys:
+        if key.parent_document_id and uf.contains(key.parent_document_id):
+            uf.union(key.document_id, key.parent_document_id)
+
+
+def build_groups(
+    documents: list[DocumentRecord],
+    keys: list[GroupingKeys],
+    *,
+    near_duplicate_threshold: float = 0.9,
+) -> dict[str, frozenset[str]]:
+    """Cluster documents into groups that must not cross splits (RFC 0012 §10).
+
+    Union-find over: exact content hash, near-duplicate content (via
+    :func:`segmenter_dataset.dedup.find_near_duplicates`), and any shared
+    non-null grouping key (process number, source process ID, document
+    family, parent/derived relationship). Returns ``{group_id: {document_id, ...}}``
+    keyed by one representative document_id per group.
+    """
+    ids = [doc.document_id for doc in documents]
+    uf = _UnionFind(ids)
+
+    _union_by_content(uf, documents, near_duplicate_threshold=near_duplicate_threshold)
+    _union_by_grouping_keys(uf, keys)
+
+    groups: dict[str, list[str]] = {}
+    for doc_id in ids:
+        root = uf.find(doc_id)
+        groups.setdefault(root, []).append(doc_id)
+    return {root: frozenset(members) for root, members in groups.items()}
+
+
+# ---------------------------------------------------------------------------
+# Assignment
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SplitAssignment:
+    """Which split each document belongs to (RFC 0012 §10)."""
+
+    train_ids: frozenset[str]
+    val_ids: frozenset[str]
+    test_ids: frozenset[str]
+
+    def __post_init__(self) -> None:
+        """Raise :class:`SplitLeakError` immediately if the three sets aren't disjoint."""
+        violations = check_disjoint(self.train_ids, self.val_ids, self.test_ids)
+        if violations:
+            raise SplitLeakError("; ".join(violations))
+
+    def split_of(self, document_id: str) -> str | None:
+        """Return ``"train"``/``"val"``/``"test"`` for a known document_id, else ``None``."""
+        if document_id in self.train_ids:
+            return "train"
+        if document_id in self.val_ids:
+            return "val"
+        if document_id in self.test_ids:
+            return "test"
+        return None
+
+
+def check_disjoint(
+    train_ids: frozenset[str], val_ids: frozenset[str], test_ids: frozenset[str]
+) -> list[str]:
+    """Return violation messages for any pairwise intersection; empty = OK."""
+    violations: list[str] = []
+    for name_a, ids_a, name_b, ids_b in (
+        ("train", train_ids, "val", val_ids),
+        ("train", train_ids, "test", test_ids),
+        ("val", val_ids, "test", test_ids),
+    ):
+        overlap = ids_a & ids_b
+        if overlap:
+            violations.append(f"{name_a}/{name_b} overlap: {sorted(overlap)}")
+    return violations
+
+
+def assign_splits(
+    groups: dict[str, frozenset[str]],
+    *,
+    train_eligible: frozenset[str],
+    evaluation_eligible: frozenset[str],
+    train_ratio: float = 0.70,
+    val_ratio: float = 0.15,
+    seed: int,
+) -> SplitAssignment:
+    """Deterministically assign groups to train/val/test (RFC 0012 §10).
+
+    A group is **evaluation-capable** (may become val or test) only if
+    every one of its documents is ``evaluation_eligible``; otherwise it can
+    only become train, and only once every member is at least
+    ``train_eligible``. Documents that are in neither eligible set are
+    dropped from the group before assignment (not yet ready for any role —
+    not an error).
+
+    Deterministic: groups are ordered by a stable hash of ``(seed,
+    group_id)`` before greedy proportional assignment, so the same inputs
+    always produce the same split — reproducibility (RFC 0012 §12/§14), not
+    an actual pseudo-random shuffle.
+    """
+
+    def sort_key(group_id: str) -> str:
+        return hashlib.sha256(f"{seed}:{group_id}".encode()).hexdigest()
+
+    train_ids: set[str] = set()
+    val_ids: set[str] = set()
+    test_ids: set[str] = set()
+
+    ordered_group_ids = sorted(groups, key=sort_key)
+    total_eligible = sum(
+        len(groups[gid] & (train_eligible | evaluation_eligible)) for gid in ordered_group_ids
+    )
+    if total_eligible == 0:
+        return SplitAssignment(frozenset(), frozenset(), frozenset())
+
+    val_target = max(1, round(total_eligible * val_ratio))
+    test_target = max(1, round(total_eligible * (1 - train_ratio - val_ratio)))
+
+    for group_id in ordered_group_ids:
+        members = groups[group_id] & (train_eligible | evaluation_eligible)
+        if not members:
+            continue
+        evaluation_capable = members <= evaluation_eligible
+
+        if (
+            evaluation_capable
+            and len(val_ids) < val_target
+            and len(val_ids) + len(members) <= val_target
+        ):
+            val_ids |= members
+        elif (
+            evaluation_capable
+            and len(test_ids) < test_target
+            and len(test_ids) + len(members) <= test_target
+        ):
+            test_ids |= members
+        else:
+            train_ids |= members
+
+    return SplitAssignment(frozenset(train_ids), frozenset(val_ids), frozenset(test_ids))
+
+
+# ---------------------------------------------------------------------------
+# Leakage rejection (RFC 0012 §10's explicit reject list)
+# ---------------------------------------------------------------------------
+
+
+def validate_split_leakage(
+    assignment: SplitAssignment,
+    documents: list[DocumentRecord],
+    groups: dict[str, frozenset[str]],
+) -> list[str]:
+    """RFC 0012 §10's explicit rejection checks; empty list = no leakage found.
+
+    Checks: no ``document_id`` assigned twice (covered structurally by
+    ``SplitAssignment``'s disjointness, re-asserted here for a single
+    combined report), no normalized-content-hash collision across splits,
+    and no group spanning more than one split.
+    """
+    problems: list[str] = []
+
+    hash_to_splits: dict[str, set[str]] = {}
+    for doc in documents:
+        split = assignment.split_of(doc.document_id)
+        if split is None:
+            continue
+        hash_to_splits.setdefault(content_hash(doc.text), set()).add(split)
+    problems.extend(
+        f"content_hash {digest} appears in multiple splits: {sorted(splits)}"
+        for digest, splits in hash_to_splits.items()
+        if len(splits) > 1
+    )
+
+    for group_id, members in groups.items():
+        splits_seen = {
+            assignment.split_of(doc_id)
+            for doc_id in members
+            if assignment.split_of(doc_id) is not None
+        }
+        if len(splits_seen) > 1:
+            problems.append(
+                f"group {group_id} spans multiple splits: {sorted(splits_seen)} "
+                f"(members: {sorted(members)})"
+            )
+
+    return problems

--- a/src/segmenter_dataset/store.py
+++ b/src/segmenter_dataset/store.py
@@ -1,0 +1,141 @@
+"""Filesystem layout for the segmenter dataset lifecycle (RFC 0012 §8).
+
+```text
+data/segmenter/
+  documents/<document_id>.json
+  annotations/<document_id>/<annotation_id>.json
+  reviews/<document_id>/<review_id>.json
+  dataset-releases/<release_id>/split_manifest.json
+  dataset-releases/<release_id>/manifest.json
+```
+
+All three per-document artifact types are content-addressed and immutable
+(RFC 0012 §3.1) — writing the same ID twice with identical content is a
+no-op; writing the same ID with *different* content is a bug (a hash
+collision, or a caller computing the ID wrong) and raises rather than
+silently overwriting, which is exactly the property §3.1 requires: "o
+registro original... nunca é apagado nem reescrito".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from segmenter_dataset.schemas import (
+    AnnotationRecord,
+    DocumentRecord,
+    ReleaseManifest,
+    ReviewRecord,
+)
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ImmutabilityError(ValueError):
+    """An attempt to write different content under an existing content-addressed ID."""
+
+
+class SegmenterDatasetStore:
+    """Read/write access to ``data/segmenter/`` (RFC 0012 §8)."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.documents_dir = root / "documents"
+        self.annotations_dir = root / "annotations"
+        self.reviews_dir = root / "reviews"
+        self.releases_dir = root / "dataset-releases"
+
+    # -- documents ----------------------------------------------------
+
+    def write_document(self, document: DocumentRecord) -> Path:
+        self.documents_dir.mkdir(parents=True, exist_ok=True)
+        path = self.documents_dir / f"{document.document_id}.json"
+        _write_immutable(path, document)
+        return path
+
+    def read_document(self, document_id: str) -> DocumentRecord:
+        path = self.documents_dir / f"{document_id}.json"
+        return DocumentRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def list_documents(self) -> list[DocumentRecord]:
+        if not self.documents_dir.exists():
+            return []
+        return [
+            DocumentRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            for path in sorted(self.documents_dir.glob("*.json"))
+        ]
+
+    # -- annotations ----------------------------------------------------
+
+    def write_annotation(self, annotation: AnnotationRecord) -> Path:
+        doc_dir = self.annotations_dir / annotation.document_id
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        path = doc_dir / f"{annotation.annotation_id}.json"
+        _write_immutable(path, annotation)
+        return path
+
+    def list_annotations(self, document_id: str | None = None) -> list[AnnotationRecord]:
+        if not self.annotations_dir.exists():
+            return []
+        pattern = f"{document_id}/*.json" if document_id else "*/*.json"
+        return [
+            AnnotationRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            for path in sorted(self.annotations_dir.glob(pattern))
+        ]
+
+    # -- reviews ----------------------------------------------------
+
+    def write_review(self, review: ReviewRecord) -> Path:
+        doc_dir = self.reviews_dir / review.document_id
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        path = doc_dir / f"{review.review_id}.json"
+        _write_immutable(path, review)
+        return path
+
+    def list_reviews(self, document_id: str | None = None) -> list[ReviewRecord]:
+        if not self.reviews_dir.exists():
+            return []
+        pattern = f"{document_id}/*.json" if document_id else "*/*.json"
+        return [
+            ReviewRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            for path in sorted(self.reviews_dir.glob(pattern))
+        ]
+
+    # -- releases ----------------------------------------------------
+
+    def release_dir(self, release_id: str) -> Path:
+        return self.releases_dir / release_id
+
+    def write_release_manifest(self, manifest: ReleaseManifest) -> Path:
+        """Write the final release manifest. Refuses to overwrite an existing release (§12)."""
+        release_dir = self.release_dir(manifest.release_id)
+        manifest_path = release_dir / "manifest.json"
+        if manifest_path.exists():
+            msg = (
+                f"release {manifest.release_id!r} already exists at {manifest_path} — "
+                "refusing to overwrite (RFC 0012 §12)"
+            )
+            raise ImmutabilityError(msg)
+        release_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+        return manifest_path
+
+    def read_release_manifest(self, release_id: str) -> ReleaseManifest:
+        path = self.release_dir(release_id) / "manifest.json"
+        return ReleaseManifest.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _write_immutable(path: Path, record: DocumentRecord | AnnotationRecord | ReviewRecord) -> None:
+    payload = record.model_dump_json(indent=2)
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if existing != payload:
+            msg = (
+                f"content-addressed record at {path} already exists with different content — "
+                "this should be impossible unless the ID was computed incorrectly (RFC 0012 §3.1)"
+            )
+            raise ImmutabilityError(msg)
+        return
+    path.write_text(payload, encoding="utf-8")

--- a/tests/segmenter_dataset/conftest.py
+++ b/tests/segmenter_dataset/conftest.py
@@ -6,6 +6,7 @@ from segmenter_dataset.schemas import (
     AnnotatorConfig,
     DocumentRecord,
     ExtractionInfo,
+    GroupingInfo,
     Label,
     ReviewRecord,
     SourceInfo,
@@ -22,6 +23,10 @@ def make_document(
     document_type: str = "sentenca",
     source_uri: str = "ia://item/doc-1",
     source_hash: str = "hash-1",
+    normalized_process_number: str | None = None,
+    source_process_id: str | None = None,
+    document_family: str | None = None,
+    parent_document_id: str | None = None,
 ) -> DocumentRecord:
     doc_id = document_id(source_system="tjro_juris", source_uri=source_uri, source_hash=source_hash)
     return DocumentRecord(
@@ -36,6 +41,12 @@ def make_document(
             source_hash=source_hash,
         ),
         extraction=ExtractionInfo(method="boundary_phrase_extractor", version="1"),
+        grouping=GroupingInfo(
+            normalized_process_number=normalized_process_number,
+            source_process_id=source_process_id,
+            document_family=document_family,
+            parent_document_id=parent_document_id,
+        ),
     )
 
 

--- a/tests/segmenter_dataset/conftest.py
+++ b/tests/segmenter_dataset/conftest.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from segmenter_dataset.ids import annotation_id, document_id, review_id
+from segmenter_dataset.schemas import (
+    AnnotationRecord,
+    AnnotatorConfig,
+    DocumentRecord,
+    ExtractionInfo,
+    Label,
+    ReviewRecord,
+    SourceInfo,
+)
+
+
+ONTOLOGY_VERSION = "segmenter-ontology-v8.0.0"
+
+
+def make_document(
+    *,
+    text: str = "CABEÇALHO texto ementa RELATÓRIO fim.",
+    tribunal: str = "TJRO",
+    document_type: str = "sentenca",
+    source_uri: str = "ia://item/doc-1",
+    source_hash: str = "hash-1",
+) -> DocumentRecord:
+    doc_id = document_id(source_system="tjro_juris", source_uri=source_uri, source_hash=source_hash)
+    return DocumentRecord(
+        document_id=doc_id,
+        text=text,
+        proposed_labels=[],
+        source=SourceInfo(
+            system="tjro_juris",
+            tribunal=tribunal,
+            document_type=document_type,
+            source_uri=source_uri,
+            source_hash=source_hash,
+        ),
+        extraction=ExtractionInfo(method="boundary_phrase_extractor", version="1"),
+    )
+
+
+def make_annotation(
+    document: DocumentRecord,
+    *,
+    annotator_id: str = "annotator-a",
+    model_family: str = "family-a",
+    seeded_with: str = "none",
+    completed_at: str = "2026-01-01T00:00:00Z",
+    labels: list[Label] | None = None,
+    covered_categories: tuple[str, ...] = ("cabecalho_inicio", "cabecalho_fim"),
+) -> AnnotationRecord:
+    labels = labels if labels is not None else [Label(start=0, end=9, category="cabecalho_inicio")]
+    ann_id = annotation_id(
+        document_id=document.document_id,
+        annotator_id=annotator_id,
+        completed_at=completed_at,
+        labels=[label.model_dump() for label in labels],
+    )
+    return AnnotationRecord(
+        annotation_id=ann_id,
+        document_id=document.document_id,
+        annotator_id=annotator_id,
+        annotator_config=AnnotatorConfig(
+            model_family=model_family, guideline_version="g1", seeded_with=seeded_with
+        ),
+        ontology_version=ONTOLOGY_VERSION,
+        covered_categories=covered_categories,
+        labels=labels,
+        completed_at=completed_at,
+        annotation_method="independent_full_read",
+    )
+
+
+def make_review(
+    document: DocumentRecord,
+    annotations: list[AnnotationRecord],
+    *,
+    status: str = "accepted",
+    approved_at: str = "2026-01-02T00:00:00Z",
+    final_labels: list[Label] | None = None,
+    reviewers: tuple[str, ...] = ("reviewer-a", "reviewer-b"),
+) -> ReviewRecord:
+    final_labels = final_labels if final_labels is not None else list(annotations[0].labels)
+    rev_id = review_id(
+        document_id=document.document_id,
+        input_annotation_ids=[a.annotation_id for a in annotations],
+        approved_at=approved_at,
+    )
+    return ReviewRecord(
+        review_id=rev_id,
+        document_id=document.document_id,
+        input_annotation_ids=tuple(a.annotation_id for a in annotations),
+        status=status,
+        final_labels=final_labels,
+        reviewers=reviewers,
+        resolution="agreement",
+        notes=(),
+        approved_at=approved_at,
+    )

--- a/tests/segmenter_dataset/test_dedup.py
+++ b/tests/segmenter_dataset/test_dedup.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from segmenter_dataset.dedup import (
+    content_hash,
+    find_exact_duplicates,
+    find_near_duplicates,
+    normalize_text,
+)
+
+
+def test_normalize_text_collapses_whitespace_and_lowercases() -> None:
+    assert normalize_text("  Foo   Bar\n\tBaz ") == "foo bar baz"
+
+
+def test_content_hash_ignores_incidental_whitespace() -> None:
+    assert content_hash("Foo Bar") == content_hash("foo   bar")
+
+
+def test_find_exact_duplicates() -> None:
+    records = {"a": "Same text", "b": "same   TEXT", "c": "different"}
+    pairs = find_exact_duplicates(records)
+    assert pairs == [("a", "b")]
+
+
+def test_find_near_duplicates_threshold() -> None:
+    records = {
+        "a": "o juiz julgou procedente o pedido do autor",
+        "b": "o juiz julgou procedente o pedido da autora",
+        "c": "texto completamente diferente sem relacao nenhuma",
+    }
+    near = find_near_duplicates(records, threshold=0.8)
+    ids = {(a, b) for a, b, _ratio in near}
+    assert ("a", "b") in ids
+    assert ("a", "c") not in ids

--- a/tests/segmenter_dataset/test_gates.py
+++ b/tests/segmenter_dataset/test_gates.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from segmenter_dataset.gates import (
+    GateResult,
+    GateSeverity,
+    UnknownGateError,
+    classify_gate,
+    evaluate_gates,
+)
+from segmenter_dataset.schemas import KnownLimitation
+
+
+def test_classify_gate_rigid() -> None:
+    assert classify_gate("ontology_schema_valid") is GateSeverity.RIGID
+
+
+def test_classify_gate_advisory() -> None:
+    assert classify_gate("multiple_tribunals") is GateSeverity.ADVISORY
+
+
+def test_classify_gate_unknown_raises() -> None:
+    with pytest.raises(UnknownGateError):
+        classify_gate("made_up_gate_name")
+
+
+def test_evaluate_gates_all_pass() -> None:
+    results = [GateResult(name="ontology_schema_valid", passed=True)]
+    evaluation = evaluate_gates(results, [])
+    assert evaluation.release_allowed is True
+
+
+def test_evaluate_gates_rigid_failure_blocks_even_with_known_limitation() -> None:
+    results = [GateResult(name="ontology_schema_valid", passed=False, detail="bad offsets")]
+    # A known_limitation naming a rigid gate cannot waive it (RFC 0012 §12.1) —
+    # classify_gate still resolves it to RIGID regardless of what's in
+    # known_limitations, so evaluate_gates never consults the list for it.
+    limitations = [KnownLimitation(gate="ontology_schema_valid", reason="please ignore")]
+    evaluation = evaluate_gates(results, limitations)
+    assert evaluation.release_allowed is False
+    assert len(evaluation.blocking_rigid_failures) == 1
+
+
+def test_evaluate_gates_advisory_failure_blocks_without_known_limitation() -> None:
+    results = [GateResult(name="multiple_tribunals", passed=False, detail="TJRO only")]
+    evaluation = evaluate_gates(results, [])
+    assert evaluation.release_allowed is False
+    assert len(evaluation.blocking_unwaived_advisory_failures) == 1
+
+
+def test_evaluate_gates_advisory_failure_waived_by_known_limitation() -> None:
+    results = [GateResult(name="multiple_tribunals", passed=False, detail="TJRO only")]
+    limitations = [
+        KnownLimitation(gate="multiple_tribunals", reason="v8.1 is explicitly TJRO-only")
+    ]
+    evaluation = evaluate_gates(results, limitations)
+    assert evaluation.release_allowed is True
+    assert len(evaluation.waived_advisory_failures) == 1

--- a/tests/segmenter_dataset/test_iaa.py
+++ b/tests/segmenter_dataset/test_iaa.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from segmenter_dataset.iaa import (
     AGGREGATE_FLOOR,
+    MIN_CI_GATE_SUPPORT,
     PER_CATEGORY_FLOOR,
     DocumentAnnotationPair,
     compute_iaa_report,
@@ -97,3 +100,61 @@ def test_compute_iaa_report_very_low_support_not_gated_at_all() -> None:
     assert result.support == 1
     assert result.gate_statistic == "not_gated_low_support"
     assert result.included_in_aggregate is False
+
+
+def test_compute_iaa_report_heterogeneous_agreement_bootstrap_varies() -> None:
+    """Distinguishes a correct bootstrap from one that just returns the point estimate.
+
+    Every other IAA test in this module uses homogeneous data (all-agree or
+    all-disagree documents), where every resample reproduces the same
+    per-category counts as the full sample — a bootstrap implementation
+    that (incorrectly) always returned the point estimate unchanged would
+    pass those tests too. Mixing 20 perfectly-agreeing documents with 10
+    perfectly-disagreeing ones makes the resampled composition (and hence
+    the resampled F1) genuinely vary run to run, so ``macro_f1_ci_low``
+    landing strictly below the point estimate is only possible if resampling
+    is actually happening.
+    """
+    agree = [_pair(f"agree{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(20)]
+    disagree = [_pair(f"dis{i}", [(0, 5, "cat")], [(10, 15, "cat")]) for i in range(10)]
+    pairs = agree + disagree
+
+    report = compute_iaa_report(pairs, seed=1, resamples=1000)
+    result = report.per_category["cat"]
+
+    assert result.support == 40
+    assert result.point_estimate == pytest.approx(2 / 3)
+    assert result.ci_low is not None
+    # A buggy "bootstrap" that just re-reports the point estimate every
+    # resample would make ci_low == point_estimate exactly; a real one
+    # produces a lower tail from unlucky resamples that draw more
+    # disagreement.
+    assert result.ci_low < result.point_estimate
+    assert report.macro_f1_ci_low is not None
+    assert report.macro_f1_ci_low < report.macro_f1_point
+
+
+def test_compute_iaa_report_support_exactly_15_uses_ci_gate() -> None:
+    """Boundary test at MIN_CI_GATE_SUPPORT (15) — only 1 and 5 were covered before.
+
+    Support of exactly 15 must take the CI-lower-bound gate path (the ``>=``
+    in ``compute_iaa_report``'s branch), not the point-estimate path used
+    for support in [5, 15).
+    """
+    pairs = [_pair(f"d{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(MIN_CI_GATE_SUPPORT)]
+    report = compute_iaa_report(pairs, seed=1, resamples=200)
+    result = report.per_category["cat"]
+    assert result.support == MIN_CI_GATE_SUPPORT
+    assert result.gate_statistic == "ci_lower_bound"
+    assert result.ci_low is not None
+
+
+def test_compute_iaa_report_support_one_below_boundary_uses_point_estimate_gate() -> None:
+    """One below the MIN_CI_GATE_SUPPORT boundary — contrasts with support == 15."""
+    pairs = [
+        _pair(f"d{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(MIN_CI_GATE_SUPPORT - 1)
+    ]
+    report = compute_iaa_report(pairs, seed=1, resamples=200)
+    result = report.per_category["cat"]
+    assert result.support == MIN_CI_GATE_SUPPORT - 1
+    assert result.gate_statistic == "point_estimate"

--- a/tests/segmenter_dataset/test_iaa.py
+++ b/tests/segmenter_dataset/test_iaa.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from segmenter_dataset.iaa import (
+    AGGREGATE_FLOOR,
+    PER_CATEGORY_FLOOR,
+    DocumentAnnotationPair,
+    compute_iaa_report,
+    f1_from_counts,
+    macro_f1,
+    per_category_f1,
+    pooled_counts,
+    support,
+)
+from segmenter_dataset.schemas import Label
+
+
+def _pair(
+    doc_id: str, spans_a: list[tuple[int, int, str]], spans_b: list[tuple[int, int, str]]
+) -> DocumentAnnotationPair:
+    return DocumentAnnotationPair(
+        document_id=doc_id,
+        labels_a=tuple(Label(start=s, end=e, category=c) for s, e, c in spans_a),
+        labels_b=tuple(Label(start=s, end=e, category=c) for s, e, c in spans_b),
+    )
+
+
+def test_f1_from_counts_perfect_agreement() -> None:
+    assert f1_from_counts(tp=5, fp=0, fn=0) == 1.0
+
+
+def test_f1_from_counts_no_overlap() -> None:
+    assert f1_from_counts(tp=0, fp=3, fn=3) == 0.0
+
+
+def test_f1_from_counts_zero_support_is_zero_not_nan() -> None:
+    assert f1_from_counts(tp=0, fp=0, fn=0) == 0.0
+
+
+def test_pooled_counts_perfect_agreement_across_documents() -> None:
+    pairs = [
+        _pair("d1", [(0, 5, "cat")], [(0, 5, "cat")]),
+        _pair("d2", [(0, 5, "cat")], [(0, 5, "cat")]),
+    ]
+    counts = pooled_counts(pairs)
+    assert counts["cat"] == (2, 0, 0)
+    assert support(counts["cat"]) == 2
+
+
+def test_per_category_f1_disagreement() -> None:
+    pairs = [_pair("d1", [(0, 5, "cat")], [(10, 15, "cat")])]
+    f1s = per_category_f1(pairs)
+    assert f1s["cat"] == 0.0
+
+
+def test_macro_f1_excludes_low_support_categories() -> None:
+    pairs = [_pair("d1", [(0, 5, "rare")], [(0, 5, "rare")])]
+    assert macro_f1(pairs, min_support=5) is None
+
+
+def test_macro_f1_includes_categories_meeting_support() -> None:
+    pairs = [_pair(f"d{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(5)]
+    assert macro_f1(pairs, min_support=5) == 1.0
+
+
+def test_compute_iaa_report_perfect_agreement_passes_aggregate_gate() -> None:
+    pairs = [_pair(f"d{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(30)]
+    report = compute_iaa_report(pairs, seed=1, resamples=200)
+    assert report.macro_f1_point == 1.0
+    assert report.macro_f1_ci_low is not None
+    assert report.macro_f1_ci_low >= AGGREGATE_FLOOR
+    assert report.aggregate_passed is True
+    assert report.unreliable_eval_categories == ()
+
+
+def test_compute_iaa_report_total_disagreement_fails_gate() -> None:
+    pairs = [_pair(f"d{i}", [(0, 5, "cat")], [(10, 15, "cat")]) for i in range(30)]
+    report = compute_iaa_report(pairs, seed=1, resamples=200)
+    assert report.aggregate_passed is False
+    assert "cat" in report.unreliable_eval_categories
+
+
+def test_compute_iaa_report_low_support_category_not_gated_by_ci() -> None:
+    # Support of 5 (< MIN_CI_GATE_SUPPORT=15) -> point-estimate gate, not CI.
+    pairs = [_pair(f"d{i}", [(0, 5, "cat")], [(0, 5, "cat")]) for i in range(5)]
+    report = compute_iaa_report(pairs, seed=1, resamples=200)
+    result = report.per_category["cat"]
+    assert result.support == 5
+    assert result.gate_statistic == "point_estimate"
+    assert result.point_estimate >= PER_CATEGORY_FLOOR
+    assert result.passed_gate is True
+
+
+def test_compute_iaa_report_very_low_support_not_gated_at_all() -> None:
+    pairs = [_pair("d1", [(0, 5, "cat")], [(0, 5, "cat")])]
+    report = compute_iaa_report(pairs, seed=1, resamples=50)
+    result = report.per_category["cat"]
+    assert result.support == 1
+    assert result.gate_statistic == "not_gated_low_support"
+    assert result.included_in_aggregate is False

--- a/tests/segmenter_dataset/test_ids.py
+++ b/tests/segmenter_dataset/test_ids.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from segmenter_dataset.ids import annotation_id, document_id, review_id
+
+
+def test_document_id_deterministic() -> None:
+    kwargs = {"source_system": "tjro_juris", "source_uri": "u1", "source_hash": "h1"}
+    assert document_id(**kwargs) == document_id(**kwargs)
+
+
+def test_document_id_ignores_text_only_depends_on_source() -> None:
+    kwargs = {"source_system": "tjro_juris", "source_uri": "u1", "source_hash": "h1"}
+    a = document_id(**kwargs)
+    b = document_id(**kwargs)
+    assert a == b
+
+
+def test_document_id_differs_for_different_source() -> None:
+    a = document_id(source_system="tjro_juris", source_uri="u1", source_hash="h1")
+    b = document_id(source_system="tjro_juris", source_uri="u2", source_hash="h1")
+    assert a != b
+
+
+def test_annotation_id_differs_for_different_labels() -> None:
+    base = {
+        "document_id": "doc_1",
+        "annotator_id": "haiku",
+        "completed_at": "2026-01-01T00:00:00Z",
+    }
+    a = annotation_id(labels=[{"start": 0, "end": 5, "category": "x"}], **base)
+    b = annotation_id(labels=[{"start": 0, "end": 6, "category": "x"}], **base)
+    assert a != b
+
+
+def test_annotation_id_same_content_same_id() -> None:
+    base = {
+        "document_id": "doc_1",
+        "annotator_id": "haiku",
+        "completed_at": "2026-01-01T00:00:00Z",
+        "labels": [{"start": 0, "end": 5, "category": "x"}],
+    }
+    assert annotation_id(**base) == annotation_id(**base)
+
+
+def test_review_id_order_independent_on_input_annotation_ids() -> None:
+    a = review_id(document_id="doc_1", input_annotation_ids=["ann_a", "ann_b"], approved_at="t")
+    b = review_id(document_id="doc_1", input_annotation_ids=["ann_b", "ann_a"], approved_at="t")
+    assert a == b

--- a/tests/segmenter_dataset/test_mechanical.py
+++ b/tests/segmenter_dataset/test_mechanical.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from segmenter_dataset.mechanical import (
+    check_final_invariants,
+    validate_ontology_membership,
+    validate_pairs,
+    validate_record,
+    validate_single_anchor_duplicates,
+)
+from segmenter_dataset.schemas import Label
+
+
+CATEGORIES = {"cabecalho_inicio", "cabecalho_fim", "dispositivo_abertura", "resultado"}
+
+
+def test_check_final_invariants_flags_out_of_bounds() -> None:
+    text = "0123456789"
+    labels = [Label(start=5, end=20, category="x")]
+    problems = check_final_invariants(text, labels)
+    assert any("exceeds text length" in p for p in problems)
+
+
+def test_check_final_invariants_flags_overlap() -> None:
+    text = "0123456789"
+    labels = [
+        Label(start=0, end=5, category="a"),
+        Label(start=3, end=8, category="b"),
+    ]
+    problems = check_final_invariants(text, labels)
+    assert any("overlaps previous span" in p for p in problems)
+
+
+def test_check_final_invariants_clean_record() -> None:
+    text = "0123456789"
+    labels = [Label(start=0, end=5, category="a"), Label(start=5, end=10, category="b")]
+    assert check_final_invariants(text, labels) == []
+
+
+def test_validate_pairs_orphan_fim() -> None:
+    labels = [Label(start=0, end=5, category="cabecalho_fim")]
+    problems = validate_pairs(labels)
+    assert any("orphaned or excess _fim" in p for p in problems)
+
+
+def test_validate_pairs_inverted_pair() -> None:
+    labels = [
+        Label(start=10, end=15, category="cabecalho_inicio"),
+        Label(start=0, end=5, category="cabecalho_fim"),
+    ]
+    problems = validate_pairs(labels)
+    assert any("inverted pair" in p for p in problems)
+
+
+def test_validate_pairs_single_dangling_inicio_requires_declaration() -> None:
+    labels = [Label(start=0, end=5, category="cabecalho_inicio")]
+    problems = validate_pairs(labels, declared_unmatched=False)
+    assert any("no declared allowed-unmatched reason" in p for p in problems)
+
+    problems_declared = validate_pairs(labels, declared_unmatched=True)
+    assert problems_declared == []
+
+
+def test_validate_pairs_balanced_ok() -> None:
+    labels = [
+        Label(start=0, end=5, category="cabecalho_inicio"),
+        Label(start=5, end=10, category="cabecalho_fim"),
+    ]
+    assert validate_pairs(labels) == []
+
+
+def test_validate_ontology_membership() -> None:
+    labels = [Label(start=0, end=5, category="not_in_ontology")]
+    problems = validate_ontology_membership(labels, CATEGORIES)
+    assert any("not_in_ontology" in p for p in problems)
+
+
+def test_validate_single_anchor_duplicates_rejected_by_default() -> None:
+    labels = [
+        Label(start=0, end=5, category="dispositivo_abertura"),
+        Label(start=10, end=15, category="dispositivo_abertura"),
+    ]
+    problems = validate_single_anchor_duplicates(labels)
+    assert any("dispositivo_abertura" in p for p in problems)
+
+
+def test_validate_single_anchor_duplicates_allowed_when_permitted() -> None:
+    labels = [
+        Label(start=0, end=5, category="resultado"),
+        Label(start=10, end=15, category="resultado"),
+    ]
+    assert validate_single_anchor_duplicates(labels, allow_multiple=frozenset({"resultado"})) == []
+
+
+def test_validate_record_composes_all_checks() -> None:
+    text = "0" * 20
+    labels = [
+        Label(start=0, end=5, category="cabecalho_inicio"),
+        Label(start=5, end=10, category="cabecalho_fim"),
+    ]
+    assert validate_record(text, labels, CATEGORIES) == []

--- a/tests/segmenter_dataset/test_mechanical.py
+++ b/tests/segmenter_dataset/test_mechanical.py
@@ -60,6 +60,25 @@ def test_validate_pairs_single_dangling_inicio_requires_declaration() -> None:
     assert problems_declared == []
 
 
+def test_validate_pairs_interleaved_inversion_is_a_known_gap_not_caught() -> None:
+    """Locks in the module-docstring's documented #832-inherited weakness.
+
+    ``_inicio`` at [10, 20] and ``_fim`` at [15, 100]: the true nesting-order
+    pairing is 20->15 (inverted, invalid), but sorted-start ``zip`` pairs
+    10->15 and 20->100 instead, both of which look valid in isolation. This
+    test is not asserting desired behavior — it documents the current gap so
+    a future fix (pairing by nesting depth) has a regression test to flip
+    green, and so this limitation can't silently regress further un-noticed.
+    """
+    labels = [
+        Label(start=10, end=11, category="cabecalho_inicio"),
+        Label(start=20, end=21, category="cabecalho_inicio"),
+        Label(start=15, end=16, category="cabecalho_fim"),
+        Label(start=100, end=101, category="cabecalho_fim"),
+    ]
+    assert validate_pairs(labels) == []
+
+
 def test_validate_pairs_balanced_ok() -> None:
     labels = [
         Label(start=0, end=5, category="cabecalho_inicio"),

--- a/tests/segmenter_dataset/test_ontology.py
+++ b/tests/segmenter_dataset/test_ontology.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from segmenter_dataset.ontology import (
+    MigrationImpact,
+    MigrationKind,
+    OntologyVersion,
+    classify_migration,
+    load_categories,
+    parse_ontology_version,
+    requires_rfc_amendment,
+)
+
+
+def test_parse_ontology_version_round_trip() -> None:
+    version = parse_ontology_version("segmenter-ontology-v8.0.0")
+    assert version == OntologyVersion(8, 0, 0)
+    assert str(version) == "segmenter-ontology-v8.0.0"
+
+
+def test_parse_ontology_version_rejects_bad_string() -> None:
+    with pytest.raises(ValueError, match="not a valid ontology version"):
+        parse_ontology_version("v8")
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        (MigrationKind.ADD_CATEGORY, MigrationImpact.MINOR),
+        (MigrationKind.REMOVE_CATEGORY, MigrationImpact.MAJOR),
+        (MigrationKind.RENAME_CATEGORY, MigrationImpact.MINOR),
+        (MigrationKind.REDEFINE_CATEGORY, MigrationImpact.MAJOR),
+        (MigrationKind.GUIDELINE_ONLY, MigrationImpact.MINOR),
+    ],
+)
+def test_classify_migration(kind: MigrationKind, expected: MigrationImpact) -> None:
+    assert classify_migration(kind) == expected
+
+
+def test_bump_minor_keeps_major() -> None:
+    version = OntologyVersion(8, 0, 0)
+    assert version.bump(MigrationImpact.MINOR) == OntologyVersion(8, 1, 0)
+
+
+def test_bump_major_resets_minor_patch() -> None:
+    version = OntologyVersion(8, 3, 0)
+    assert version.bump(MigrationImpact.MAJOR) == OntologyVersion(9, 0, 0)
+
+
+def test_requires_rfc_amendment_only_for_major() -> None:
+    assert requires_rfc_amendment(MigrationImpact.MAJOR) is True
+    assert requires_rfc_amendment(MigrationImpact.MINOR) is False
+
+
+def test_load_categories_excludes_o(tmp_path: Path) -> None:
+    label_space = tmp_path / "label_space.json"
+    label_space.write_text(json.dumps({"span_class_names": ["O", "a", "b"]}), encoding="utf-8")
+    assert load_categories(label_space) == {"a", "b"}
+
+
+def test_load_categories_matches_real_label_space() -> None:
+    real_path = Path("data/segmenter_splits/label_space.json")
+    if not real_path.exists():
+        pytest.skip("data/segmenter_splits/label_space.json not present in this checkout")
+    categories = load_categories(real_path)
+    assert "ref_normativa" not in categories
+    assert "dispositivo_abertura" in categories

--- a/tests/segmenter_dataset/test_provenance.py
+++ b/tests/segmenter_dataset/test_provenance.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from segmenter_dataset.provenance import extract_normalized_process_number, normalize_cnj
+
+
+def test_normalize_cnj_strips_mask() -> None:
+    assert normalize_cnj("7007824-46.2021.8.22.0007") == "70078244620218220007"
+
+
+def test_normalize_cnj_rejects_wrong_length() -> None:
+    assert normalize_cnj("123-45") is None
+
+
+def test_extract_normalized_process_number_from_real_juris_header() -> None:
+    """Verbatim excerpt of a real TJRO sentença — confirms the regex matches production text.
+
+    Source: doc_020451850468f609103c41689fd50742 on the
+    segmenter-pr2-corpus-ingestion branch, not a hand-written fixture format.
+    """
+    text = (
+        "PODER JUDICIÁRIO DO ESTADO DE RONDÔNIA Tribunal de Justiça de Rondônia "
+        "Cacoal - 4ª Vara Cível Avenida Cuiabá, nº 2025, Bairro Centro, "
+        "CEP 76963-731, Cacoal, - cpecacoal@tjro.jus.br - Processo n.: "
+        "7007824-46.2021.8.22.0007 Classe: Procedimento Comum Cível Assunto: "
+        "Auxílio-Doença Previdenciário AUTOR: EDILZA LUZIA TONIATO PERIS..."
+    )
+    assert (
+        extract_normalized_process_number(source_uri="ia://item/x", text=text)
+        == "70078244620218220007"
+    )
+
+
+def test_extract_normalized_process_number_prefers_source_uri() -> None:
+    text = "corpo do documento sem numero de processo algum aqui"
+    uri = "ia://item/7000585-10.2020.8.22.0012"
+    assert extract_normalized_process_number(source_uri=uri, text=text) == "70005851020208220012"
+
+
+def test_extract_normalized_process_number_returns_none_when_absent() -> None:
+    assert (
+        extract_normalized_process_number(source_uri="ia://item/x", text="sem numero aqui") is None
+    )
+
+
+def test_extract_normalized_process_number_ignores_later_jurisprudence_citation() -> None:
+    """Guards a real false-positive found auditing the segmenter-pr2-corpus-ingestion branch.
+
+    Two unrelated real TJRO sentenças (doc_c2c6acba8c697497dfdb97cf7e3973ba and
+    doc_ccb2ce4c263ef670e30458a9715f21fa) both cite the SAME third-party
+    precedent case number deep in their body text ("Cito, ainda, trecho do
+    acórdão lançado no processo n. 7000355-02.2019.8.22.0012..."). Naive "any
+    CNJ-shaped number anywhere in the text" extraction would incorrectly union
+    these two unrelated documents via that shared citation. Taking only the
+    first match (the document's own header, which always precedes any
+    body-text citation in this corpus) avoids it.
+    """
+    header = (
+        "PODER JUDICIÁRIO DO ESTADO DE RONDÔNIA ... AUTOS : "
+        "7000585-10.2020.8.22.0012 Classe Procedimento Comum Cível ..."
+    )
+    citation = (
+        "Cito, ainda, trecho do acórdão lançado no processo n. "
+        "7000355-02.2019.8.22.0012, de relatoria de ARLEN JOSE SILVA DE SOUZA, "
+        "julgado em 23 de outubro de 2019."
+    )
+    text = f"{header} corpo da decisão. {citation}"
+    assert (
+        extract_normalized_process_number(source_uri="ia://item/x", text=text)
+        == "70005851020208220012"
+    )

--- a/tests/segmenter_dataset/test_release.py
+++ b/tests/segmenter_dataset/test_release.py
@@ -24,15 +24,34 @@ def _text_for(role: str, index: int) -> str:
     return f"0123{role}{index:03d}89ABCDEFGHIJ"
 
 
+# Both single-tribunal fixtures used by most tests below need this pair to
+# pass the release (RFC 0012 §14's multiple_tribunals/multiple_source_systems
+# advisory gates, wired for real — release.py's "advisory gate coverage"
+# note).
+SINGLE_TRIBUNAL_KNOWN_LIMITATIONS = [
+    KnownLimitation(gate="multiple_tribunals", reason="TJRO-only for v8.1"),
+    KnownLimitation(gate="multiple_source_systems", reason="tjro_juris-only for v8.1"),
+]
+
+
 def _seed_release(
-    store: SegmenterDatasetStore, *, n_train: int, n_val: int, n_test: int
+    store: SegmenterDatasetStore,
+    *,
+    n_train: int,
+    n_val: int,
+    n_test: int,
+    tribunals: tuple[str, ...] = ("TJRO",),
 ) -> SplitAssignment:
     train_ids: set[str] = set()
     val_ids: set[str] = set()
     test_ids: set[str] = set()
 
     for i in range(n_train):
-        doc = make_document(text=_text_for("train", i), source_uri=f"train-{i}")
+        doc = make_document(
+            text=_text_for("train", i),
+            source_uri=f"train-{i}",
+            tribunal=tribunals[i % len(tribunals)],
+        )
         store.write_document(doc)
         annotation = make_annotation(
             doc, labels=PAIR_LABELS, covered_categories=("cabecalho_inicio", "cabecalho_fim")
@@ -82,6 +101,7 @@ def test_build_dataset_release_succeeds_with_sufficient_support(tmp_path: Path) 
         dependency_lock_hash="lock123",
         ontology_categories=ONTOLOGY,
         split_assignment=assignment,
+        known_limitations=SINGLE_TRIBUNAL_KNOWN_LIMITATIONS,
         iaa_seed=1,
     )
 
@@ -101,8 +121,67 @@ def test_build_dataset_release_succeeds_with_sufficient_support(tmp_path: Path) 
             dependency_lock_hash="lock123",
             ontology_categories=ONTOLOGY,
             split_assignment=assignment,
+            known_limitations=SINGLE_TRIBUNAL_KNOWN_LIMITATIONS,
             iaa_seed=1,
         )
+
+
+def test_build_dataset_release_blocked_by_single_tribunal_without_known_limitation(
+    tmp_path: Path,
+) -> None:
+    """Locks in that multiple_tribunals/multiple_source_systems are genuinely evaluated now.
+
+    PR #838 review finding #3 — previously neither gate was ever computed,
+    so a single-tribunal, single-source fixture like this one would build a
+    release with no known_limitations at all.
+    """
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        build_dataset_release(
+            store,
+            release_id="segmenter-silver-v8.1",
+            ontology_version="segmenter-ontology-v8.0.0",
+            guideline_version="g1",
+            source_commit="abc123",
+            dependency_lock_hash="lock123",
+            ontology_categories=ONTOLOGY,
+            split_assignment=assignment,
+            iaa_seed=1,
+        )
+    gate_names = {g.name for g in exc_info.value.gate_results}
+    assert "multiple_tribunals" in gate_names
+    assert "multiple_source_systems" in gate_names
+
+
+def test_build_dataset_release_multiple_tribunals_gate_passes_without_waiver(
+    tmp_path: Path,
+) -> None:
+    """A genuinely multi-tribunal corpus should not need a multiple_tribunals waiver.
+
+    Only multiple_source_systems remains waived here (the fixture still uses
+    a single source system).
+    """
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5, tribunals=("TJRO", "TJSP"))
+
+    manifest = build_dataset_release(
+        store,
+        release_id="segmenter-silver-v8.1",
+        ontology_version="segmenter-ontology-v8.0.0",
+        guideline_version="g1",
+        source_commit="abc123",
+        dependency_lock_hash="lock123",
+        ontology_categories=ONTOLOGY,
+        split_assignment=assignment,
+        known_limitations=[
+            KnownLimitation(gate="multiple_source_systems", reason="tjro_juris-only for v8.1")
+        ],
+        iaa_seed=1,
+    )
+    assert manifest.tribunals.keys() == {"TJRO", "TJSP"}
+    assert manifest.known_limitations[0].gate == "multiple_source_systems"
 
 
 def test_build_dataset_release_blocked_by_insufficient_train_support(tmp_path: Path) -> None:
@@ -164,10 +243,11 @@ def test_build_dataset_release_advisory_gate_waived_by_known_limitation(tmp_path
     store = SegmenterDatasetStore(tmp_path)
     assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
 
-    # multiple_tribunals is never automatically evaluated as failing in this
-    # module (single-tribunal fixtures don't run that gate at all here) —
-    # this test instead verifies a rigid-gate detail: an unrelated known
-    # limitation does not mask a real rigid failure.
+    # multiple_tribunals and multiple_source_systems are both genuinely
+    # evaluated as failing for this single-tribunal, single-source fixture
+    # (PR #838 review finding #3) — both need a matching known_limitation or
+    # the release is blocked (see the sibling "blocked_by_single_tribunal"
+    # test above for the unwaived case).
     manifest = build_dataset_release(
         store,
         release_id="segmenter-silver-v8.2",
@@ -177,7 +257,8 @@ def test_build_dataset_release_advisory_gate_waived_by_known_limitation(tmp_path
         dependency_lock_hash="lock123",
         ontology_categories=ONTOLOGY,
         split_assignment=assignment,
-        known_limitations=[KnownLimitation(gate="multiple_tribunals", reason="TJRO-only for v8.1")],
+        known_limitations=SINGLE_TRIBUNAL_KNOWN_LIMITATIONS,
         iaa_seed=1,
     )
-    assert manifest.known_limitations[0].gate == "multiple_tribunals"
+    waived_gates = {kl.gate for kl in manifest.known_limitations}
+    assert waived_gates == {"multiple_tribunals", "multiple_source_systems"}

--- a/tests/segmenter_dataset/test_release.py
+++ b/tests/segmenter_dataset/test_release.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import make_annotation, make_document, make_review
+
+from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
+from segmenter_dataset.schemas import KnownLimitation, Label
+from segmenter_dataset.splits import SplitAssignment, SplitLeakError
+from segmenter_dataset.store import SegmenterDatasetStore
+
+
+ONTOLOGY = {"cabecalho_inicio", "cabecalho_fim"}
+PAIR_LABELS = [
+    Label(start=0, end=5, category="cabecalho_inicio"),
+    Label(start=10, end=15, category="cabecalho_fim"),
+]
+
+
+def _text_for(role: str, index: int) -> str:
+    # Unique per document — sharing text across documents would (correctly)
+    # trip the cross-split content-hash leakage gate.
+    return f"0123{role}{index:03d}89ABCDEFGHIJ"
+
+
+def _seed_release(
+    store: SegmenterDatasetStore, *, n_train: int, n_val: int, n_test: int
+) -> SplitAssignment:
+    train_ids: set[str] = set()
+    val_ids: set[str] = set()
+    test_ids: set[str] = set()
+
+    for i in range(n_train):
+        doc = make_document(text=_text_for("train", i), source_uri=f"train-{i}")
+        store.write_document(doc)
+        annotation = make_annotation(
+            doc, labels=PAIR_LABELS, covered_categories=("cabecalho_inicio", "cabecalho_fim")
+        )
+        store.write_annotation(annotation)
+        train_ids.add(doc.document_id)
+
+    for role, n, ids in (("val", n_val, val_ids), ("test", n_test, test_ids)):
+        for i in range(n):
+            doc = make_document(text=_text_for(role, i), source_uri=f"{role}-{i}")
+            store.write_document(doc)
+            ann_a = make_annotation(
+                doc,
+                annotator_id="a",
+                model_family="fam-a",
+                labels=PAIR_LABELS,
+                covered_categories=("cabecalho_inicio", "cabecalho_fim"),
+            )
+            ann_b = make_annotation(
+                doc,
+                annotator_id="b",
+                model_family="fam-b",
+                labels=PAIR_LABELS,
+                covered_categories=("cabecalho_inicio", "cabecalho_fim"),
+            )
+            store.write_annotation(ann_a)
+            store.write_annotation(ann_b)
+            review = make_review(doc, [ann_a, ann_b], final_labels=PAIR_LABELS)
+            store.write_review(review)
+            ids.add(doc.document_id)
+
+    return SplitAssignment(
+        train_ids=frozenset(train_ids), val_ids=frozenset(val_ids), test_ids=frozenset(test_ids)
+    )
+
+
+def test_build_dataset_release_succeeds_with_sufficient_support(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+
+    manifest = build_dataset_release(
+        store,
+        release_id="segmenter-silver-v8.1",
+        ontology_version="segmenter-ontology-v8.0.0",
+        guideline_version="g1",
+        source_commit="abc123",
+        dependency_lock_hash="lock123",
+        ontology_categories=ONTOLOGY,
+        split_assignment=assignment,
+        iaa_seed=1,
+    )
+
+    assert manifest.counts == {"train": 10, "validation": 5, "test": 5}
+    assert manifest.annotation_quality.val_iaa_span_f1 == 1.0
+    assert manifest.annotation_quality.test_iaa_span_f1 == 1.0
+    assert manifest.annotation_quality.unreliable_eval_categories == ()
+
+    # RFC 0012 §12 step 9: refuses to overwrite an existing release.
+    with pytest.raises(Exception, match="already exists"):
+        build_dataset_release(
+            store,
+            release_id="segmenter-silver-v8.1",
+            ontology_version="segmenter-ontology-v8.0.0",
+            guideline_version="g1",
+            source_commit="abc123",
+            dependency_lock_hash="lock123",
+            ontology_categories=ONTOLOGY,
+            split_assignment=assignment,
+            iaa_seed=1,
+        )
+
+
+def test_build_dataset_release_blocked_by_insufficient_train_support(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=2, n_val=5, n_test=5)
+
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        build_dataset_release(
+            store,
+            release_id="segmenter-silver-v8.1",
+            ontology_version="segmenter-ontology-v8.0.0",
+            guideline_version="g1",
+            source_commit="abc123",
+            dependency_lock_hash="lock123",
+            ontology_categories=ONTOLOGY,
+            split_assignment=assignment,
+            iaa_seed=1,
+        )
+    gate_names = {g.name for g in exc_info.value.gate_results}
+    assert "train_minimum_support_per_category" in gate_names
+
+
+def test_build_dataset_release_raises_when_val_document_not_adjudicated(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+
+    # Add one more document with only an annotation (no review) but assign
+    # it to val — a document that hasn't reached the role's required state.
+    unreviewed = make_document(text="0123456789ABCDEFGHIJ", source_uri="val-unreviewed")
+    store.write_document(unreviewed)
+    store.write_annotation(
+        make_annotation(
+            unreviewed,
+            labels=PAIR_LABELS,
+            covered_categories=("cabecalho_inicio", "cabecalho_fim"),
+        )
+    )
+    broken_assignment = SplitAssignment(
+        train_ids=assignment.train_ids,
+        val_ids=assignment.val_ids | {unreviewed.document_id},
+        test_ids=assignment.test_ids,
+    )
+
+    with pytest.raises(SplitLeakError, match="no accepted review record"):
+        build_dataset_release(
+            store,
+            release_id="segmenter-silver-v8.1",
+            ontology_version="segmenter-ontology-v8.0.0",
+            guideline_version="g1",
+            source_commit="abc123",
+            dependency_lock_hash="lock123",
+            ontology_categories=ONTOLOGY,
+            split_assignment=broken_assignment,
+            iaa_seed=1,
+        )
+
+
+def test_build_dataset_release_advisory_gate_waived_by_known_limitation(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+
+    # multiple_tribunals is never automatically evaluated as failing in this
+    # module (single-tribunal fixtures don't run that gate at all here) —
+    # this test instead verifies a rigid-gate detail: an unrelated known
+    # limitation does not mask a real rigid failure.
+    manifest = build_dataset_release(
+        store,
+        release_id="segmenter-silver-v8.2",
+        ontology_version="segmenter-ontology-v8.0.0",
+        guideline_version="g1",
+        source_commit="abc123",
+        dependency_lock_hash="lock123",
+        ontology_categories=ONTOLOGY,
+        split_assignment=assignment,
+        known_limitations=[KnownLimitation(gate="multiple_tribunals", reason="TJRO-only for v8.1")],
+        iaa_seed=1,
+    )
+    assert manifest.known_limitations[0].gate == "multiple_tribunals"

--- a/tests/segmenter_dataset/test_schemas.py
+++ b/tests/segmenter_dataset/test_schemas.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from conftest import make_annotation, make_document, make_review
+from pydantic import ValidationError
+
+from segmenter_dataset.schemas import Label
+
+
+def test_label_rejects_bad_offsets() -> None:
+    with pytest.raises(ValidationError):
+        Label(start=5, end=5, category="x")
+    with pytest.raises(ValidationError):
+        Label(start=6, end=5, category="x")
+
+
+def test_annotation_rejects_label_outside_covered_categories() -> None:
+    document = make_document()
+    with pytest.raises(ValidationError, match="covered_categories"):
+        make_annotation(
+            document,
+            labels=[Label(start=0, end=9, category="resultado")],
+            covered_categories=("cabecalho_inicio",),
+        )
+
+
+def test_review_requires_two_inputs_when_accepted() -> None:
+    document = make_document()
+    annotation = make_annotation(document)
+    with pytest.raises(ValidationError, match="at least two"):
+        make_review(document, [annotation], status="accepted")
+
+
+def test_review_accepts_two_inputs() -> None:
+    document = make_document()
+    a = make_annotation(document, annotator_id="a", model_family="fam-a")
+    b = make_annotation(document, annotator_id="b", model_family="fam-b")
+    review = make_review(document, [a, b])
+    assert review.status == "accepted"
+    assert len(review.input_annotation_ids) == 2

--- a/tests/segmenter_dataset/test_splits.py
+++ b/tests/segmenter_dataset/test_splits.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pytest
 from conftest import make_annotation, make_document, make_review
 
+from segmenter_dataset.dedup import near_duplicate_ratio
 from segmenter_dataset.splits import (
+    EmptyEvalSplitError,
     GroupingKeys,
     SplitAssignment,
     SplitLeakError,
@@ -77,6 +79,97 @@ def test_build_groups_clusters_by_process_number() -> None:
     assert len(groups) == 1
 
 
+def test_build_groups_from_document_unions_real_duplicate_pair_from_corpus() -> None:
+    """Real-corpus regression for PR #838 review finding #1.
+
+    First ~500 chars of two real TJRO sentenças from the
+    segmenter-pr2-corpus-ingestion branch (doc_802e3bcb7ef5134b8b98e18f4d71a9d9
+    and doc_9c45d216d09c12dbe0b743e0cff5f139), confirmed during corpus audit
+    to share the same process number (7000062-51.2022.8.22.0004) in their
+    own headers. Exercises the real path end to end:
+    ``GroupingKeys.from_document`` -> ``provenance.extract_normalized_process_number``
+    -> ``build_groups``, with no mocking of the extraction step. Note this
+    particular real pair is template-similar enough (near-dup ratio ~0.96)
+    that near-duplicate grouping alone would also catch it; the synthetic
+    test below isolates process-number grouping's marginal contribution
+    below the near-dup threshold.
+    """
+    text_a = (
+        "PODER JUDICIÁRIO DO ESTADO DE RONDÔNIA COMARCA DE OURO PRETO DO OESTE "
+        "2ª VARA CÍVEL Av. Daniel Comboni, 1480, 1º Andar. Fórum Des. Cássio "
+        "Rodolfo Sbarzi Guedes 76920-000. Ouro Preto do Oeste-RO. Tel.: (69) "
+        "3416-1721. E-mail: opo2civel@tjro.jus.br Sala de Atendimento Virtual: "
+        "https://meet.google.com/pwx-zsmd-eaf Processo 7000062-51.2022.8.22.0004 "
+        "Classe Procedimento Comum Cível Assunto Bem de Família (Voluntário) "
+        "Requerente RONALDO CANDIDO RIBEIRO VANUZA SILVA RIBEIRO Advogado(a) "
+        "FILIPH MENEZES"
+    )
+    text_b = (
+        "PODER JUDICIÁRIO DO ESTADO DE RONDÔNIA COMARCA DE OURO PRETO DO OESTE "
+        "2ª VARA CÍVEL Av. Daniel Comboni, 1480, 1º Andar. Fórum Des. Cássio "
+        "Rodolfo Sbarzi Guedes 76920-000. Ouro Preto do Oeste-RO. Tel.: (69) "
+        "3416-1721. E-mail: opo2civel@tjro.jus.br Sala de Atendimento Virtual: "
+        "https://meet.google.com/pwx-zsmd-eaf Processo 7000062-51.2022.8.22.0004 "
+        "Classe Procedimento Comum Cível Assunto Bem de Família (Voluntário) "
+        "Requerente OUTRA PARTE DIFERENTE Advogado(a) OUTRO ADVOGADO"
+    )
+    doc_a = make_document(text=text_a, source_uri="real-corpus-802e3bcb")
+    doc_b = make_document(text=text_b, source_uri="real-corpus-9c45d216")
+
+    keys = [GroupingKeys.from_document(doc) for doc in (doc_a, doc_b)]
+    groups = build_groups([doc_a, doc_b], keys)
+
+    assert len(groups) == 1
+    (members,) = groups.values()
+    assert members == {doc_a.document_id, doc_b.document_id}
+
+
+def test_build_groups_from_document_unions_same_processo_below_near_dup_threshold() -> None:
+    """Isolates finding #1's marginal contribution over near-dup grouping alone.
+
+    The shared header line is the real, regex-validated format (RFC 0012
+    §10's own process-number key); the bodies are deliberately unrelated
+    synthetic content (a merits sentença vs. a motion ruling) to keep
+    near-dup similarity below the 0.9 default threshold — this is the exact
+    leakage scenario the PR #838 review flagged: "two documents that are
+    genuinely the same underlying processo but differ more than 0.9 in text
+    similarity."
+    """
+    header = (
+        "PODER JUDICIÁRIO DO ESTADO DE RONDÔNIA Tribunal de Justiça de Rondônia "
+        "Cacoal - 4ª Vara Cível Processo n.: 7007824-46.2021.8.22.0007 Classe: "
+        "Procedimento Comum Cível Assunto: Auxílio-Doença Previdenciário "
+    )
+    body_a = (
+        "SENTENÇA Vistos etc. O autor pleiteia a concessão de auxílio doença "
+        "junto ao INSS alegando incapacidade laboral decorrente de lesão na "
+        "coluna vertebral comprovada por laudo pericial judicial produzido "
+        "nos autos após regular instrução processual e contraditório."
+    )
+    body_b = (
+        "DECISÃO Trata-se de embargos de declaração opostos pela parte ré "
+        "contra a sentença proferida, alegando omissão quanto ao termo "
+        "inicial do benefício concedido. Recebo os embargos e passo à "
+        "análise do mérito recursal à luz do art. 1022 do CPC vigente."
+    )
+    text_a = header + body_a
+    text_b = header + body_b
+    assert near_duplicate_ratio(text_a, text_b) < 0.9
+
+    doc_a = make_document(text=text_a, source_uri="synthetic-same-processo-a")
+    doc_b = make_document(text=text_b, source_uri="synthetic-same-processo-b")
+
+    # Content-hash/near-dup unions must not fire here (that's the point of
+    # this test); only the process-number key should.
+    content_only_keys = [GroupingKeys(document_id=doc.document_id) for doc in (doc_a, doc_b)]
+    content_only_groups = build_groups([doc_a, doc_b], content_only_keys)
+    assert len(content_only_groups) == 2
+
+    real_keys = [GroupingKeys.from_document(doc) for doc in (doc_a, doc_b)]
+    real_groups = build_groups([doc_a, doc_b], real_keys)
+    assert len(real_groups) == 1
+
+
 def test_assign_splits_respects_eligibility() -> None:
     docs = [
         make_document(text=f"documento numero {i} com texto variado", source_uri=f"u{i}")
@@ -96,6 +189,74 @@ def test_assign_splits_respects_eligibility() -> None:
     # Train-only documents must never land in val/test.
     assert train_only_ids.isdisjoint(assignment.val_ids)
     assert train_only_ids.isdisjoint(assignment.test_ids)
+
+
+def test_assign_splits_raises_when_eval_eligible_groups_starve_val_or_test() -> None:
+    """Regression for PR #838 review finding #2.
+
+    Reproduces the exact scenario the review described: every eval-eligible
+    group has >= 2 members (as real process-number/near-dup grouping
+    produces once finding #1 is wired) and the computed target is 1 — no
+    group fits "under target", so the old ``assign_splits`` silently packed
+    every one of them into train, leaving val AND test both empty with no
+    error raised anywhere (``SplitAssignment``'s disjointness check has
+    nothing to catch, since nothing overlaps). This asserts the new code
+    raises instead of returning that silently-empty assignment.
+    """
+    # Deliberately dissimilar bodies within and across families (near-dup
+    # ratio well under 0.9) so only the shared document_family key drives
+    # grouping — isolates "the group is >= 2 members" from "the group is
+    # >= 2 members because of unrelated near-dup contamination".
+    bodies = [
+        "sentença de mérito julgando procedente o pedido inicial do autor",
+        "embargos de declaração opostos pela parte ré quanto ao termo inicial",
+        "decisão interlocutória deferindo a tutela de urgência requerida",
+        "acórdão que reforma parcialmente a sentença de primeiro grau",
+    ]
+    docs = [make_document(text=bodies[i], source_uri=f"g{i}") for i in range(4)]
+    # Two groups of 2 via a shared grouping key — mirrors what real
+    # process-number/near-dup grouping would produce.
+    keys = [
+        GroupingKeys(document_id=docs[0].document_id, document_family="fam-a"),
+        GroupingKeys(document_id=docs[1].document_id, document_family="fam-a"),
+        GroupingKeys(document_id=docs[2].document_id, document_family="fam-b"),
+        GroupingKeys(document_id=docs[3].document_id, document_family="fam-b"),
+    ]
+    groups = build_groups(docs, keys)
+    assert len(groups) == 2
+    assert all(len(members) == 2 for members in groups.values())
+
+    eval_ids = frozenset(doc.document_id for doc in docs)
+
+    with pytest.raises(EmptyEvalSplitError):
+        assign_splits(
+            groups,
+            train_eligible=eval_ids,
+            evaluation_eligible=eval_ids,
+            train_ratio=0.70,
+            val_ratio=0.15,  # total_eligible=4 -> val_target=test_target=1
+            seed=1,
+        )
+
+
+def test_assign_splits_allows_empty_eval_when_nothing_is_eval_eligible() -> None:
+    """An empty val/test must not raise when there is no eval-eligible data at all.
+
+    E.g. a train-only corpus, early in the annotation pipeline.
+    ``EmptyEvalSplitError`` only fires when eval-eligible groups existed but
+    got starved out by target sizing.
+    """
+    docs = [
+        make_document(text=f"apenas treino {i} texto variado", source_uri=f"t{i}") for i in range(3)
+    ]
+    groups = {doc.document_id: frozenset({doc.document_id}) for doc in docs}
+    train_ids = frozenset(doc.document_id for doc in docs)
+
+    assignment = assign_splits(
+        groups, train_eligible=train_ids, evaluation_eligible=frozenset(), seed=1
+    )
+    assert assignment.val_ids == frozenset()
+    assert assignment.test_ids == frozenset()
 
 
 def test_assign_splits_is_deterministic() -> None:

--- a/tests/segmenter_dataset/test_splits.py
+++ b/tests/segmenter_dataset/test_splits.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+from conftest import make_annotation, make_document, make_review
+
+from segmenter_dataset.splits import (
+    GroupingKeys,
+    SplitAssignment,
+    SplitLeakError,
+    assign_splits,
+    build_groups,
+    check_disjoint,
+    evaluation_eligible_document_ids,
+    train_eligible_document_ids,
+    validate_split_leakage,
+)
+
+
+def test_check_disjoint_no_overlap() -> None:
+    assert check_disjoint(frozenset({"a"}), frozenset({"b"}), frozenset({"c"})) == []
+
+
+def test_check_disjoint_reports_overlap() -> None:
+    violations = check_disjoint(frozenset({"a", "b"}), frozenset({"b"}), frozenset())
+    assert any("train/val overlap" in v for v in violations)
+
+
+def test_split_assignment_raises_on_overlap() -> None:
+    with pytest.raises(SplitLeakError):
+        SplitAssignment(frozenset({"a"}), frozenset({"a"}), frozenset())
+
+
+def test_split_of() -> None:
+    assignment = SplitAssignment(frozenset({"a"}), frozenset({"b"}), frozenset({"c"}))
+    assert assignment.split_of("a") == "train"
+    assert assignment.split_of("b") == "val"
+    assert assignment.split_of("c") == "test"
+    assert assignment.split_of("z") is None
+
+
+def test_train_eligible_document_ids_needs_only_annotation() -> None:
+    document = make_document()
+    annotation = make_annotation(document)
+    assert document.document_id in train_eligible_document_ids([annotation])
+
+
+def test_evaluation_eligible_document_ids_needs_accepted_review() -> None:
+    document = make_document()
+    a = make_annotation(document, annotator_id="a", model_family="fam-a")
+    b = make_annotation(document, annotator_id="b", model_family="fam-b")
+    review = make_review(document, [a, b], status="accepted")
+    assert document.document_id in evaluation_eligible_document_ids([review])
+
+
+def test_build_groups_clusters_exact_duplicates() -> None:
+    doc_a = make_document(text="texto identico aqui", source_uri="u1")
+    doc_b = make_document(text="texto identico aqui", source_uri="u2")
+    doc_c = make_document(text="texto completamente diferente", source_uri="u3")
+    keys = [GroupingKeys(document_id=d.document_id) for d in (doc_a, doc_b, doc_c)]
+    groups = build_groups([doc_a, doc_b, doc_c], keys)
+    members_by_group = list(groups.values())
+    grouped_pair = {doc_a.document_id, doc_b.document_id}
+    assert any(grouped_pair <= members for members in members_by_group)
+    assert not any(
+        {doc_a.document_id, doc_c.document_id} <= members for members in members_by_group
+    )
+
+
+def test_build_groups_clusters_by_process_number() -> None:
+    doc_a = make_document(text="texto A", source_uri="u1")
+    doc_b = make_document(text="texto B totalmente distinto", source_uri="u2")
+    keys = [
+        GroupingKeys(document_id=doc_a.document_id, normalized_process_number="0001234"),
+        GroupingKeys(document_id=doc_b.document_id, normalized_process_number="0001234"),
+    ]
+    groups = build_groups([doc_a, doc_b], keys)
+    assert len(groups) == 1
+
+
+def test_assign_splits_respects_eligibility() -> None:
+    docs = [
+        make_document(text=f"documento numero {i} com texto variado", source_uri=f"u{i}")
+        for i in range(10)
+    ]
+    train_only_ids = frozenset(d.document_id for d in docs[:5])
+    eval_ids = frozenset(d.document_id for d in docs[5:])
+    groups = {d.document_id: frozenset({d.document_id}) for d in docs}
+
+    assignment = assign_splits(
+        groups,
+        train_eligible=train_only_ids | eval_ids,
+        evaluation_eligible=eval_ids,
+        seed=42,
+    )
+
+    # Train-only documents must never land in val/test.
+    assert train_only_ids.isdisjoint(assignment.val_ids)
+    assert train_only_ids.isdisjoint(assignment.test_ids)
+
+
+def test_assign_splits_is_deterministic() -> None:
+    docs = [make_document(text=f"doc {i} texto", source_uri=f"u{i}") for i in range(20)]
+    all_ids = frozenset(d.document_id for d in docs)
+    groups = {d.document_id: frozenset({d.document_id}) for d in docs}
+
+    first = assign_splits(groups, train_eligible=all_ids, evaluation_eligible=all_ids, seed=7)
+    second = assign_splits(groups, train_eligible=all_ids, evaluation_eligible=all_ids, seed=7)
+    assert first == second
+
+
+def test_validate_split_leakage_detects_group_spanning_splits() -> None:
+    doc_a = make_document(text="grupo compartilhado", source_uri="u1")
+    doc_b = make_document(text="grupo compartilhado", source_uri="u2")
+    groups = {doc_a.document_id: frozenset({doc_a.document_id, doc_b.document_id})}
+    assignment = SplitAssignment(
+        train_ids=frozenset({doc_a.document_id}),
+        val_ids=frozenset({doc_b.document_id}),
+        test_ids=frozenset(),
+    )
+    problems = validate_split_leakage(assignment, [doc_a, doc_b], groups)
+    assert any("spans multiple splits" in p for p in problems)

--- a/tests/segmenter_dataset/test_store.py
+++ b/tests/segmenter_dataset/test_store.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import make_annotation, make_document
+
+from segmenter_dataset.store import ImmutabilityError, SegmenterDatasetStore
+
+
+def test_write_and_read_document_round_trips(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    document = make_document()
+    store.write_document(document)
+    reloaded = store.read_document(document.document_id)
+    assert reloaded == document
+
+
+def test_write_document_twice_same_content_is_noop(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    document = make_document()
+    store.write_document(document)
+    store.write_document(document)  # should not raise
+    assert len(store.list_documents()) == 1
+
+
+def test_write_document_same_id_different_content_raises(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    document = make_document()
+    store.write_document(document)
+
+    # Force a collision: same document_id, different text, bypassing the
+    # normal content-addressing path to simulate a hash-collision bug.
+    forged = document.model_copy(update={"text": "different text entirely"})
+    with pytest.raises(ImmutabilityError):
+        store.write_document(forged)
+
+
+def test_list_annotations_filters_by_document(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    doc_a = make_document(source_uri="u1")
+    doc_b = make_document(source_uri="u2")
+    store.write_document(doc_a)
+    store.write_document(doc_b)
+    store.write_annotation(make_annotation(doc_a))
+    store.write_annotation(make_annotation(doc_b))
+
+    assert len(store.list_annotations()) == 2
+    assert len(store.list_annotations(document_id=doc_a.document_id)) == 1
+
+
+def test_write_release_manifest_refuses_overwrite(tmp_path: Path) -> None:
+    from segmenter_dataset.schemas import AnnotationQuality, ReleaseManifest
+
+    store = SegmenterDatasetStore(tmp_path)
+    manifest = ReleaseManifest(
+        release_id="segmenter-silver-v8.1",
+        ontology_version="segmenter-ontology-v8.0.0",
+        guideline_version="g1",
+        source_commit="abc123",
+        dependency_lock_hash="lock123",
+        split_hashes={"train": "t", "validation": "v", "test": "s"},
+        document_resolutions={"train": {}, "validation": {}, "test": {}},
+        annotation_quality=AnnotationQuality(),
+        created_at="2026-01-01T00:00:00Z",
+    )
+    store.write_release_manifest(manifest)
+    with pytest.raises(ImmutabilityError):
+        store.write_release_manifest(manifest)


### PR DESCRIPTION
## Description

Implements **PR 1** of RFC 0012's implementation plan (§15): the artifact contract, leakage-safe grouped splitter, and immutable `build_dataset_release` builder. Based on the RFC branch (#836) since this PR depends on it — please merge #836 first, or review this diff on top of it.

New package `src/segmenter_dataset/`:

| Module | What it implements | Source |
|---|---|---|
| `schemas.py` | Pydantic records matching RFC 0012 §8 exactly: `DocumentRecord`, `AnnotationRecord` (with `covered_categories` — §5.1's false-negative guard), `ReviewRecord` (`input_annotation_ids` referencing specific annotations, not just `document_id`), `ReleaseManifest` (`document_resolutions` pinning exact lineage per split) | New |
| `ids.py` | Deterministic, content-addressed IDs (`document_id`/`annotation_id`/`review_id`) | New |
| `ontology.py` | `segmenter-ontology-v8.0.0` (v7 frozen); semver migration classification (add/remove/rename/redefine/guideline-only) per §5.1 | New |
| `mechanical.py` | Full §11 validation (offset bounds, overlap, pair balance, ontology membership, single-anchor duplicates) | Adapted from PR #832's `transform.check_final_invariants` + `validators.py` |
| `dedup.py` | Exact/near-duplicate detection | Reused near-verbatim from PR #832 |
| `splits.py` | Role eligibility (train=annotated, val/test=adjudicated — fixes the contradiction both PR #832 and RFC round 1 had), document grouping (union-find over content hash/near-dup/process-number/family/parent), deterministic assignment, leakage rejection | Disjointness primitives adapted from PR #832's `split_guard.py` |
| `iaa.py` | The exact statistical spec RFC 0012 §8 fixed across three review rounds: pooled exact-span-match F1, macro-average with a support floor, document-level bootstrap CI, the normative v8.1 floor (0.75 agg / 0.5 per-category) gated on CI lower bound at support ≥15 and point estimate at support 5–14 | New — no PR #832 equivalent |
| `gates.py` | The closed rigid/advisory gate classification from §12.1 — no gate outside either list can exist, and a known limitation can never reference a rigid gate | New |
| `store.py` | Content-addressed immutable storage for `documents/`, `annotations/`, `reviews/`, `dataset-releases/<release-id>/` | New |
| `release.py` | The full 9-step `build_dataset_release` procedure (§12) | New |
| `__main__.py` | `segmenter-dataset assign-splits` / `build-release` Typer CLI | New |

`build_gold_release` is the RFC's provisional name for the release command (§9.1/§12) — this PR names it `build_dataset_release` since the human-reference gate that would earn the `gold` name doesn't exist yet.

**Test plan**
- [x] 79 new tests (`uv run pytest tests/segmenter_dataset/`)
- [x] `uv run ruff check` / `uv run ruff format --check` clean, repo-wide
- [x] Full existing test suite unaffected (`uv run pytest tests/ --ignore=tests/segmenter_dataset`)
- [x] CLI smoke-tested (`python -m segmenter_dataset --help`)

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. *(N/A — new CLI, `segmenter-dataset` registered in `pyproject.toml`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPCj1EM3pvwqZS4CQyjvSH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPCj1EM3pvwqZS4CQyjvSH)_