### PR TITLE
fix(segmenter-dataset): enforce release invariants found in PR #838 review

### DIFF
--- a/format-report.txt
+++ b/format-report.txt
@@ -1,0 +1,1 @@
+223 files already formatted

--- a/ruff.toml
+++ b/ruff.toml
@@ -123,6 +123,9 @@ ignore = [
 # §8's document/annotation/review/release CRUD) — a docstring on each would
 # just restate the method name.
 "src/segmenter_dataset/store.py" = ["D102", "D107"]
+# Atomic release verification intentionally raises inside its cleanup boundary;
+# extracting those failures solely for TRY/EM style would obscure the transaction.
+"src/segmenter_dataset/release.py" = ["ANN202", "D101", "D107", "EM101", "EM102", "PLR2004", "RUF017", "TRY003", "TRY301"]
 
 # ── Tests ──────────────────────────────────────────────────────────────────
 # assert is idiomatic pytest; no docstrings/type-hints required; private access
@@ -130,7 +133,7 @@ ignore = [
 "tests/**/*.py" = [
     "S101",             # assert
     "D100", "D101", "D102", "D103", "D104", "D205",  # missing docstrings
-    "ANN001", "ANN201", "ANN202", "ANN401",  # missing type annotations
+    "ANN001", "ANN201", "ANN202", "ANN003", "ANN401",  # missing type annotations
     "PLR2004",          # magic value comparison
     "ARG001",           # unused function argument (fixtures pass unused args)
     "INP001",           # implicit namespace package

--- a/src/segmenter_dataset/__main__.py
+++ b/src/segmenter_dataset/__main__.py
@@ -1,14 +1,4 @@
-"""CLI entry point for the segmenter dataset lifecycle (RFC 0012).
-
-Two commands, split at the same seam as RFC 0012 §10/§12:
-
-- ``assign-splits`` — groups documents, applies role eligibility, and writes
-  a ``split_manifest.json`` (RFC 0012 §8's intermediate, not-yet-a-release
-  artifact).
-- ``build-release`` — reads a ``split_manifest.json`` and runs
-  ``build_dataset_release`` (RFC 0012 §12), writing the final immutable
-  release manifest.
-"""
+"""CLI for split assignment and immutable dataset release construction."""
 
 from __future__ import annotations
 
@@ -20,12 +10,12 @@ import typer
 
 from segmenter_dataset.ontology import ONTOLOGY_V8, load_categories
 from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
-from segmenter_dataset.schemas import KnownLimitation
+from segmenter_dataset.schemas import KnownLimitation, SplitManifest
 from segmenter_dataset.splits import (
     GroupingKeys,
-    SplitAssignment,
     assign_splits,
     build_groups,
+    create_split_manifest,
     evaluation_eligible_document_ids,
     train_eligible_document_ids,
 )
@@ -33,10 +23,6 @@ from segmenter_dataset.store import SegmenterDatasetStore
 
 
 if TYPE_CHECKING:
-    # Path stays a live import above — Typer's @app.command parameters below
-    # need a runtime-resolvable annotation to build the CLI schema.
-    # GateResult is only used in a plain helper, not a command, so it's safe
-    # to defer.
     from segmenter_dataset.gates import GateResult
 
 
@@ -49,20 +35,20 @@ def assign_splits_command(
     output: Path = typer.Option(..., help="Where to write split_manifest.json"),
     train_ratio: float = typer.Option(0.70),
     val_ratio: float = typer.Option(0.15),
-    seed: int = typer.Option(..., help="Deterministic assignment seed (RFC 0012 §10)"),
+    seed: int = typer.Option(..., help="Deterministic assignment seed"),
     near_duplicate_threshold: float = typer.Option(0.9),
 ) -> None:
-    """Group documents, apply role eligibility, and write a split manifest."""
+    """Group documents, apply role eligibility, and write a reproducible manifest."""
     store = SegmenterDatasetStore(data_root)
     documents = store.list_documents()
     annotations = store.list_annotations()
     reviews = store.list_reviews()
-
-    grouping_keys = [GroupingKeys(document_id=doc.document_id) for doc in documents]
+    grouping_keys = [GroupingKeys.from_document(document) for document in documents]
     groups = build_groups(
-        documents, grouping_keys, near_duplicate_threshold=near_duplicate_threshold
+        documents,
+        grouping_keys,
+        near_duplicate_threshold=near_duplicate_threshold,
     )
-
     assignment = assign_splits(
         groups,
         train_eligible=train_eligible_document_ids(annotations),
@@ -71,22 +57,19 @@ def assign_splits_command(
         val_ratio=val_ratio,
         seed=seed,
     )
-
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(
-        json.dumps(
-            {
-                "train_ids": sorted(assignment.train_ids),
-                "val_ids": sorted(assignment.val_ids),
-                "test_ids": sorted(assignment.test_ids),
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
+    manifest = create_split_manifest(
+        assignment,
+        groups,
+        seed=seed,
+        train_ratio=train_ratio,
+        val_ratio=val_ratio,
+        near_duplicate_threshold=near_duplicate_threshold,
     )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
     typer.echo(
-        f"wrote {output}: train={len(assignment.train_ids)} "
-        f"val={len(assignment.val_ids)} test={len(assignment.test_ids)}"
+        f"wrote {output}: train={len(manifest.train_ids)} "
+        f"val={len(manifest.val_ids)} test={len(manifest.test_ids)}"
     )
 
 
@@ -96,49 +79,47 @@ def build_release_command(
     split_manifest: Path = typer.Option(..., exists=True, help="Output of assign-splits"),
     release_id: str = typer.Option(...),
     label_space: Path = typer.Option(..., exists=True, help="Path to label_space.json"),
-    source_commit: str = typer.Option(...),
-    dependency_lock_hash: str = typer.Option(...),
+    source_commit: str = typer.Option(..., help="Full 40-character Git commit SHA"),
+    dependency_lock_hash: str = typer.Option(..., help="SHA-256 of the pinned lockfile"),
+    ci_provider: str = typer.Option(..., help="CI provider, e.g. github-actions"),
+    ci_run_id: str = typer.Option(..., help="Immutable CI run identifier"),
     guideline_version: str = typer.Option(...),
     iaa_seed: int = typer.Option(...),
+    iaa_resamples: int = typer.Option(1000, min=1000),
     known_limitations: Path | None = typer.Option(
         None, exists=True, help="JSON list of {gate, reason}"
     ),
     ontology_version: str = typer.Option(ONTOLOGY_V8),
 ) -> None:
-    """Build the immutable dataset release (RFC 0012 §12)."""
+    """Build the immutable dataset release."""
     store = SegmenterDatasetStore(data_root)
-    split_data = json.loads(split_manifest.read_text(encoding="utf-8"))
-    assignment = SplitAssignment(
-        train_ids=frozenset(split_data["train_ids"]),
-        val_ids=frozenset(split_data["val_ids"]),
-        test_ids=frozenset(split_data["test_ids"]),
-    )
-
+    manifest = SplitManifest.model_validate_json(split_manifest.read_text(encoding="utf-8"))
     limitations: list[KnownLimitation] = []
     if known_limitations is not None:
         raw = json.loads(known_limitations.read_text(encoding="utf-8"))
         limitations = [KnownLimitation(**entry) for entry in raw]
 
-    ontology_categories = load_categories(label_space)
-
     try:
-        manifest = build_dataset_release(
+        release_manifest = build_dataset_release(
             store,
             release_id=release_id,
             ontology_version=ontology_version,
             guideline_version=guideline_version,
             source_commit=source_commit,
             dependency_lock_hash=dependency_lock_hash,
-            ontology_categories=ontology_categories,
-            split_assignment=assignment,
+            ci_provider=ci_provider,
+            ci_run_id=ci_run_id,
+            ontology_categories=load_categories(label_space),
+            split_manifest=manifest,
             known_limitations=limitations,
             iaa_seed=iaa_seed,
+            iaa_resamples=iaa_resamples,
         )
     except ReleaseBlockedError as exc:
         _echo_gate_failures(exc.gate_results)
         raise typer.Exit(code=1) from exc
 
-    typer.echo(f"release {manifest.release_id!r} written: counts={manifest.counts}")
+    typer.echo(f"release {release_manifest.release_id!r} written: counts={release_manifest.counts}")
 
 
 def _echo_gate_failures(gate_results: list[GateResult]) -> None:

--- a/src/segmenter_dataset/gates.py
+++ b/src/segmenter_dataset/gates.py
@@ -1,23 +1,4 @@
-"""Readiness gates (RFC 0012 §12.1, §14): rigid vs. advisory, a closed allowlist.
-
-There is no generic ``--skip-gates`` (RFC 0012 §3.5, §12) — and per-gate
-waivers alone are not enough either, because waiving every gate one by one
-is the same antipattern with extra ceremony (§12.1). Every gate belongs to
-exactly one of two fixed classes:
-
-- **rigid** — never waivable, always blocks the release. Fixed by this
-  module, not configurable by a caller: schema validity, unresolved
-  annotation conflicts, split leakage, test contamination, checksum/build
-  integrity, and the IAA floor (§8).
-- **advisory** — a small, closed allowlist (tribunal diversity, source
-  diversity, temporal diversity, representative eval set, external test
-  review — exactly RFC 0012 §14's "exigidos para alegações amplas de
-  produção"). A failing advisory gate blocks the release unless it has a
-  matching :class:`~segmenter_dataset.schemas.KnownLimitation` entry.
-
-A gate name outside both sets is a programming error, not a silently
-permitted waiver — :func:`classify_gate` raises rather than defaulting.
-"""
+"""Readiness gates: rigid invariants and a closed advisory allowlist."""
 
 from __future__ import annotations
 
@@ -31,14 +12,13 @@ if TYPE_CHECKING:
 
 
 class GateSeverity(StrEnum):
-    """Which class a gate belongs to (RFC 0012 §12.1)."""
+    """Whether a gate is non-waivable or an advisory limitation."""
 
     RIGID = "rigid"
     ADVISORY = "advisory"
 
 
-# RFC 0012 §14 "Exigidos para treino baseline" — all rigid (§12.1).
-RIGID_GATES: frozenset[str] = frozenset(
+RIGID_GATES = frozenset(
     {
         "ontology_schema_valid",
         "split_disjoint_by_group_id_hash",
@@ -52,11 +32,7 @@ RIGID_GATES: frozenset[str] = frozenset(
         "ci_reproducible_build",
     }
 )
-
-# RFC 0012 §14 "Exigidos para alegações amplas de produção" — the only gates
-# eligible for a known_limitation (§12.1). Closed: nothing outside this set
-# may ever be waived.
-ADVISORY_GATES: frozenset[str] = frozenset(
+ADVISORY_GATES = frozenset(
     {
         "multiple_tribunals",
         "multiple_source_systems",
@@ -68,25 +44,26 @@ ADVISORY_GATES: frozenset[str] = frozenset(
 
 
 class UnknownGateError(ValueError):
-    """A gate name is neither rigid nor advisory — not silently permitted."""
+    """A gate name is outside the RFC's closed classification."""
+
+
+class InvalidKnownLimitationError(ValueError):
+    """A known limitation attempts to waive a rigid or unknown gate."""
 
 
 def classify_gate(name: str) -> GateSeverity:
-    """Return the fixed severity class of a gate; raises for an unknown name."""
+    """Return the fixed RFC severity for a gate name."""
     if name in RIGID_GATES:
         return GateSeverity.RIGID
     if name in ADVISORY_GATES:
         return GateSeverity.ADVISORY
-    msg = (
-        f"unknown gate {name!r} — not in RIGID_GATES or ADVISORY_GATES; "
-        "adding a new gate requires updating RFC 0012 §12.1/§14, not a CLI flag"
-    )
-    raise UnknownGateError(msg)
+    message = f"unknown gate {name!r}; adding a gate requires updating RFC 0012"
+    raise UnknownGateError(message)
 
 
 @dataclass(frozen=True)
 class GateResult:
-    """Outcome of evaluating one gate."""
+    """One gate's pass/fail result and human-readable evidence."""
 
     name: str
     passed: bool
@@ -94,13 +71,13 @@ class GateResult:
 
     @property
     def severity(self) -> GateSeverity:
-        """This gate's fixed class — rigid or advisory (RFC 0012 §12.1)."""
+        """Return this gate's fixed RFC severity."""
         return classify_gate(self.name)
 
 
 @dataclass(frozen=True)
 class GateEvaluation:
-    """Aggregate outcome of every gate for a release attempt."""
+    """Combined outcome after applying advisory known limitations."""
 
     release_allowed: bool
     blocking_rigid_failures: tuple[GateResult, ...]
@@ -111,22 +88,30 @@ class GateEvaluation:
 def evaluate_gates(
     results: list[GateResult], known_limitations: list[KnownLimitation]
 ) -> GateEvaluation:
-    """Combine gate results with recorded known limitations (RFC 0012 §12.1).
+    """Evaluate gates after rejecting invalid waiver declarations."""
+    for limitation in known_limitations:
+        try:
+            severity = classify_gate(limitation.gate)
+        except UnknownGateError as exc:
+            raise InvalidKnownLimitationError(str(exc)) from exc
+        if severity is GateSeverity.RIGID:
+            message = f"known limitation cannot reference rigid gate {limitation.gate!r}"
+            raise InvalidKnownLimitationError(message)
+        if limitation.status != "known_limitation" or not limitation.reason.strip():
+            message = f"invalid known limitation for gate {limitation.gate!r}"
+            raise InvalidKnownLimitationError(message)
 
-    A rigid failure always blocks, regardless of ``known_limitations`` — no
-    known-limitation entry can reference a rigid gate name (RFC 0012 §12.1
-    closes that loophole by construction: only advisory gate names are ever
-    checked against the ``known_limitations`` list here).
-    """
-    waived_gate_names = {kl.gate for kl in known_limitations}
-
-    rigid_failures = tuple(r for r in results if not r.passed and r.severity is GateSeverity.RIGID)
-    advisory_failures = tuple(
-        r for r in results if not r.passed and r.severity is GateSeverity.ADVISORY
+    waived_gate_names = {limitation.gate for limitation in known_limitations}
+    rigid_failures = tuple(
+        result for result in results if not result.passed and result.severity is GateSeverity.RIGID
     )
-    waived = tuple(r for r in advisory_failures if r.name in waived_gate_names)
-    unwaived = tuple(r for r in advisory_failures if r.name not in waived_gate_names)
-
+    advisory_failures = tuple(
+        result
+        for result in results
+        if not result.passed and result.severity is GateSeverity.ADVISORY
+    )
+    waived = tuple(result for result in advisory_failures if result.name in waived_gate_names)
+    unwaived = tuple(result for result in advisory_failures if result.name not in waived_gate_names)
     return GateEvaluation(
         release_allowed=not rigid_failures and not unwaived,
         blocking_rigid_failures=rigid_failures,

--- a/src/segmenter_dataset/ids.py
+++ b/src/segmenter_dataset/ids.py
@@ -1,82 +1,90 @@
-"""Deterministic, content-addressed IDs for the segmenter dataset lifecycle.
-
-RFC 0012 §3.1, §8: a document/annotation/review is identified by the hash of
-its own content, never by a counter. Two annotations with identical content
-collapse to the same ``annotation_id``; any difference in label, annotator,
-or timestamp produces a new ID, never overwriting the previous one — that is
-what "a document is never promoted, only referenced by new records" (§3.1)
-means at the ID-generation layer.
-"""
+"""Deterministic IDs for the segmenter dataset artifacts."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+from typing import Any
 
 
 def _stable_json(value: object) -> str:
-    """Canonical JSON encoding used as hash input — sorted keys, no whitespace."""
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
-def document_id(*, source_system: str, source_uri: str, source_hash: str) -> str:
-    """Content-addressed ID for a document record (RFC 0012 §8).
+def _digest(prefix: str, payload: dict[str, Any]) -> str:
+    digest = hashlib.sha256(_stable_json(payload).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:32]}"
 
-    Derived only from source identity fields, never from ``text`` directly —
-    ``source_hash`` already commits to the exact bytes fetched from the
-    source system, and keeping the ID formula independent of ``text`` means
-    re-extracting the same source document with a different heuristic
-    extractor (different ``proposed_labels``) still resolves to the same
-    ``document_id``, as RFC 0012 §3.1 requires (the document record is one
-    artifact type; extraction method is a detail of it, not a new identity).
+
+def document_id(*, source_system: str, source_uri: str, source_hash: str) -> str:
+    """Stable source-addressed document identity.
+
+    ``source_hash`` commits to the exact fetched bytes; extraction proposals are
+    deliberately excluded so multiple extraction passes refer to one source document.
     """
-    digest = hashlib.sha256(
-        _stable_json(
-            {
-                "source_system": source_system,
-                "source_uri": source_uri,
-                "source_hash": source_hash,
-            }
-        ).encode("utf-8")
-    ).hexdigest()
-    return f"doc_{digest[:32]}"
+    return _digest(
+        "doc",
+        {
+            "source_system": source_system,
+            "source_uri": source_uri,
+            "source_hash": source_hash,
+        },
+    )
 
 
 def annotation_id(
     *,
     document_id: str,
     annotator_id: str,
+    annotator_config: dict[str, Any],
+    ontology_version: str,
+    covered_categories: list[str] | tuple[str, ...],
+    labels: list[dict[str, Any]],
+    allowed_unmatched: dict[str, str],
     completed_at: str,
-    labels: list[dict],
+    annotation_method: str,
 ) -> str:
-    """Content-addressed ID for an annotation record (RFC 0012 §8)."""
-    digest = hashlib.sha256(
-        _stable_json(
-            {
-                "document_id": document_id,
-                "annotator_id": annotator_id,
-                "completed_at": completed_at,
-                "labels": labels,
-            }
-        ).encode("utf-8")
-    ).hexdigest()
-    return f"ann_{digest[:32]}"
+    """Content-addressed annotation ID over every semantically relevant field."""
+    return _digest(
+        "ann",
+        {
+            "document_id": document_id,
+            "annotator_id": annotator_id,
+            "annotator_config": annotator_config,
+            "ontology_version": ontology_version,
+            "covered_categories": sorted(covered_categories),
+            "labels": labels,
+            "allowed_unmatched": allowed_unmatched,
+            "completed_at": completed_at,
+            "annotation_method": annotation_method,
+        },
+    )
 
 
 def review_id(
     *,
     document_id: str,
-    input_annotation_ids: list[str],
+    input_annotation_ids: list[str] | tuple[str, ...],
+    status: str,
+    final_labels: list[dict[str, Any]],
+    allowed_unmatched: dict[str, str],
+    reviewers: list[str] | tuple[str, ...],
+    resolution: str,
+    notes: list[str] | tuple[str, ...],
     approved_at: str,
 ) -> str:
-    """Content-addressed ID for a review/adjudication record (RFC 0012 §8)."""
-    digest = hashlib.sha256(
-        _stable_json(
-            {
-                "document_id": document_id,
-                "input_annotation_ids": sorted(input_annotation_ids),
-                "approved_at": approved_at,
-            }
-        ).encode("utf-8")
-    ).hexdigest()
-    return f"rev_{digest[:32]}"
+    """Content-addressed review ID over the complete adjudication result."""
+    return _digest(
+        "rev",
+        {
+            "document_id": document_id,
+            "input_annotation_ids": sorted(input_annotation_ids),
+            "status": status,
+            "final_labels": final_labels,
+            "allowed_unmatched": allowed_unmatched,
+            "reviewers": sorted(reviewers),
+            "resolution": resolution,
+            "notes": list(notes),
+            "approved_at": approved_at,
+        },
+    )

--- a/src/segmenter_dataset/mechanical.py
+++ b/src/segmenter_dataset/mechanical.py
@@ -1,26 +1,14 @@
-"""Mechanical validation (RFC 0012 §11).
-
-Deliberately separate from annotation-quality review (RFC 0012 §3.2): every
-check here is a syntactic/structural property of a ``(text, labels)`` pair —
-offsets, pairing, ontology membership — never a judgment about whether a
-label is the *correct* one. Runs in-process, never via repeated subprocess
-calls to an external validator (§11).
-
-Adapted from PR #832's ``scripts/synthetic_segmenter/transform.py``
-(``check_final_invariants``) and ``validators.py`` (pair/ontology checks) —
-see RFC 0012 §18. The pair-base derivation here is generalized to read
-``_inicio``/``_fim`` suffixes off whatever categories are actually present,
-rather than a hardcoded tuple, so it doesn't silently go stale if the
-ontology changes.
-"""
+"""Mechanical validation for segmenter dataset records (RFC 0012 §11)."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from segmenter_dataset.schemas import MIN_INDEPENDENT_ANNOTATIONS
+
 
 if TYPE_CHECKING:
-    from segmenter_dataset.schemas import Label
+    from segmenter_dataset.schemas import AnnotationRecord, Label, ReviewRecord
 
 
 _INICIO_SUFFIX = "_inicio"
@@ -28,32 +16,24 @@ _FIM_SUFFIX = "_fim"
 
 
 def check_final_invariants(text: str, labels: list[Label]) -> list[str]:
-    """Offset-bound and overlap checks (RFC 0012 §11).
-
-    ``0 <= start < end <= len(text)``, no overlapping spans. Pydantic
-    already enforces ``start < end`` per-label (``schemas.Label``); this
-    additionally checks the bound against ``text`` and cross-label overlap,
-    which a single label can't self-validate.
-    """
+    """Check bounds and forbidden overlap."""
     problems: list[str] = []
-    text_len = len(text)
     ordered = sorted(labels, key=lambda label: (label.start, label.end))
-    prev_end = -1
+    previous_end = -1
     for label in ordered:
-        if label.end > text_len:
-            problems.append(f"[{label.category}] end={label.end} exceeds text length {text_len}")
+        if label.end > len(text):
+            problems.append(f"[{label.category}] end={label.end} exceeds text length {len(text)}")
             continue
-        if label.start < prev_end:
+        if label.start < previous_end:
             problems.append(
                 f"[{label.category}] overlaps previous span "
-                f"(start={label.start} < prev_end={prev_end})"
+                f"(start={label.start} < prev_end={previous_end})"
             )
-        prev_end = max(prev_end, label.end)
+        previous_end = max(previous_end, label.end)
     return problems
 
 
 def _pair_bases(labels: list[Label]) -> set[str]:
-    """Every ``_inicio``/``_fim`` base name actually present in ``labels``."""
     bases: set[str] = set()
     for label in labels:
         if label.category.endswith(_INICIO_SUFFIX):
@@ -63,62 +43,67 @@ def _pair_bases(labels: list[Label]) -> set[str]:
     return bases
 
 
-def validate_pairs(labels: list[Label], *, declared_unmatched: bool = False) -> list[str]:
-    """Pair-balance checks (RFC 0012 §11).
+def validate_pairs(
+    labels: list[Label],
+    *,
+    allowed_unmatched: dict[str, str] | None = None,
+    declared_unmatched: bool | None = None,
+) -> list[str]:
+    """Check pair balance and require an explicit reason for every unmatched base.
 
-    Catches: orphaned/excess ``_fim`` (no matching ``_inicio``), unbalanced
-    counts beyond the single-dangling-``_inicio`` case, and inverted pairs
-    (a ``_fim`` at or before its own ``_inicio``). ``declared_unmatched``
-    cross-checks against a record's provenance-declared
-    ``unmatched_pair`` flag when the caller has one (§11: "_inicio sem par
-    exige razão explícita de allowed-unmatched").
+    ``declared_unmatched`` remains for backwards-compatible callers; persisted
+    records use ``allowed_unmatched`` so one blanket boolean cannot authorize an
+    unrelated dangling pair.
     """
     problems: list[str] = []
-    unmatched_bases_in_text: set[str] = set()
+    unmatched_bases: set[str] = set()
 
     for base in sorted(_pair_bases(labels)):
-        inicio_starts = sorted(
+        starts = sorted(
             label.start for label in labels if label.category == f"{base}{_INICIO_SUFFIX}"
         )
-        fim_starts = sorted(
-            label.start for label in labels if label.category == f"{base}{_FIM_SUFFIX}"
-        )
-        n_inicio, n_fim = len(inicio_starts), len(fim_starts)
-
-        if n_fim > n_inicio:
+        ends = sorted(label.start for label in labels if label.category == f"{base}{_FIM_SUFFIX}")
+        if len(ends) > len(starts):
             problems.append(
-                f"{base}: {n_fim} _fim label(s) but only {n_inicio} _inicio label(s) — "
+                f"{base}: {len(ends)} _fim label(s) but only {len(starts)} _inicio label(s) — "
                 "orphaned or excess _fim"
             )
-        elif n_inicio - n_fim > 1:
+        elif len(starts) - len(ends) > 1:
             problems.append(
-                f"{base}: {n_inicio} _inicio label(s) vs {n_fim} _fim label(s) — unbalanced "
-                "beyond the single-dangling-_inicio case"
+                f"{base}: {len(starts)} _inicio label(s) vs {len(ends)} _fim label(s) — "
+                "unbalanced beyond the single-dangling-_inicio case"
             )
-        elif n_inicio - n_fim == 1:
-            unmatched_bases_in_text.add(base)
+        elif len(starts) - len(ends) == 1:
+            unmatched_bases.add(base)
 
-        for inicio_start, fim_start in zip(inicio_starts, fim_starts, strict=False):
-            if fim_start <= inicio_start:
+        for start, end in zip(starts, ends, strict=False):
+            if end <= start:
                 problems.append(
-                    f"{base}: _fim at offset {fim_start} is not after its _inicio at "
-                    f"offset {inicio_start} — inverted pair"
+                    f"{base}: _fim at offset {end} is not after its _inicio "
+                    f"at offset {start} — inverted pair"
                 )
                 break
 
-    if unmatched_bases_in_text and not declared_unmatched:
-        problems.append(
-            f"record has unmatched pair(s) {sorted(unmatched_bases_in_text)} but no "
-            "declared allowed-unmatched reason"
-        )
-    if declared_unmatched and not unmatched_bases_in_text:
-        problems.append("declared_unmatched=True but no unmatched pair found in labels")
+    allowed_bases = unmatched_bases if allowed_unmatched is None and declared_unmatched else set()
+    if allowed_unmatched is not None:
+        allowed_bases = set(allowed_unmatched)
 
+    missing_reasons = unmatched_bases - allowed_bases
+    extra_reasons = allowed_bases - unmatched_bases
+    if missing_reasons:
+        problems.append(
+            f"record has unmatched pair(s) {sorted(missing_reasons)} but no declared "
+            "allowed-unmatched reason"
+        )
+    if extra_reasons:
+        problems.append(
+            f"allowed_unmatched declares bases with no unmatched pair: {sorted(extra_reasons)}"
+        )
     return problems
 
 
 def validate_ontology_membership(labels: list[Label], ontology_categories: set[str]) -> list[str]:
-    """Every label's category must be in the trainable ontology (RFC 0012 §11)."""
+    """Return labels whose category is outside the release ontology."""
     return [
         f"category {label.category!r} not in ontology"
         for label in labels
@@ -129,23 +114,16 @@ def validate_ontology_membership(labels: list[Label], ontology_categories: set[s
 def validate_single_anchor_duplicates(
     labels: list[Label], *, allow_multiple: frozenset[str] = frozenset()
 ) -> list[str]:
-    """Reject duplicate single-anchor categories unless explicitly permitted (RFC 0012 §11).
-
-    A "single anchor" category is one without an ``_inicio``/``_fim``
-    pairing (e.g. ``dispositivo_abertura``). More than one occurrence in a
-    record is rejected by default — pass its name in ``allow_multiple`` to
-    permit it explicitly.
-    """
-    single_anchor_counts: dict[str, int] = {}
+    """Reject repeated single-anchor categories unless explicitly allowed."""
+    counts: dict[str, int] = {}
     for label in labels:
         if label.category.endswith(_INICIO_SUFFIX) or label.category.endswith(_FIM_SUFFIX):
             continue
-        single_anchor_counts[label.category] = single_anchor_counts.get(label.category, 0) + 1
-
+        counts[label.category] = counts.get(label.category, 0) + 1
     return [
         f"category {category!r} appears {count} times — single-anchor categories must "
         "appear at most once unless explicitly permitted"
-        for category, count in sorted(single_anchor_counts.items())
+        for category, count in sorted(counts.items())
         if count > 1 and category not in allow_multiple
     ]
 
@@ -155,19 +133,88 @@ def validate_record(
     labels: list[Label],
     ontology_categories: set[str],
     *,
-    declared_unmatched: bool = False,
+    allowed_unmatched: dict[str, str] | None = None,
+    declared_unmatched: bool | None = None,
     allow_multiple_single_anchor: frozenset[str] = frozenset(),
 ) -> list[str]:
-    """Full RFC 0012 §11 mechanical validation for one ``(text, labels)`` record.
-
-    Composes every check this module offers; returns an empty list iff the
-    record is mechanically valid. Does not check semantic correctness of
-    the labels (§3.2) — only structure.
-    """
-    problems = list(check_final_invariants(text, labels))
+    """Run all mechanical checks for one text-and-label record."""
+    problems = check_final_invariants(text, labels)
     problems.extend(validate_ontology_membership(labels, ontology_categories))
-    problems.extend(validate_pairs(labels, declared_unmatched=declared_unmatched))
+    problems.extend(
+        validate_pairs(
+            labels,
+            allowed_unmatched=allowed_unmatched,
+            declared_unmatched=declared_unmatched,
+        )
+    )
     problems.extend(
         validate_single_anchor_duplicates(labels, allow_multiple=allow_multiple_single_anchor)
     )
+    return problems
+
+
+def annotations_are_independent(a: AnnotationRecord, b: AnnotationRecord) -> list[str]:
+    """Validate RFC 0012's pairwise independence contract."""
+    problems: list[str] = []
+    if a.annotation_id == b.annotation_id:
+        problems.append("the two annotation IDs are identical")
+    if a.document_id != b.document_id:
+        problems.append("annotations refer to different documents")
+    if not a.is_independent_capable() or not b.is_independent_capable():
+        problems.append("both annotations must be unseeded independent_full_read runs")
+    if (
+        a.annotator_config.model_family == b.annotator_config.model_family
+        and a.annotator_id == b.annotator_id
+    ):
+        problems.append(
+            "same model family and same annotator/run ID do not establish independent execution"
+        )
+    return problems
+
+
+def validate_review_lineage(
+    review: ReviewRecord,
+    annotations_by_id: dict[str, AnnotationRecord],
+    *,
+    ontology_version: str,
+    ontology_categories: set[str],
+) -> list[str]:
+    """Validate an accepted review and the exact annotations it adjudicates."""
+    problems: list[str] = []
+    inputs = [annotations_by_id.get(annotation_id) for annotation_id in review.input_annotation_ids]
+    missing = [
+        annotation_id
+        for annotation_id, annotation in zip(review.input_annotation_ids, inputs, strict=True)
+        if annotation is None
+    ]
+    if missing:
+        return [f"review references missing annotation IDs: {sorted(missing)}"]
+
+    annotations = [annotation for annotation in inputs if annotation is not None]
+    if len(annotations) != MIN_INDEPENDENT_ANNOTATIONS:
+        problems.append(
+            "evaluation reviews must resolve exactly two annotations because the RFC IAA "
+            "metric is pairwise"
+        )
+        return problems
+
+    for annotation in annotations:
+        if annotation.document_id != review.document_id:
+            problems.append(
+                f"annotation {annotation.annotation_id} belongs to {annotation.document_id}, "
+                f"not review document {review.document_id}"
+            )
+        if annotation.ontology_version != ontology_version:
+            problems.append(
+                f"annotation {annotation.annotation_id} uses ontology "
+                f"{annotation.ontology_version}, expected {ontology_version}"
+            )
+        missing_coverage = ontology_categories - set(annotation.covered_categories)
+        if missing_coverage:
+            problems.append(
+                f"annotation {annotation.annotation_id} does not cover evaluation categories "
+                f"{sorted(missing_coverage)}"
+            )
+
+    problems.extend(annotations_are_independent(annotations[0], annotations[1]))
     return problems

--- a/src/segmenter_dataset/release.py
+++ b/src/segmenter_dataset/release.py
@@ -1,36 +1,23 @@
-"""``build_dataset_release`` (RFC 0012 §12).
-
-Does not promote candidates — packages records already **annotated**
-(train) or **adjudicated** (validation/test), with split-assignment already
-resolved (RFC 0012 §10), into an immutable, checksummed release:
-
-1. load annotations (train) and reviews (validation/test);
-2. verify split integrity;
-3. validate every resolved record mechanically (RFC 0012 §11);
-4. compute counts, hashes, and IAA (RFC 0012 §8);
-5. check independently classified readiness gates (RFC 0012 §12.1, §14);
-6. write into a temporary directory;
-7. verify the written release;
-8. atomically rename it to the final release ID;
-9. refuse to overwrite an existing release.
-
-``build_gold_release`` is this RFC's provisional name for the same command
-(RFC 0012 §9.1, §12) — reserved for a release that has additionally cleared
-the human-reference gate. This module's public name is
-``build_dataset_release`` because that gate does not exist yet.
-"""
+"""Immutable dataset release builder (RFC 0012 §12)."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+import re
+import shutil
 import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 from segmenter_dataset import mechanical
-from segmenter_dataset.dedup import content_hash
 from segmenter_dataset.gates import GateResult, evaluate_gates
-from segmenter_dataset.iaa import DocumentAnnotationPair, compute_iaa_report
+from segmenter_dataset.iaa import (
+    DEFAULT_BOOTSTRAP_RESAMPLES,
+    DocumentAnnotationPair,
+    compute_iaa_report,
+)
 from segmenter_dataset.schemas import (
     AnnotationQuality,
     AnnotationRecord,
@@ -39,15 +26,17 @@ from segmenter_dataset.schemas import (
     Label,
     ReleaseManifest,
     ReviewRecord,
+    SplitManifest,
 )
-from segmenter_dataset.splits import SplitAssignment, SplitLeakError, check_disjoint
+from segmenter_dataset.splits import (
+    assignment_from_manifest,
+    build_groups,
+    validate_split_leakage,
+)
 from segmenter_dataset.store import ImmutabilityError, SegmenterDatasetStore
 
 
-# RFC 0012 §5.6/§16.2 — categories too structural to isolate; a sub-floor
-# IAA result here escalates from a per-category exclusion to a whole-release
-# rigid failure (RFC 0012 §8).
-CRITICAL_CATEGORIES: frozenset[str] = frozenset(
+CRITICAL_CATEGORIES = frozenset(
     {
         "dispositivo_abertura",
         "resultado",
@@ -55,142 +44,178 @@ CRITICAL_CATEGORIES: frozenset[str] = frozenset(
         "acordao_decisorio_fim",
     }
 )
-
-# RFC 0012 §5.4 — minimum train support per category, minimum val support
-# for reported per-category metrics.
 MIN_TRAIN_SUPPORT_PER_CATEGORY = 10
 MIN_VAL_SUPPORT_PER_CATEGORY = 5
-
-# RFC 0012 §5.3/§9 — an IAA pair needs both independent annotations present.
-MIN_INDEPENDENT_ANNOTATIONS_FOR_IAA = 2
+_SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class ReleaseBlockedError(RuntimeError):
-    """A rigid gate failed, or an unwaived advisory gate failed (RFC 0012 §12.1)."""
+    """A rigid or unwaived advisory gate blocked the release."""
 
     def __init__(self, message: str, gate_results: list[GateResult]) -> None:
-        """Store the failing ``gate_results`` alongside the summary ``message``."""
         super().__init__(message)
         self.gate_results = gate_results
 
 
 @dataclass(frozen=True)
 class ResolvedSplitDocument:
-    """One document's resolved content for a given split, with its lineage ID."""
-
     document: DocumentRecord
     labels: list[Label]
-    resolution_id: str  # annotation_id (train) or review_id (val/test)
+    allowed_unmatched: dict[str, str]
+    resolution_id: str
+    input_annotation_ids: tuple[str, ...] = ()
 
 
-def _latest_accepted_review(reviews: list[ReviewRecord], document_id: str) -> ReviewRecord | None:
-    accepted = [r for r in reviews if r.document_id == document_id and r.status == "accepted"]
-    if not accepted:
-        return None
-    return max(accepted, key=lambda r: r.approved_at)
+def _latest(items: list, document_id: str, *, timestamp: str, accepted: bool = False):
+    matches = [item for item in items if item.document_id == document_id]
+    if accepted:
+        matches = [item for item in matches if item.status == "accepted"]
+    return max(matches, key=lambda item: getattr(item, timestamp)) if matches else None
 
 
-def _latest_annotation(
-    annotations: list[AnnotationRecord], document_id: str
-) -> AnnotationRecord | None:
-    matching = [a for a in annotations if a.document_id == document_id]
-    if not matching:
-        return None
-    return max(matching, key=lambda a: a.completed_at)
-
-
-def resolve_split(
+def _resolve_split(
     role: str,
     document_ids: frozenset[str],
-    documents_by_id: dict[str, DocumentRecord],
+    documents: dict[str, DocumentRecord],
     annotations: list[AnnotationRecord],
     reviews: list[ReviewRecord],
-) -> list[ResolvedSplitDocument]:
-    """Resolve each document in a split to the record its role requires (RFC 0012 §10).
-
-    ``role == "train"`` resolves to the latest annotation; ``"val"``/``"test"``
-    resolve to the latest accepted review. Raises if a document lacks the
-    record its role requires — this is what RFC 0012 §12 step 2 ("verifica
-    integridade de splits") ultimately checks.
-    """
+    *,
+    ontology_version: str,
+    ontology_categories: set[str],
+) -> tuple[list[ResolvedSplitDocument], list[str]]:
     resolved: list[ResolvedSplitDocument] = []
+    problems: list[str] = []
+    annotations_by_id = {item.annotation_id: item for item in annotations}
+
     for document_id in sorted(document_ids):
-        document = documents_by_id[document_id]
+        document = documents.get(document_id)
+        if document is None:
+            problems.append(f"{role} references missing document {document_id}")
+            continue
         if role == "train":
-            annotation = _latest_annotation(annotations, document_id)
+            annotation = _latest(annotations, document_id, timestamp="completed_at")
             if annotation is None:
-                msg = f"train document {document_id!r} has no annotation record"
-                raise SplitLeakError(msg)
+                problems.append(f"train document {document_id} has no annotation")
+                continue
+            if annotation.ontology_version != ontology_version:
+                problems.append(
+                    f"train annotation {annotation.annotation_id} uses "
+                    f"{annotation.ontology_version}, expected {ontology_version}"
+                )
+            unknown = set(annotation.covered_categories) - ontology_categories
+            if unknown:
+                problems.append(
+                    f"train annotation {annotation.annotation_id} covers unknown "
+                    f"categories {sorted(unknown)}"
+                )
             resolved.append(
-                ResolvedSplitDocument(document, annotation.labels, annotation.annotation_id)
+                ResolvedSplitDocument(
+                    document,
+                    annotation.labels,
+                    annotation.allowed_unmatched,
+                    annotation.annotation_id,
+                )
             )
-        else:
-            review = _latest_accepted_review(reviews, document_id)
-            if review is None:
-                msg = f"{role} document {document_id!r} has no accepted review record"
-                raise SplitLeakError(msg)
-            resolved.append(ResolvedSplitDocument(document, review.final_labels, review.review_id))
-    return resolved
+            continue
+
+        review = _latest(
+            reviews,
+            document_id,
+            timestamp="approved_at",
+            accepted=True,
+        )
+        if review is None:
+            problems.append(f"{role} document {document_id} has no accepted review")
+            continue
+        problems.extend(
+            f"[{role}:{document_id}] {problem}"
+            for problem in mechanical.validate_review_lineage(
+                review,
+                annotations_by_id,
+                ontology_version=ontology_version,
+                ontology_categories=ontology_categories,
+            )
+        )
+        resolved.append(
+            ResolvedSplitDocument(
+                document,
+                review.final_labels,
+                review.allowed_unmatched,
+                review.review_id,
+                review.input_annotation_ids,
+            )
+        )
+    return resolved, problems
 
 
-def _split_hash(resolved: list[ResolvedSplitDocument]) -> str:
-    joined = "|".join(
-        f"{r.document.document_id}:{r.resolution_id}"
-        for r in sorted(resolved, key=lambda item: item.document.document_id)
-    )
-    return content_hash(joined)
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
 
 
-def _category_counts(resolved: list[ResolvedSplitDocument]) -> dict[str, int]:
+def _split_hash(items: list[ResolvedSplitDocument]) -> str:
+    payload = [
+        [item.document.document_id, item.resolution_id]
+        for item in sorted(items, key=lambda item: item.document.document_id)
+    ]
+    return _sha256(json.dumps(payload, separators=(",", ":")))
+
+
+def _category_counts(items: list[ResolvedSplitDocument]) -> dict[str, int]:
     counts: dict[str, int] = {}
-    for item in resolved:
+    for item in items:
         for label in item.labels:
             counts[label.category] = counts.get(label.category, 0) + 1
     return counts
 
 
-def _mechanical_gate(
+def _support_gates(
     train: list[ResolvedSplitDocument],
     val: list[ResolvedSplitDocument],
-    test: list[ResolvedSplitDocument],
-    ontology_categories: set[str],
-) -> GateResult:
-    problems: list[str] = []
-    for role_name, resolved in (("train", train), ("val", val), ("test", test)):
-        for item in resolved:
-            record_problems = mechanical.validate_record(
-                item.document.text, item.labels, ontology_categories
-            )
-            problems.extend(
-                f"[{role_name}:{item.document.document_id}] {p}" for p in record_problems
-            )
-    return GateResult(
-        name="ontology_schema_valid",
-        passed=not problems,
-        detail="; ".join(problems[:20]) if problems else "all records mechanically valid",
+    ontology: set[str],
+) -> tuple[GateResult, GateResult]:
+    def below(items: list[ResolvedSplitDocument], floor: int) -> dict[str, int]:
+        counts = _category_counts(items)
+        return {
+            category: counts.get(category, 0)
+            for category in sorted(ontology)
+            if counts.get(category, 0) < floor
+        }
+
+    train_below = below(train, MIN_TRAIN_SUPPORT_PER_CATEGORY)
+    val_below = below(val, MIN_VAL_SUPPORT_PER_CATEGORY)
+    return (
+        GateResult(
+            "train_minimum_support_per_category",
+            not train_below,
+            f"below floor: {train_below}" if train_below else "all categories meet floor",
+        ),
+        GateResult(
+            "val_minimum_support_for_reported_metrics",
+            not val_below,
+            f"below floor: {val_below}" if val_below else "all categories meet floor",
+        ),
     )
 
 
-def _support_gates(
-    train: list[ResolvedSplitDocument], val: list[ResolvedSplitDocument]
-) -> tuple[GateResult, GateResult]:
-    train_counts = _category_counts(train)
-    val_counts = _category_counts(val)
-
-    under_train = {c: n for c, n in train_counts.items() if n < MIN_TRAIN_SUPPORT_PER_CATEGORY}
-    under_val = {c: n for c, n in val_counts.items() if n < MIN_VAL_SUPPORT_PER_CATEGORY}
-
-    return (
-        GateResult(
-            name="train_minimum_support_per_category",
-            passed=not under_train,
-            detail=f"below floor: {under_train}" if under_train else "all categories meet floor",
-        ),
-        GateResult(
-            name="val_minimum_support_for_reported_metrics",
-            passed=not under_val,
-            detail=f"below floor: {under_val}" if under_val else "all categories meet floor",
-        ),
+def _mechanical_gate(
+    splits: dict[str, list[ResolvedSplitDocument]], ontology: set[str]
+) -> GateResult:
+    problems = [
+        f"[{role}:{item.document.document_id}] {problem}"
+        for role, items in splits.items()
+        for item in items
+        for problem in mechanical.validate_record(
+            item.document.text,
+            item.labels,
+            ontology,
+            allowed_unmatched=item.allowed_unmatched,
+        )
+    ]
+    return GateResult(
+        "ontology_schema_valid",
+        not problems,
+        "; ".join(problems[:20]) if problems else "all records mechanically valid",
     )
 
 
@@ -198,71 +223,56 @@ def _iaa_gates(
     val: list[ResolvedSplitDocument],
     test: list[ResolvedSplitDocument],
     annotations: list[AnnotationRecord],
-    reviews: list[ReviewRecord],
     *,
-    iaa_seed: int,
+    seed: int,
+    resamples: int,
 ) -> tuple[GateResult, GateResult, AnnotationQuality]:
-    def pairs_for(resolved: list[ResolvedSplitDocument]) -> list[DocumentAnnotationPair]:
-        out: list[DocumentAnnotationPair] = []
-        for item in resolved:
-            review = _latest_accepted_review(reviews, item.document.document_id)
-            if review is None:
+    by_id = {item.annotation_id: item for item in annotations}
+
+    def pairs(items: list[ResolvedSplitDocument]) -> list[DocumentAnnotationPair]:
+        result = []
+        for item in items:
+            if len(item.input_annotation_ids) != 2:
                 continue
-            inputs = [a for a in annotations if a.annotation_id in review.input_annotation_ids]
-            if len(inputs) < MIN_INDEPENDENT_ANNOTATIONS_FOR_IAA:
-                continue
-            out.append(
-                DocumentAnnotationPair(
-                    document_id=item.document.document_id,
-                    labels_a=tuple(inputs[0].labels),
-                    labels_b=tuple(inputs[1].labels),
+            first, second = (by_id.get(value) for value in item.input_annotation_ids)
+            if first is not None and second is not None:
+                result.append(
+                    DocumentAnnotationPair(
+                        item.document.document_id,
+                        tuple(first.labels),
+                        tuple(second.labels),
+                    )
                 )
-            )
-        return out
+        return result
 
-    val_report = compute_iaa_report(pairs_for(val), seed=iaa_seed)
-    test_report = compute_iaa_report(pairs_for(test), seed=iaa_seed)
-
-    aggregate_passed = val_report.aggregate_passed and test_report.aggregate_passed
-    critical_failed = {
-        category
-        for report in (val_report, test_report)
-        for category in report.unreliable_eval_categories
-        if category in CRITICAL_CATEGORIES
-    }
-
-    per_category_iaa = {
-        f"val:{cat}": r.point_estimate for cat, r in val_report.per_category.items()
-    } | {f"test:{cat}": r.point_estimate for cat, r in test_report.per_category.items()}
-
+    val_report = compute_iaa_report(pairs(val), seed=seed, resamples=resamples)
+    test_report = compute_iaa_report(pairs(test), seed=seed, resamples=resamples)
+    unreliable = set(val_report.unreliable_eval_categories) | set(
+        test_report.unreliable_eval_categories
+    )
+    critical = unreliable & CRITICAL_CATEGORIES
+    per_category = {
+        f"val:{key}": value.point_estimate for key, value in val_report.per_category.items()
+    } | {f"test:{key}": value.point_estimate for key, value in test_report.per_category.items()}
     quality = AnnotationQuality(
         val_iaa_span_f1=val_report.macro_f1_point,
         val_iaa_span_f1_ci95_low=val_report.macro_f1_ci_low,
         test_iaa_span_f1=test_report.macro_f1_point,
         test_iaa_span_f1_ci95_low=test_report.macro_f1_ci_low,
-        per_category_iaa=per_category_iaa,
-        unreliable_eval_categories=tuple(
-            sorted(
-                set(val_report.unreliable_eval_categories)
-                | set(test_report.unreliable_eval_categories)
-            )
-        ),
+        per_category_iaa=per_category,
+        unreliable_eval_categories=tuple(sorted(unreliable)),
     )
-
     return (
         GateResult(
-            name="iaa_aggregate_floor",
-            passed=aggregate_passed,
-            detail=(
-                f"val macro-F1 CI-low={val_report.macro_f1_ci_low}, "
-                f"test macro-F1 CI-low={test_report.macro_f1_ci_low}"
-            ),
+            "iaa_aggregate_floor",
+            val_report.aggregate_passed and test_report.aggregate_passed,
+            f"val CI-low={val_report.macro_f1_ci_low}; test CI-low={test_report.macro_f1_ci_low}",
         ),
         GateResult(
-            name="iaa_critical_category_floor",
-            passed=not critical_failed,
-            detail=f"critical categories below floor: {sorted(critical_failed)}"
-            if critical_failed
+            "iaa_critical_category_floor",
+            not critical,
+            f"critical categories below floor: {sorted(critical)}"
+            if critical
             else "all critical categories meet floor",
         ),
         quality,
@@ -277,124 +287,118 @@ def build_dataset_release(
     guideline_version: str,
     source_commit: str,
     dependency_lock_hash: str,
+    ci_provider: str,
+    ci_run_id: str,
     ontology_categories: set[str],
-    split_assignment: SplitAssignment,
+    split_manifest: SplitManifest,
     known_limitations: list[KnownLimitation] | None = None,
     iaa_seed: int,
+    iaa_resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
 ) -> ReleaseManifest:
-    """Run the full RFC 0012 §12 release procedure; returns the written manifest.
-
-    Raises :class:`ReleaseBlockedError` if any rigid gate fails, or if an
-    advisory gate fails without a matching known limitation.
-    Raises :class:`~segmenter_dataset.store.ImmutabilityError` if
-    ``release_id`` already exists.
-    """
+    """Build, verify and atomically publish one dataset release."""
     known_limitations = known_limitations or []
-    release_dir = store.release_dir(release_id)
-    if release_dir.exists():
-        msg = f"release {release_id!r} already exists at {release_dir} (RFC 0012 §12 step 9)"
-        raise ImmutabilityError(msg)
+    if store.release_dir(release_id).exists():
+        raise ImmutabilityError(f"release {release_id!r} already exists")
 
-    # Step 1: load.
-    documents_by_id = {d.document_id: d for d in store.list_documents()}
+    all_documents = store.list_documents()
+    documents = {item.document_id: item for item in all_documents}
     annotations = store.list_annotations()
     reviews = store.list_reviews()
-
-    # Step 2: verify split integrity.
-    disjoint_problems = check_disjoint(
-        split_assignment.train_ids, split_assignment.val_ids, split_assignment.test_ids
+    assignment = assignment_from_manifest(split_manifest)
+    groups = build_groups(
+        all_documents,
+        near_duplicate_threshold=split_manifest.near_duplicate_threshold,
     )
-    hash_by_split: dict[str, set[str]] = {}
+    recorded_groups = {frozenset(value) for value in split_manifest.groups.values()}
+    recomputed_groups = {frozenset(value) for value in groups.values()}
+    leakage = validate_split_leakage(assignment, all_documents, groups)
+    if recorded_groups != recomputed_groups:
+        leakage.append("split manifest groups differ from recomputed groups")
+
+    resolved: dict[str, list[ResolvedSplitDocument]] = {}
+    problems: dict[str, list[str]] = {}
     for role, ids in (
-        ("train", split_assignment.train_ids),
-        ("val", split_assignment.val_ids),
-        ("test", split_assignment.test_ids),
+        ("train", assignment.train_ids),
+        ("validation", assignment.val_ids),
+        ("test", assignment.test_ids),
     ):
-        for document_id in ids:
-            digest = content_hash(documents_by_id[document_id].text)
-            hash_by_split.setdefault(digest, set()).add(role)
-    cross_split_hash_collisions = [
-        digest for digest, roles in hash_by_split.items() if len(roles) > 1
-    ]
-    split_integrity_passed = not disjoint_problems and not cross_split_hash_collisions
-
-    train = resolve_split(
-        "train", split_assignment.train_ids, documents_by_id, annotations, reviews
-    )
-    val = resolve_split("val", split_assignment.val_ids, documents_by_id, annotations, reviews)
-    test = resolve_split("test", split_assignment.test_ids, documents_by_id, annotations, reviews)
-
-    # Step 3: mechanical validation.
-    mechanical_gate = _mechanical_gate(train, val, test, ontology_categories)
-
-    # Step 4: counts, hashes, IAA.
-    train_support_gate, val_support_gate = _support_gates(train, val)
-    iaa_aggregate_gate, iaa_critical_gate, annotation_quality = _iaa_gates(
-        val, test, annotations, reviews, iaa_seed=iaa_seed
-    )
-    split_hashes = {
-        "train": _split_hash(train),
-        "validation": _split_hash(val),
-        "test": _split_hash(test),
-    }
-    document_resolutions = {
-        "train": {r.document.document_id: r.resolution_id for r in train},
-        "validation": {r.document.document_id: r.resolution_id for r in val},
-        "test": {r.document.document_id: r.resolution_id for r in test},
-    }
-    counts = {"train": len(train), "validation": len(val), "test": len(test)}
-    tribunals: dict[str, int] = {}
-    document_types: dict[str, int] = {}
-    for resolved in (*train, *val, *test):
-        tribunals[resolved.document.source.tribunal] = (
-            tribunals.get(resolved.document.source.tribunal, 0) + 1
-        )
-        document_types[resolved.document.source.document_type] = (
-            document_types.get(resolved.document.source.document_type, 0) + 1
+        resolved[role], problems[role] = _resolve_split(
+            "val" if role == "validation" else role,
+            ids,
+            documents,
+            annotations,
+            reviews,
+            ontology_version=ontology_version,
+            ontology_categories=ontology_categories,
         )
 
-    # Step 5: gates.
-    hash_collision_details = [f"hash collision: {h}" for h in cross_split_hash_collisions]
-    val_test_adjudicated = len(val) == len(split_assignment.val_ids) and len(test) == len(
-        split_assignment.test_ids
+    support = _support_gates(resolved["train"], resolved["validation"], ontology_categories)
+    iaa_aggregate, iaa_critical, quality = _iaa_gates(
+        resolved["validation"],
+        resolved["test"],
+        annotations,
+        seed=iaa_seed,
+        resamples=iaa_resamples,
     )
-    gate_results = [
+    split_hashes = {role: _split_hash(items) for role, items in resolved.items()}
+    split_manifest_hash = _sha256(split_manifest.model_dump_json())
+    resolution_problems = sum(problems.values(), [])
+    eval_problems = problems["validation"] + problems["test"]
+    checksum_ok = bool(_SHA256_RE.fullmatch(split_manifest_hash)) and all(
+        _SHA256_RE.fullmatch(value) for value in split_hashes.values()
+    )
+    provenance_ok = (
+        bool(_SHA40_RE.fullmatch(source_commit))
+        and bool(_SHA256_RE.fullmatch(dependency_lock_hash))
+        and bool(ci_provider.strip())
+        and bool(ci_run_id.strip())
+    )
+
+    gates = [
         GateResult(
-            name="split_disjoint_by_group_id_hash",
-            passed=split_integrity_passed,
-            detail="; ".join(disjoint_problems + hash_collision_details) or "no leakage found",
+            "split_disjoint_by_group_id_hash",
+            not leakage,
+            "; ".join(leakage) if leakage else "no leakage found",
         ),
         GateResult(
-            name="no_unresolved_annotation_conflicts",
-            passed=True,
-            detail="resolved by latest accepted review per document",
+            "no_unresolved_annotation_conflicts",
+            not resolution_problems,
+            "; ".join(resolution_problems[:20]) if resolution_problems else "all lineage resolves",
         ),
         GateResult(
-            name="val_test_independently_adjudicated",
-            passed=val_test_adjudicated,
-            detail="every val/test document resolved to an accepted review",
+            "val_test_independently_adjudicated",
+            not eval_problems
+            and len(resolved["validation"]) == len(assignment.val_ids)
+            and len(resolved["test"]) == len(assignment.test_ids),
+            "; ".join(eval_problems[:20])
+            if eval_problems
+            else "all evaluation documents independently adjudicated",
         ),
-        mechanical_gate,
-        iaa_aggregate_gate,
-        iaa_critical_gate,
-        train_support_gate,
-        val_support_gate,
-        GateResult(name="release_checksums_generated", passed=True, detail="computed in step 4"),
+        _mechanical_gate(resolved, ontology_categories),
+        iaa_aggregate,
+        iaa_critical,
+        *support,
         GateResult(
-            name="ci_reproducible_build",
-            passed=bool(source_commit) and bool(dependency_lock_hash),
-            detail="source_commit and dependency_lock_hash both provided",
+            "release_checksums_generated",
+            checksum_ok,
+            "release hashes computed" if checksum_ok else "invalid release hashes",
+        ),
+        GateResult(
+            "ci_reproducible_build",
+            provenance_ok,
+            "complete CI provenance" if provenance_ok else "invalid build provenance",
         ),
     ]
-    evaluation = evaluate_gates(gate_results, known_limitations)
+    evaluation = evaluate_gates(gates, known_limitations)
     if not evaluation.release_allowed:
-        failing = list(evaluation.blocking_rigid_failures) + list(
-            evaluation.blocking_unwaived_advisory_failures
+        failures = [
+            *evaluation.blocking_rigid_failures,
+            *evaluation.blocking_unwaived_advisory_failures,
+        ]
+        raise ReleaseBlockedError(
+            "release blocked: " + "; ".join(f"{item.name}: {item.detail}" for item in failures),
+            failures,
         )
-        msg = "release blocked by gate failures: " + "; ".join(
-            f"{g.name}: {g.detail}" for g in failing
-        )
-        raise ReleaseBlockedError(msg, failing)
 
     manifest = ReleaseManifest(
         release_id=release_id,
@@ -402,55 +406,67 @@ def build_dataset_release(
         guideline_version=guideline_version,
         source_commit=source_commit,
         dependency_lock_hash=dependency_lock_hash,
+        ci_provider=ci_provider,
+        ci_run_id=ci_run_id,
+        split_manifest_hash=split_manifest_hash,
         split_hashes=split_hashes,
-        document_resolutions=document_resolutions,
-        counts=counts,
-        tribunals=tribunals,
-        document_types=document_types,
-        annotation_quality=annotation_quality,
+        document_resolutions={
+            role: {item.document.document_id: item.resolution_id for item in items}
+            for role, items in resolved.items()
+        },
+        counts={role: len(items) for role, items in resolved.items()},
+        tribunals=_source_counts(resolved, "tribunal"),
+        document_types=_source_counts(resolved, "document_type"),
+        annotation_quality=quality,
+        iaa_seed=iaa_seed,
+        iaa_resamples=iaa_resamples,
         known_limitations=tuple(known_limitations),
-        created_at=_iso_now(),
+        created_at=datetime.now(UTC).isoformat(),
     )
-
-    # Steps 6-8: write to a temp dir, verify, atomically rename.
-    _atomic_write_release(store, manifest)
+    _atomic_write_release(store, manifest, split_manifest)
     return manifest
 
 
-def _iso_now() -> str:
-    return datetime.now(UTC).isoformat()
+def _source_counts(splits: dict[str, list[ResolvedSplitDocument]], field: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for items in splits.values():
+        for item in items:
+            value = getattr(item.document.source, field)
+            counts[value] = counts.get(value, 0) + 1
+    return counts
 
 
-class _RoundTripError(RuntimeError):
-    """The written release manifest didn't round-trip — refuse to publish it."""
-
-
-def _verify_round_trip(manifest_path: Path, manifest: ReleaseManifest) -> None:
-    reloaded = ReleaseManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
-    if reloaded != manifest:
-        msg = "written release manifest does not round-trip — refusing to publish"
-        raise _RoundTripError(msg)
-
-
-def _atomic_write_release(store: SegmenterDatasetStore, manifest: ReleaseManifest) -> None:
+def _atomic_write_release(
+    store: SegmenterDatasetStore,
+    manifest: ReleaseManifest,
+    split_manifest: SplitManifest,
+) -> None:
     store.releases_dir.mkdir(parents=True, exist_ok=True)
     final_dir = store.release_dir(manifest.release_id)
-
-    tmp_dir = Path(tempfile.mkdtemp(prefix=f".{manifest.release_id}.tmp-", dir=store.releases_dir))
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{manifest.release_id}.tmp-", dir=store.releases_dir)
+    )
     try:
-        manifest_path = tmp_dir / "manifest.json"
-        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
-
-        # Step 7: verify the written release round-trips.
-        _verify_round_trip(manifest_path, manifest)
-
-        # Step 8: atomic rename. Step 9 (refuse overwrite) was already
-        # checked before any work started; Path.rename still fails loudly
-        # if something raced and created final_dir in the meantime.
-        tmp_dir.rename(final_dir)
+        artifacts = {
+            "manifest.json": manifest.model_dump_json(indent=2),
+            "split_manifest.json": split_manifest.model_dump_json(indent=2),
+        }
+        for name, content in artifacts.items():
+            (temporary / name).write_text(content, encoding="utf-8")
+        checksums = {name: _sha256(content) for name, content in artifacts.items()}
+        (temporary / "checksums.sha256").write_text(
+            "".join(f"{digest}  {name}\n" for name, digest in sorted(checksums.items())),
+            encoding="utf-8",
+        )
+        if ReleaseManifest.model_validate_json(artifacts["manifest.json"]) != manifest:
+            raise RuntimeError("manifest does not round-trip")
+        if SplitManifest.model_validate_json(artifacts["split_manifest.json"]) != split_manifest:
+            raise RuntimeError("split manifest does not round-trip")
+        for name, expected in checksums.items():
+            if _sha256((temporary / name).read_text(encoding="utf-8")) != expected:
+                raise RuntimeError(f"checksum verification failed for {name}")
+        temporary.rename(final_dir)
     except BaseException:
-        if tmp_dir.exists():
-            for child in tmp_dir.iterdir():
-                child.unlink()
-            tmp_dir.rmdir()
+        if temporary.exists():
+            shutil.rmtree(temporary)
         raise

--- a/src/segmenter_dataset/schemas.py
+++ b/src/segmenter_dataset/schemas.py
@@ -1,35 +1,10 @@
-"""Record schemas for the segmenter dataset lifecycle (RFC 0012 §8).
-
-Three artifact types that coexist per document (RFC 0012 §3.1) — a document
-record is never edited or replaced; each annotation and each review is an
-additional record referencing it, never an overwrite:
-
-- :class:`DocumentRecord` — immutable source text + provenance.
-- :class:`AnnotationRecord` — one annotator's complete labeling of a
-  document, plus which ontology categories it actually considered
-  (``covered_categories`` — RFC 0012 §5.1's false-negative guard).
-- :class:`ReviewRecord` — adjudication of one or more annotations,
-  referencing them explicitly by ``annotation_id`` (RFC 0012 §8's lineage
-  fix — a review never just references a bare ``document_id``).
-
-:class:`ReleaseManifest` is the dataset-level artifact (§3.1: split-assigned
-and released are properties of a *build*, not of a document) produced by
-``release.build_dataset_release``.
-
-Pydantic validates shape and type here; the semantic/mechanical invariants
-of RFC 0012 §11 (offset bounds, pair balance, ontology membership, ...) are
-a separate concern in :mod:`segmenter_dataset.mechanical`, per RFC 0012
-§3.2 — mechanical validity is not semantic correctness, and neither layer
-should quietly absorb the other's job.
-"""
+"""Record schemas for the segmenter dataset lifecycle (RFC 0012 §8)."""
 
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-# RFC 0012 §5.3/§9 — an accepted review must resolve at least two
-# independent annotations.
 MIN_INDEPENDENT_ANNOTATIONS = 2
 
 
@@ -45,16 +20,16 @@ class Label(BaseModel):
     @model_validator(mode="after")
     def _check_order(self) -> Label:
         if not (0 <= self.start < self.end):
-            msg = (
-                "label offsets must satisfy 0 <= start < end, got "
-                f"start={self.start} end={self.end}"
+            message = (
+                "label offsets must satisfy 0 <= start < end, "
+                f"got start={self.start} end={self.end}"
             )
-            raise ValueError(msg)
+            raise ValueError(message)
         return self
 
 
 class SourceInfo(BaseModel):
-    """Where a document came from (RFC 0012 §8)."""
+    """Where a document came from."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -65,8 +40,19 @@ class SourceInfo(BaseModel):
     source_hash: str
 
 
+class GroupingInfo(BaseModel):
+    """Stable keys used to prevent related documents crossing splits."""
+
+    model_config = ConfigDict(frozen=True)
+
+    normalized_process_number: str | None = None
+    source_process_id: str | None = None
+    document_family: str | None = None
+    parent_document_id: str | None = None
+
+
 class ExtractionInfo(BaseModel):
-    """Which heuristic extractor produced ``proposed_labels`` (RFC 0012 §8)."""
+    """Which heuristic extractor produced ``proposed_labels``."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -75,25 +61,20 @@ class ExtractionInfo(BaseModel):
 
 
 class DocumentRecord(BaseModel):
-    """Immutable source-text record (RFC 0012 §8 "Registro de documento").
-
-    Never edited after creation — ``document_id`` is content-addressed
-    (:func:`segmenter_dataset.ids.document_id`) from ``source``, so two
-    extraction passes over the same source document resolve to the same
-    record rather than minting a new identity per extractor run.
-    """
+    """Immutable source-text record."""
 
     model_config = ConfigDict(frozen=True)
 
-    document_id: str
+    document_id: str = Field(pattern=r"^doc_[0-9a-f]{32}$")
     text: str
     proposed_labels: list[Label] = Field(default_factory=list)
     source: SourceInfo
     extraction: ExtractionInfo
+    grouping: GroupingInfo = Field(default_factory=GroupingInfo)
 
 
 class AnnotatorConfig(BaseModel):
-    """Identity of the annotator run that produced an :class:`AnnotationRecord`."""
+    """Identity of the annotator run that produced an annotation."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -103,90 +84,81 @@ class AnnotatorConfig(BaseModel):
 
 
 class AnnotationRecord(BaseModel):
-    """One annotator's complete labeling of a document (RFC 0012 §8).
-
-    ``covered_categories`` is the RFC 0012 §5.1 false-negative guard: it is
-    the subset of the ontology this annotator actually considered. A
-    category outside this set must be masked out of training loss/support
-    for this document (§5.1), never read as a negative example.
-    """
+    """One annotator's complete labeling of a document."""
 
     model_config = ConfigDict(frozen=True)
 
-    annotation_id: str
-    document_id: str
+    annotation_id: str = Field(pattern=r"^ann_[0-9a-f]{32}$")
+    document_id: str = Field(pattern=r"^doc_[0-9a-f]{32}$")
     annotator_id: str
     annotator_config: AnnotatorConfig
     ontology_version: str
     covered_categories: tuple[str, ...]
     labels: list[Label] = Field(default_factory=list)
+    allowed_unmatched: dict[str, str] = Field(default_factory=dict)
     completed_at: str
     annotation_method: str
 
     @model_validator(mode="after")
-    def _labels_within_covered_categories(self) -> AnnotationRecord:
-        uncovered = {label.category for label in self.labels} - set(self.covered_categories)
+    def _validate_annotation_contract(self) -> AnnotationRecord:
+        covered = set(self.covered_categories)
+        uncovered = {label.category for label in self.labels} - covered
         if uncovered:
-            msg = (
-                f"labels use categories outside covered_categories: {sorted(uncovered)} — "
-                "an annotator cannot produce a label for a category it wasn't asked to consider"
-            )
-            raise ValueError(msg)
+            message = f"labels use categories outside covered_categories: {sorted(uncovered)}"
+            raise ValueError(message)
+        blank_reasons = sorted(
+            base for base, reason in self.allowed_unmatched.items() if not reason.strip()
+        )
+        if blank_reasons:
+            message = f"allowed_unmatched requires a non-empty reason: {blank_reasons}"
+            raise ValueError(message)
         return self
 
     def is_independent_capable(self) -> bool:
-        """RFC 0012 §5.3: an annotation counts as independent only if unseeded.
-
-        This checks the necessary local condition (``seeded_with == "none"``)
-        — the full definition also requires distinct model families *or*
-        provably isolated runs across a *pair* of annotations, which is a
-        property of two records together, not one (see
-        :func:`segmenter_dataset.mechanical.annotations_are_independent`).
-        """
-        return self.annotator_config.seeded_with == "none"
+        """Return whether local metadata permits independent use."""
+        return (
+            self.annotator_config.seeded_with == "none"
+            and self.annotation_method == "independent_full_read"
+        )
 
 
 class ReviewRecord(BaseModel):
-    """Adjudication of one or more annotations (RFC 0012 §8 "Registro de review").
-
-    ``input_annotation_ids`` names exactly which annotation records this
-    review resolved — never just ``document_id``, because a document may
-    accumulate more than two annotations over time and a reconstructed
-    release must be able to tell which pair a given review adjudicated
-    (RFC 0012 §8's lineage fix).
-    """
+    """Adjudication of explicit annotation records."""
 
     model_config = ConfigDict(frozen=True)
 
-    review_id: str
-    document_id: str
+    review_id: str = Field(pattern=r"^rev_[0-9a-f]{32}$")
+    document_id: str = Field(pattern=r"^doc_[0-9a-f]{32}$")
     input_annotation_ids: tuple[str, ...]
     status: str
     final_labels: list[Label] = Field(default_factory=list)
+    allowed_unmatched: dict[str, str] = Field(default_factory=dict)
     reviewers: tuple[str, ...]
     resolution: str
     notes: tuple[str, ...] = ()
     approved_at: str
 
     @model_validator(mode="after")
-    def _at_least_two_inputs_when_accepted(self) -> ReviewRecord:
-        n_inputs = len(self.input_annotation_ids)
-        if self.status == "accepted" and n_inputs < MIN_INDEPENDENT_ANNOTATIONS:
-            msg = (
-                "an accepted review must resolve at least two independent annotations "
-                f"(RFC 0012 §9); got {n_inputs}"
-            )
-            raise ValueError(msg)
+    def _validate_review_contract(self) -> ReviewRecord:
+        if self.status == "accepted":
+            unique_inputs = set(self.input_annotation_ids)
+            if len(unique_inputs) < MIN_INDEPENDENT_ANNOTATIONS:
+                message = "an accepted review must resolve at least two distinct annotations"
+                raise ValueError(message)
+            if len(unique_inputs) != len(self.input_annotation_ids):
+                message = "input_annotation_ids must not contain duplicates"
+                raise ValueError(message)
+        blank_reasons = sorted(
+            base for base, reason in self.allowed_unmatched.items() if not reason.strip()
+        )
+        if blank_reasons:
+            message = f"allowed_unmatched requires a non-empty reason: {blank_reasons}"
+            raise ValueError(message)
         return self
 
 
 class KnownLimitation(BaseModel):
-    """A waivable/advisory gate recorded as a lightweight known limitation.
-
-    RFC 0012 §12/§12.1: no formal ``approved_by``/expiry object — the next
-    major release is the natural review point (§13.1), not a hardcoded
-    expiry field.
-    """
+    """A waivable advisory gate recorded in the release manifest."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -195,8 +167,36 @@ class KnownLimitation(BaseModel):
     reason: str
 
 
+class SplitManifest(BaseModel):
+    """Reproducible split-assignment artifact consumed by the release builder."""
+
+    model_config = ConfigDict(frozen=True)
+
+    train_ids: tuple[str, ...]
+    val_ids: tuple[str, ...]
+    test_ids: tuple[str, ...]
+    seed: int
+    train_ratio: float
+    val_ratio: float
+    near_duplicate_threshold: float
+    groups: dict[str, tuple[str, ...]]
+
+    @model_validator(mode="after")
+    def _validate_ratios(self) -> SplitManifest:
+        if not (0 < self.train_ratio < 1 and 0 < self.val_ratio < 1):
+            message = "train_ratio and val_ratio must be between 0 and 1"
+            raise ValueError(message)
+        if self.train_ratio + self.val_ratio >= 1:
+            message = "train_ratio + val_ratio must be < 1"
+            raise ValueError(message)
+        if not (0 <= self.near_duplicate_threshold <= 1):
+            message = "near_duplicate_threshold must be in [0, 1]"
+            raise ValueError(message)
+        return self
+
+
 class AnnotationQuality(BaseModel):
-    """IAA evidence required by RFC 0012 §8/§14 — never a bare number."""
+    """IAA evidence required by RFC 0012 §8/§14."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -209,28 +209,25 @@ class AnnotationQuality(BaseModel):
 
 
 class ReleaseManifest(BaseModel):
-    """Dataset-level release artifact (RFC 0012 §8, §12).
-
-    Lives at ``dataset-releases/<release_id>/manifest.json`` once
-    ``release.build_dataset_release`` finishes. ``document_resolutions``
-    pins the exact ``annotation_id``/``review_id`` used per document per
-    split — without it, rebuilding from the same ``document_id`` set could
-    silently pick a different annotation if the document was re-annotated
-    between builds (RFC 0012 §8's lineage fix).
-    """
+    """Dataset-level immutable release artifact."""
 
     model_config = ConfigDict(frozen=True)
 
-    release_id: str
+    release_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
     ontology_version: str
     guideline_version: str
-    source_commit: str
-    dependency_lock_hash: str
+    source_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
+    dependency_lock_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    ci_provider: str
+    ci_run_id: str
+    split_manifest_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
     split_hashes: dict[str, str]
     document_resolutions: dict[str, dict[str, str]]
     counts: dict[str, int] = Field(default_factory=dict)
     tribunals: dict[str, int] = Field(default_factory=dict)
     document_types: dict[str, int] = Field(default_factory=dict)
     annotation_quality: AnnotationQuality
+    iaa_seed: int
+    iaa_resamples: int
     known_limitations: tuple[KnownLimitation, ...] = ()
     created_at: str

--- a/src/segmenter_dataset/splits.py
+++ b/src/segmenter_dataset/splits.py
@@ -1,22 +1,4 @@
-"""Split policy (RFC 0012 §10): grouping, role eligibility, and leakage checks.
-
-Split assignment happens only after a document reaches the state its target
-role requires (RFC 0012 §10, fixed in review round 2 — there is no single
-"after adjudication" rule for all three splits):
-
-- **train** role requires only **annotated** (one complete annotation +
-  mechanical validation; risk spot-review resolution is a maintainer
-  process this module doesn't model — see RFC 0012 §9);
-- **validation**/**test** roles require **adjudicated** (an accepted
-  :class:`~segmenter_dataset.schemas.ReviewRecord`).
-
-Grouping (so a related-document group never crosses splits) and the
-disjointness/leakage primitives are adapted from PR #832's
-``scripts/synthetic_segmenter/split_guard.py`` (RFC 0012 §18) — the
-synthetic-lineage-specific helpers there (``assign_child_split``,
-``require_train_only_sources``, ``calibration_eligible_ids``) are left
-behind for PR 4/synthetic to reuse; they aren't RFC 0012's PR 1 concern.
-"""
+"""Split policy: grouping, role eligibility, deterministic assignment, leakage checks."""
 
 from __future__ import annotations
 
@@ -25,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from segmenter_dataset.dedup import content_hash, find_near_duplicates
+from segmenter_dataset.schemas import SplitManifest
 
 
 if TYPE_CHECKING:
@@ -32,37 +15,22 @@ if TYPE_CHECKING:
 
 
 class SplitLeakError(ValueError):
-    """A split-integrity invariant (RFC 0012 §10) was violated."""
-
-
-# ---------------------------------------------------------------------------
-# Role eligibility
-# ---------------------------------------------------------------------------
+    """A split-integrity invariant was violated."""
 
 
 def train_eligible_document_ids(annotations: list[AnnotationRecord]) -> frozenset[str]:
-    """Documents eligible for the **train** role: at least one annotation exists.
-
-    Mechanical validation of each annotation is assumed to have already
-    happened (``mechanical.validate_record``) before it reaches this
-    function — this only checks presence, not correctness (RFC 0012 §3.2).
-    """
-    return frozenset(a.document_id for a in annotations)
+    """Return documents with at least one annotation for train eligibility."""
+    return frozenset(annotation.document_id for annotation in annotations)
 
 
 def evaluation_eligible_document_ids(reviews: list[ReviewRecord]) -> frozenset[str]:
-    """Documents eligible for the **validation**/**test** role: an accepted review exists."""
-    return frozenset(r.document_id for r in reviews if r.status == "accepted")
-
-
-# ---------------------------------------------------------------------------
-# Grouping — a group never crosses splits (RFC 0012 §10)
-# ---------------------------------------------------------------------------
+    """Return documents with an accepted review for evaluation eligibility."""
+    return frozenset(review.document_id for review in reviews if review.status == "accepted")
 
 
 @dataclass(frozen=True)
 class GroupingKeys:
-    """Grouping keys for one document, per RFC 0012 §10 (all optional)."""
+    """Grouping keys for one document."""
 
     document_id: str
     normalized_process_number: str | None = None
@@ -70,10 +38,20 @@ class GroupingKeys:
     document_family: str | None = None
     parent_document_id: str | None = None
 
+    @classmethod
+    def from_document(cls, document: DocumentRecord) -> GroupingKeys:
+        """Build grouping keys from persisted document metadata."""
+        grouping = document.grouping
+        return cls(
+            document_id=document.document_id,
+            normalized_process_number=grouping.normalized_process_number,
+            source_process_id=grouping.source_process_id,
+            document_family=grouping.document_family,
+            parent_document_id=grouping.parent_document_id,
+        )
+
 
 class _UnionFind:
-    """Minimal union-find for clustering documents that share any grouping key."""
-
     def __init__(self, ids: list[str]) -> None:
         self._parent = {doc_id: doc_id for doc_id in ids}
 
@@ -93,31 +71,35 @@ class _UnionFind:
 
 
 def _union_shared_values(uf: _UnionFind, id_lists: dict[str, list[str]]) -> None:
-    """Union every group of ids sharing a common key value."""
-    for group_ids in id_lists.values():
-        for other in group_ids[1:]:
-            uf.union(group_ids[0], other)
+    for ids in id_lists.values():
+        for other in ids[1:]:
+            uf.union(ids[0], other)
 
 
 def _union_by_content(
-    uf: _UnionFind, documents: list[DocumentRecord], *, near_duplicate_threshold: float
+    uf: _UnionFind,
+    documents: list[DocumentRecord],
+    *,
+    near_duplicate_threshold: float,
 ) -> None:
-    """Union documents sharing an exact content hash or a near-duplicate ratio."""
     by_hash: dict[str, list[str]] = {}
-    for doc in documents:
-        by_hash.setdefault(content_hash(doc.text), []).append(doc.document_id)
+    for document in documents:
+        by_hash.setdefault(content_hash(document.text), []).append(document.document_id)
     _union_shared_values(uf, by_hash)
 
-    texts = {doc.document_id: doc.text for doc in documents}
+    texts = {document.document_id: document.text for document in documents}
     for id_a, id_b, _ratio in find_near_duplicates(texts, threshold=near_duplicate_threshold):
         uf.union(id_a, id_b)
 
 
-_GROUPING_KEY_FIELDS = ("normalized_process_number", "source_process_id", "document_family")
+_GROUPING_KEY_FIELDS = (
+    "normalized_process_number",
+    "source_process_id",
+    "document_family",
+)
 
 
 def _union_by_grouping_keys(uf: _UnionFind, keys: list[GroupingKeys]) -> None:
-    """Union documents sharing a non-null grouping key or a parent/child relationship."""
     for field in _GROUPING_KEY_FIELDS:
         by_key: dict[str, list[str]] = {}
         for key in keys:
@@ -133,52 +115,47 @@ def _union_by_grouping_keys(uf: _UnionFind, keys: list[GroupingKeys]) -> None:
 
 def build_groups(
     documents: list[DocumentRecord],
-    keys: list[GroupingKeys],
+    keys: list[GroupingKeys] | None = None,
     *,
     near_duplicate_threshold: float = 0.9,
 ) -> dict[str, frozenset[str]]:
-    """Cluster documents into groups that must not cross splits (RFC 0012 §10).
+    """Cluster documents using content, process, family and parent relationships."""
+    keys = keys or [GroupingKeys.from_document(document) for document in documents]
+    document_ids = {document.document_id for document in documents}
+    key_ids = {key.document_id for key in keys}
+    if key_ids != document_ids:
+        missing = sorted(document_ids - key_ids)
+        extra = sorted(key_ids - document_ids)
+        message = f"grouping keys do not match documents: missing={missing}, extra={extra}"
+        raise SplitLeakError(message)
 
-    Union-find over: exact content hash, near-duplicate content (via
-    :func:`segmenter_dataset.dedup.find_near_duplicates`), and any shared
-    non-null grouping key (process number, source process ID, document
-    family, parent/derived relationship). Returns ``{group_id: {document_id, ...}}``
-    keyed by one representative document_id per group.
-    """
-    ids = [doc.document_id for doc in documents]
-    uf = _UnionFind(ids)
-
+    uf = _UnionFind(sorted(document_ids))
     _union_by_content(uf, documents, near_duplicate_threshold=near_duplicate_threshold)
     _union_by_grouping_keys(uf, keys)
 
     groups: dict[str, list[str]] = {}
-    for doc_id in ids:
-        root = uf.find(doc_id)
-        groups.setdefault(root, []).append(doc_id)
+    for document_id in sorted(document_ids):
+        groups.setdefault(uf.find(document_id), []).append(document_id)
     return {root: frozenset(members) for root, members in groups.items()}
-
-
-# ---------------------------------------------------------------------------
-# Assignment
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class SplitAssignment:
-    """Which split each document belongs to (RFC 0012 §10)."""
+    """Disjoint document IDs assigned to train, validation, and test."""
 
     train_ids: frozenset[str]
     val_ids: frozenset[str]
     test_ids: frozenset[str]
 
     def __post_init__(self) -> None:
-        """Raise :class:`SplitLeakError` immediately if the three sets aren't disjoint."""
+        """Reject overlapping split assignments immediately."""
         violations = check_disjoint(self.train_ids, self.val_ids, self.test_ids)
         if violations:
-            raise SplitLeakError("; ".join(violations))
+            message = "; ".join(violations)
+            raise SplitLeakError(message)
 
     def split_of(self, document_id: str) -> str | None:
-        """Return ``"train"``/``"val"``/``"test"`` for a known document_id, else ``None``."""
+        """Return the assigned split for a document, if any."""
         if document_id in self.train_ids:
             return "train"
         if document_id in self.val_ids:
@@ -191,7 +168,7 @@ class SplitAssignment:
 def check_disjoint(
     train_ids: frozenset[str], val_ids: frozenset[str], test_ids: frozenset[str]
 ) -> list[str]:
-    """Return violation messages for any pairwise intersection; empty = OK."""
+    """Return pairwise overlap violations between split ID sets."""
     violations: list[str] = []
     for name_a, ids_a, name_b, ids_b in (
         ("train", train_ids, "val", val_ids),
@@ -213,20 +190,10 @@ def assign_splits(
     val_ratio: float = 0.15,
     seed: int,
 ) -> SplitAssignment:
-    """Deterministically assign groups to train/val/test (RFC 0012 §10).
-
-    A group is **evaluation-capable** (may become val or test) only if
-    every one of its documents is ``evaluation_eligible``; otherwise it can
-    only become train, and only once every member is at least
-    ``train_eligible``. Documents that are in neither eligible set are
-    dropped from the group before assignment (not yet ready for any role —
-    not an error).
-
-    Deterministic: groups are ordered by a stable hash of ``(seed,
-    group_id)`` before greedy proportional assignment, so the same inputs
-    always produce the same split — reproducibility (RFC 0012 §12/§14), not
-    an actual pseudo-random shuffle.
-    """
+    """Deterministically assign whole groups without splitting related documents."""
+    if not (0 < train_ratio < 1 and 0 < val_ratio < 1 and train_ratio + val_ratio < 1):
+        message = "invalid train/validation ratios"
+        raise ValueError(message)
 
     def sort_key(group_id: str) -> str:
         return hashlib.sha256(f"{seed}:{group_id}".encode()).hexdigest()
@@ -234,44 +201,63 @@ def assign_splits(
     train_ids: set[str] = set()
     val_ids: set[str] = set()
     test_ids: set[str] = set()
-
-    ordered_group_ids = sorted(groups, key=sort_key)
-    total_eligible = sum(
-        len(groups[gid] & (train_eligible | evaluation_eligible)) for gid in ordered_group_ids
+    ordered = sorted(groups, key=sort_key)
+    total = sum(
+        len(groups[group_id] & (train_eligible | evaluation_eligible)) for group_id in ordered
     )
-    if total_eligible == 0:
+    if total == 0:
         return SplitAssignment(frozenset(), frozenset(), frozenset())
 
-    val_target = max(1, round(total_eligible * val_ratio))
-    test_target = max(1, round(total_eligible * (1 - train_ratio - val_ratio)))
+    val_target = max(1, round(total * val_ratio))
+    test_target = max(1, round(total * (1 - train_ratio - val_ratio)))
 
-    for group_id in ordered_group_ids:
+    for group_id in ordered:
         members = groups[group_id] & (train_eligible | evaluation_eligible)
         if not members:
             continue
-        evaluation_capable = members <= evaluation_eligible
-
-        if (
-            evaluation_capable
-            and len(val_ids) < val_target
-            and len(val_ids) + len(members) <= val_target
-        ):
-            val_ids |= members
-        elif (
-            evaluation_capable
-            and len(test_ids) < test_target
-            and len(test_ids) + len(members) <= test_target
-        ):
-            test_ids |= members
-        else:
-            train_ids |= members
+        if members <= evaluation_eligible:
+            val_deficit = val_target - len(val_ids)
+            test_deficit = test_target - len(test_ids)
+            if val_deficit > 0 or test_deficit > 0:
+                if val_deficit >= test_deficit:
+                    val_ids |= members
+                else:
+                    test_ids |= members
+                continue
+        train_ids |= members
 
     return SplitAssignment(frozenset(train_ids), frozenset(val_ids), frozenset(test_ids))
 
 
-# ---------------------------------------------------------------------------
-# Leakage rejection (RFC 0012 §10's explicit reject list)
-# ---------------------------------------------------------------------------
+def create_split_manifest(
+    assignment: SplitAssignment,
+    groups: dict[str, frozenset[str]],
+    *,
+    seed: int,
+    train_ratio: float,
+    val_ratio: float,
+    near_duplicate_threshold: float,
+) -> SplitManifest:
+    """Create a reproducible split manifest with assignment parameters."""
+    return SplitManifest(
+        train_ids=tuple(sorted(assignment.train_ids)),
+        val_ids=tuple(sorted(assignment.val_ids)),
+        test_ids=tuple(sorted(assignment.test_ids)),
+        seed=seed,
+        train_ratio=train_ratio,
+        val_ratio=val_ratio,
+        near_duplicate_threshold=near_duplicate_threshold,
+        groups={group_id: tuple(sorted(members)) for group_id, members in sorted(groups.items())},
+    )
+
+
+def assignment_from_manifest(manifest: SplitManifest) -> SplitAssignment:
+    """Reconstruct the split assignment encoded in a manifest."""
+    return SplitAssignment(
+        train_ids=frozenset(manifest.train_ids),
+        val_ids=frozenset(manifest.val_ids),
+        test_ids=frozenset(manifest.test_ids),
+    )
 
 
 def validate_split_leakage(
@@ -279,21 +265,14 @@ def validate_split_leakage(
     documents: list[DocumentRecord],
     groups: dict[str, frozenset[str]],
 ) -> list[str]:
-    """RFC 0012 §10's explicit rejection checks; empty list = no leakage found.
-
-    Checks: no ``document_id`` assigned twice (covered structurally by
-    ``SplitAssignment``'s disjointness, re-asserted here for a single
-    combined report), no normalized-content-hash collision across splits,
-    and no group spanning more than one split.
-    """
-    problems: list[str] = []
+    """Return ID, exact-hash, or grouping leakage violations."""
+    problems = check_disjoint(assignment.train_ids, assignment.val_ids, assignment.test_ids)
 
     hash_to_splits: dict[str, set[str]] = {}
-    for doc in documents:
-        split = assignment.split_of(doc.document_id)
-        if split is None:
-            continue
-        hash_to_splits.setdefault(content_hash(doc.text), set()).add(split)
+    for document in documents:
+        split = assignment.split_of(document.document_id)
+        if split is not None:
+            hash_to_splits.setdefault(content_hash(document.text), set()).add(split)
     problems.extend(
         f"content_hash {digest} appears in multiple splits: {sorted(splits)}"
         for digest, splits in hash_to_splits.items()
@@ -302,14 +281,13 @@ def validate_split_leakage(
 
     for group_id, members in groups.items():
         splits_seen = {
-            assignment.split_of(doc_id)
-            for doc_id in members
-            if assignment.split_of(doc_id) is not None
+            assignment.split_of(document_id)
+            for document_id in members
+            if assignment.split_of(document_id) is not None
         }
         if len(splits_seen) > 1:
             problems.append(
                 f"group {group_id} spans multiple splits: {sorted(splits_seen)} "
                 f"(members: {sorted(members)})"
             )
-
     return problems

--- a/tests/segmenter_dataset/conftest.py
+++ b/tests/segmenter_dataset/conftest.py
@@ -6,6 +6,7 @@ from segmenter_dataset.schemas import (
     AnnotatorConfig,
     DocumentRecord,
     ExtractionInfo,
+    GroupingInfo,
     Label,
     ReviewRecord,
     SourceInfo,
@@ -22,6 +23,10 @@ def make_document(
     document_type: str = "sentenca",
     source_uri: str = "ia://item/doc-1",
     source_hash: str = "hash-1",
+    normalized_process_number: str | None = None,
+    source_process_id: str | None = None,
+    document_family: str | None = None,
+    parent_document_id: str | None = None,
 ) -> DocumentRecord:
     doc_id = document_id(source_system="tjro_juris", source_uri=source_uri, source_hash=source_hash)
     return DocumentRecord(
@@ -36,6 +41,12 @@ def make_document(
             source_hash=source_hash,
         ),
         extraction=ExtractionInfo(method="boundary_phrase_extractor", version="1"),
+        grouping=GroupingInfo(
+            normalized_process_number=normalized_process_number,
+            source_process_id=source_process_id,
+            document_family=document_family,
+            parent_document_id=parent_document_id,
+        ),
     )
 
 
@@ -48,26 +59,39 @@ def make_annotation(
     completed_at: str = "2026-01-01T00:00:00Z",
     labels: list[Label] | None = None,
     covered_categories: tuple[str, ...] = ("cabecalho_inicio", "cabecalho_fim"),
+    allowed_unmatched: dict[str, str] | None = None,
+    ontology_version: str = ONTOLOGY_VERSION,
+    annotation_method: str = "independent_full_read",
 ) -> AnnotationRecord:
     labels = labels if labels is not None else [Label(start=0, end=9, category="cabecalho_inicio")]
+    allowed_unmatched = allowed_unmatched or {}
+    config = AnnotatorConfig(
+        model_family=model_family,
+        guideline_version="g1",
+        seeded_with=seeded_with,
+    )
     ann_id = annotation_id(
         document_id=document.document_id,
         annotator_id=annotator_id,
-        completed_at=completed_at,
+        annotator_config=config.model_dump(),
+        ontology_version=ontology_version,
+        covered_categories=covered_categories,
         labels=[label.model_dump() for label in labels],
+        allowed_unmatched=allowed_unmatched,
+        completed_at=completed_at,
+        annotation_method=annotation_method,
     )
     return AnnotationRecord(
         annotation_id=ann_id,
         document_id=document.document_id,
         annotator_id=annotator_id,
-        annotator_config=AnnotatorConfig(
-            model_family=model_family, guideline_version="g1", seeded_with=seeded_with
-        ),
-        ontology_version=ONTOLOGY_VERSION,
+        annotator_config=config,
+        ontology_version=ontology_version,
         covered_categories=covered_categories,
         labels=labels,
+        allowed_unmatched=allowed_unmatched,
         completed_at=completed_at,
-        annotation_method="independent_full_read",
+        annotation_method=annotation_method,
     )
 
 
@@ -78,22 +102,34 @@ def make_review(
     status: str = "accepted",
     approved_at: str = "2026-01-02T00:00:00Z",
     final_labels: list[Label] | None = None,
+    allowed_unmatched: dict[str, str] | None = None,
     reviewers: tuple[str, ...] = ("reviewer-a", "reviewer-b"),
+    resolution: str = "agreement",
+    notes: tuple[str, ...] = (),
 ) -> ReviewRecord:
     final_labels = final_labels if final_labels is not None else list(annotations[0].labels)
+    allowed_unmatched = allowed_unmatched or {}
+    input_ids = tuple(annotation.annotation_id for annotation in annotations)
     rev_id = review_id(
         document_id=document.document_id,
-        input_annotation_ids=[a.annotation_id for a in annotations],
+        input_annotation_ids=input_ids,
+        status=status,
+        final_labels=[label.model_dump() for label in final_labels],
+        allowed_unmatched=allowed_unmatched,
+        reviewers=reviewers,
+        resolution=resolution,
+        notes=notes,
         approved_at=approved_at,
     )
     return ReviewRecord(
         review_id=rev_id,
         document_id=document.document_id,
-        input_annotation_ids=tuple(a.annotation_id for a in annotations),
+        input_annotation_ids=input_ids,
         status=status,
         final_labels=final_labels,
+        allowed_unmatched=allowed_unmatched,
         reviewers=reviewers,
-        resolution="agreement",
-        notes=(),
+        resolution=resolution,
+        notes=notes,
         approved_at=approved_at,
     )

--- a/tests/segmenter_dataset/test_allowed_unmatched.py
+++ b/tests/segmenter_dataset/test_allowed_unmatched.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from segmenter_dataset.mechanical import validate_pairs
+from segmenter_dataset.schemas import Label
+
+
+def test_allowed_unmatched_is_scoped_to_the_exact_pair_base() -> None:
+    labels = [Label(start=0, end=5, category="cabecalho_inicio")]
+
+    assert (
+        validate_pairs(
+            labels,
+            allowed_unmatched={"cabecalho": "document ends after the opening anchor"},
+        )
+        == []
+    )
+
+    problems = validate_pairs(
+        labels,
+        allowed_unmatched={"ementa": "wrong pair"},
+    )
+    assert any("no declared allowed-unmatched reason" in problem for problem in problems)
+    assert any("no unmatched pair" in problem for problem in problems)

--- a/tests/segmenter_dataset/test_build_provenance.py
+++ b/tests/segmenter_dataset/test_build_provenance.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from segmenter_dataset.schemas import AnnotationQuality, ReleaseManifest
+
+
+def test_release_manifest_requires_full_hashes_and_ci_identity() -> None:
+    with pytest.raises(ValidationError):
+        ReleaseManifest(
+            release_id="segmenter-silver-v8.1",
+            ontology_version="segmenter-ontology-v8.0.0",
+            guideline_version="g1",
+            source_commit="abc123",
+            dependency_lock_hash="lock123",
+            ci_provider="",
+            ci_run_id="",
+            split_manifest_hash="x",
+            split_hashes={},
+            document_resolutions={},
+            annotation_quality=AnnotationQuality(),
+            iaa_seed=1,
+            iaa_resamples=1000,
+            created_at="2026-01-01T00:00:00Z",
+        )

--- a/tests/segmenter_dataset/test_gates.py
+++ b/tests/segmenter_dataset/test_gates.py
@@ -5,6 +5,7 @@ import pytest
 from segmenter_dataset.gates import (
     GateResult,
     GateSeverity,
+    InvalidKnownLimitationError,
     UnknownGateError,
     classify_gate,
     evaluate_gates,
@@ -26,20 +27,20 @@ def test_classify_gate_unknown_raises() -> None:
 
 
 def test_evaluate_gates_all_pass() -> None:
-    results = [GateResult(name="ontology_schema_valid", passed=True)]
-    evaluation = evaluate_gates(results, [])
+    evaluation = evaluate_gates([GateResult(name="ontology_schema_valid", passed=True)], [])
     assert evaluation.release_allowed is True
 
 
-def test_evaluate_gates_rigid_failure_blocks_even_with_known_limitation() -> None:
+def test_known_limitation_cannot_name_rigid_gate() -> None:
     results = [GateResult(name="ontology_schema_valid", passed=False, detail="bad offsets")]
-    # A known_limitation naming a rigid gate cannot waive it (RFC 0012 §12.1) —
-    # classify_gate still resolves it to RIGID regardless of what's in
-    # known_limitations, so evaluate_gates never consults the list for it.
     limitations = [KnownLimitation(gate="ontology_schema_valid", reason="please ignore")]
-    evaluation = evaluate_gates(results, limitations)
-    assert evaluation.release_allowed is False
-    assert len(evaluation.blocking_rigid_failures) == 1
+    with pytest.raises(InvalidKnownLimitationError):
+        evaluate_gates(results, limitations)
+
+
+def test_known_limitation_cannot_name_unknown_gate() -> None:
+    with pytest.raises(InvalidKnownLimitationError):
+        evaluate_gates([], [KnownLimitation(gate="invented", reason="no")])
 
 
 def test_evaluate_gates_advisory_failure_blocks_without_known_limitation() -> None:
@@ -51,9 +52,7 @@ def test_evaluate_gates_advisory_failure_blocks_without_known_limitation() -> No
 
 def test_evaluate_gates_advisory_failure_waived_by_known_limitation() -> None:
     results = [GateResult(name="multiple_tribunals", passed=False, detail="TJRO only")]
-    limitations = [
-        KnownLimitation(gate="multiple_tribunals", reason="v8.1 is explicitly TJRO-only")
-    ]
+    limitations = [KnownLimitation(gate="multiple_tribunals", reason="TJRO-only")]
     evaluation = evaluate_gates(results, limitations)
     assert evaluation.release_allowed is True
     assert len(evaluation.waived_advisory_failures) == 1

--- a/tests/segmenter_dataset/test_ids.py
+++ b/tests/segmenter_dataset/test_ids.py
@@ -3,46 +3,73 @@ from __future__ import annotations
 from segmenter_dataset.ids import annotation_id, document_id, review_id
 
 
+BASE_ANNOTATION = {
+    "document_id": "doc_" + "1" * 32,
+    "annotator_id": "haiku-run-1",
+    "annotator_config": {
+        "model_family": "haiku",
+        "guideline_version": "g1",
+        "seeded_with": "none",
+    },
+    "ontology_version": "segmenter-ontology-v8.0.0",
+    "covered_categories": ["x"],
+    "labels": [{"start": 0, "end": 5, "category": "x"}],
+    "allowed_unmatched": {},
+    "completed_at": "2026-01-01T00:00:00Z",
+    "annotation_method": "independent_full_read",
+}
+
+BASE_REVIEW = {
+    "document_id": "doc_" + "1" * 32,
+    "input_annotation_ids": ["ann_" + "a" * 32, "ann_" + "b" * 32],
+    "status": "accepted",
+    "final_labels": [{"start": 0, "end": 5, "category": "x"}],
+    "allowed_unmatched": {},
+    "reviewers": ["r1", "r2"],
+    "resolution": "agreement",
+    "notes": [],
+    "approved_at": "2026-01-02T00:00:00Z",
+}
+
+
 def test_document_id_deterministic() -> None:
     kwargs = {"source_system": "tjro_juris", "source_uri": "u1", "source_hash": "h1"}
     assert document_id(**kwargs) == document_id(**kwargs)
 
 
-def test_document_id_ignores_text_only_depends_on_source() -> None:
-    kwargs = {"source_system": "tjro_juris", "source_uri": "u1", "source_hash": "h1"}
-    a = document_id(**kwargs)
-    b = document_id(**kwargs)
-    assert a == b
-
-
 def test_document_id_differs_for_different_source() -> None:
-    a = document_id(source_system="tjro_juris", source_uri="u1", source_hash="h1")
-    b = document_id(source_system="tjro_juris", source_uri="u2", source_hash="h1")
-    assert a != b
+    first = document_id(source_system="tjro_juris", source_uri="u1", source_hash="h1")
+    second = document_id(source_system="tjro_juris", source_uri="u2", source_hash="h1")
+    assert first != second
 
 
-def test_annotation_id_differs_for_different_labels() -> None:
-    base = {
-        "document_id": "doc_1",
-        "annotator_id": "haiku",
-        "completed_at": "2026-01-01T00:00:00Z",
+def test_annotation_id_changes_for_every_semantic_field() -> None:
+    original = annotation_id(**BASE_ANNOTATION)
+    changed = dict(BASE_ANNOTATION)
+    changed["covered_categories"] = ["x", "y"]
+    assert annotation_id(**changed) != original
+
+    changed = dict(BASE_ANNOTATION)
+    changed["annotator_config"] = {
+        **BASE_ANNOTATION["annotator_config"],
+        "guideline_version": "g2",
     }
-    a = annotation_id(labels=[{"start": 0, "end": 5, "category": "x"}], **base)
-    b = annotation_id(labels=[{"start": 0, "end": 6, "category": "x"}], **base)
-    assert a != b
+    assert annotation_id(**changed) != original
 
 
 def test_annotation_id_same_content_same_id() -> None:
-    base = {
-        "document_id": "doc_1",
-        "annotator_id": "haiku",
-        "completed_at": "2026-01-01T00:00:00Z",
-        "labels": [{"start": 0, "end": 5, "category": "x"}],
-    }
-    assert annotation_id(**base) == annotation_id(**base)
+    assert annotation_id(**BASE_ANNOTATION) == annotation_id(**BASE_ANNOTATION)
 
 
-def test_review_id_order_independent_on_input_annotation_ids() -> None:
-    a = review_id(document_id="doc_1", input_annotation_ids=["ann_a", "ann_b"], approved_at="t")
-    b = review_id(document_id="doc_1", input_annotation_ids=["ann_b", "ann_a"], approved_at="t")
-    assert a == b
+def test_review_id_order_independent_on_inputs_and_reviewers() -> None:
+    first = review_id(**BASE_REVIEW)
+    changed = dict(BASE_REVIEW)
+    changed["input_annotation_ids"] = list(reversed(BASE_REVIEW["input_annotation_ids"]))
+    changed["reviewers"] = list(reversed(BASE_REVIEW["reviewers"]))
+    assert review_id(**changed) == first
+
+
+def test_review_id_changes_when_final_labels_change() -> None:
+    changed = dict(BASE_REVIEW)
+    changed["final_labels"] = [{"start": 0, "end": 6, "category": "x"}]
+    assert review_id(**changed) != review_id(**BASE_REVIEW)

--- a/tests/segmenter_dataset/test_release.py
+++ b/tests/segmenter_dataset/test_release.py
@@ -6,9 +6,13 @@ import pytest
 from conftest import make_annotation, make_document, make_review
 
 from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
-from segmenter_dataset.schemas import KnownLimitation, Label
-from segmenter_dataset.splits import SplitAssignment, SplitLeakError
-from segmenter_dataset.store import SegmenterDatasetStore
+from segmenter_dataset.schemas import Label
+from segmenter_dataset.splits import (
+    SplitAssignment,
+    build_groups,
+    create_split_manifest,
+)
+from segmenter_dataset.store import ImmutabilityError, SegmenterDatasetStore
 
 
 ONTOLOGY = {"cabecalho_inicio", "cabecalho_fim"}
@@ -16,168 +20,192 @@ PAIR_LABELS = [
     Label(start=0, end=5, category="cabecalho_inicio"),
     Label(start=10, end=15, category="cabecalho_fim"),
 ]
+SOURCE_COMMIT = "a" * 40
+LOCK_HASH = "b" * 64
 
 
 def _text_for(role: str, index: int) -> str:
-    # Unique per document — sharing text across documents would (correctly)
-    # trip the cross-split content-hash leakage gate.
     return f"0123{role}{index:03d}89ABCDEFGHIJ"
 
 
 def _seed_release(
-    store: SegmenterDatasetStore, *, n_train: int, n_val: int, n_test: int
-) -> SplitAssignment:
+    store: SegmenterDatasetStore,
+    *,
+    n_train: int,
+    n_val: int,
+    n_test: int,
+    same_eval_run: bool = False,
+):
     train_ids: set[str] = set()
     val_ids: set[str] = set()
     test_ids: set[str] = set()
 
-    for i in range(n_train):
-        doc = make_document(text=_text_for("train", i), source_uri=f"train-{i}")
-        store.write_document(doc)
-        annotation = make_annotation(
-            doc, labels=PAIR_LABELS, covered_categories=("cabecalho_inicio", "cabecalho_fim")
+    for index in range(n_train):
+        document = make_document(text=_text_for("train", index), source_uri=f"train-{index}")
+        store.write_document(document)
+        store.write_annotation(
+            make_annotation(
+                document,
+                labels=PAIR_LABELS,
+                covered_categories=tuple(sorted(ONTOLOGY)),
+            )
         )
-        store.write_annotation(annotation)
-        train_ids.add(doc.document_id)
+        train_ids.add(document.document_id)
 
-    for role, n, ids in (("val", n_val, val_ids), ("test", n_test, test_ids)):
-        for i in range(n):
-            doc = make_document(text=_text_for(role, i), source_uri=f"{role}-{i}")
-            store.write_document(doc)
-            ann_a = make_annotation(
-                doc,
-                annotator_id="a",
-                model_family="fam-a",
+    for role, count, ids in (("val", n_val, val_ids), ("test", n_test, test_ids)):
+        for index in range(count):
+            document = make_document(text=_text_for(role, index), source_uri=f"{role}-{index}")
+            store.write_document(document)
+            annotation_a = make_annotation(
+                document,
+                annotator_id="same-run" if same_eval_run else "run-a",
+                model_family="same-family" if same_eval_run else "fam-a",
+                completed_at="2026-01-01T00:00:00Z",
                 labels=PAIR_LABELS,
-                covered_categories=("cabecalho_inicio", "cabecalho_fim"),
+                covered_categories=tuple(sorted(ONTOLOGY)),
             )
-            ann_b = make_annotation(
-                doc,
-                annotator_id="b",
-                model_family="fam-b",
+            annotation_b = make_annotation(
+                document,
+                annotator_id="same-run" if same_eval_run else "run-b",
+                model_family="same-family" if same_eval_run else "fam-b",
+                completed_at="2026-01-01T00:00:01Z",
                 labels=PAIR_LABELS,
-                covered_categories=("cabecalho_inicio", "cabecalho_fim"),
+                covered_categories=tuple(sorted(ONTOLOGY)),
             )
-            store.write_annotation(ann_a)
-            store.write_annotation(ann_b)
-            review = make_review(doc, [ann_a, ann_b], final_labels=PAIR_LABELS)
-            store.write_review(review)
-            ids.add(doc.document_id)
+            store.write_annotation(annotation_a)
+            store.write_annotation(annotation_b)
+            store.write_review(
+                make_review(document, [annotation_a, annotation_b], final_labels=PAIR_LABELS)
+            )
+            ids.add(document.document_id)
 
-    return SplitAssignment(
-        train_ids=frozenset(train_ids), val_ids=frozenset(val_ids), test_ids=frozenset(test_ids)
+    assignment = SplitAssignment(
+        train_ids=frozenset(train_ids),
+        val_ids=frozenset(val_ids),
+        test_ids=frozenset(test_ids),
+    )
+    documents = store.list_documents()
+    groups = build_groups(documents, near_duplicate_threshold=0.99)
+    return create_split_manifest(
+        assignment,
+        groups,
+        seed=7,
+        train_ratio=0.70,
+        val_ratio=0.15,
+        near_duplicate_threshold=0.99,
     )
 
 
-def test_build_dataset_release_succeeds_with_sufficient_support(tmp_path: Path) -> None:
+def _build(store: SegmenterDatasetStore, split_manifest, **overrides):
+    kwargs = {
+        "release_id": "segmenter-silver-v8.1",
+        "ontology_version": "segmenter-ontology-v8.0.0",
+        "guideline_version": "g1",
+        "source_commit": SOURCE_COMMIT,
+        "dependency_lock_hash": LOCK_HASH,
+        "ci_provider": "github-actions",
+        "ci_run_id": "12345",
+        "ontology_categories": ONTOLOGY,
+        "split_manifest": split_manifest,
+        "iaa_seed": 1,
+        "iaa_resamples": 100,
+    }
+    kwargs.update(overrides)
+    return build_dataset_release(store, **kwargs)
+
+
+def test_build_dataset_release_succeeds_and_writes_auditable_artifacts(
+    tmp_path: Path,
+) -> None:
     store = SegmenterDatasetStore(tmp_path)
-    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5)
 
-    manifest = build_dataset_release(
-        store,
-        release_id="segmenter-silver-v8.1",
-        ontology_version="segmenter-ontology-v8.0.0",
-        guideline_version="g1",
-        source_commit="abc123",
-        dependency_lock_hash="lock123",
-        ontology_categories=ONTOLOGY,
-        split_assignment=assignment,
-        iaa_seed=1,
-    )
+    manifest = _build(store, split_manifest)
 
     assert manifest.counts == {"train": 10, "validation": 5, "test": 5}
     assert manifest.annotation_quality.val_iaa_span_f1 == 1.0
-    assert manifest.annotation_quality.test_iaa_span_f1 == 1.0
-    assert manifest.annotation_quality.unreliable_eval_categories == ()
+    release_dir = store.release_dir(manifest.release_id)
+    assert (release_dir / "manifest.json").exists()
+    assert (release_dir / "split_manifest.json").exists()
+    assert (release_dir / "checksums.sha256").exists()
+    assert manifest.iaa_seed == 1
+    assert manifest.iaa_resamples == 100
 
-    # RFC 0012 §12 step 9: refuses to overwrite an existing release.
-    with pytest.raises(Exception, match="already exists"):
-        build_dataset_release(
-            store,
-            release_id="segmenter-silver-v8.1",
-            ontology_version="segmenter-ontology-v8.0.0",
-            guideline_version="g1",
-            source_commit="abc123",
-            dependency_lock_hash="lock123",
-            ontology_categories=ONTOLOGY,
-            split_assignment=assignment,
-            iaa_seed=1,
-        )
+    with pytest.raises(ImmutabilityError, match="already exists"):
+        _build(store, split_manifest)
 
 
-def test_build_dataset_release_blocked_by_insufficient_train_support(tmp_path: Path) -> None:
+def test_zero_support_category_blocks_release(tmp_path: Path) -> None:
     store = SegmenterDatasetStore(tmp_path)
-    assignment = _seed_release(store, n_train=2, n_val=5, n_test=5)
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5)
 
     with pytest.raises(ReleaseBlockedError) as exc_info:
-        build_dataset_release(
-            store,
-            release_id="segmenter-silver-v8.1",
-            ontology_version="segmenter-ontology-v8.0.0",
-            guideline_version="g1",
-            source_commit="abc123",
-            dependency_lock_hash="lock123",
-            ontology_categories=ONTOLOGY,
-            split_assignment=assignment,
-            iaa_seed=1,
-        )
-    gate_names = {g.name for g in exc_info.value.gate_results}
+        _build(store, split_manifest, ontology_categories=ONTOLOGY | {"resultado"})
+
+    gate_names = {gate.name for gate in exc_info.value.gate_results}
     assert "train_minimum_support_per_category" in gate_names
+    assert "val_minimum_support_for_reported_metrics" in gate_names
 
 
-def test_build_dataset_release_raises_when_val_document_not_adjudicated(tmp_path: Path) -> None:
+def test_non_independent_eval_annotations_block_release(tmp_path: Path) -> None:
     store = SegmenterDatasetStore(tmp_path)
-    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5, same_eval_run=True)
 
-    # Add one more document with only an annotation (no review) but assign
-    # it to val — a document that hasn't reached the role's required state.
-    unreviewed = make_document(text="0123456789ABCDEFGHIJ", source_uri="val-unreviewed")
-    store.write_document(unreviewed)
-    store.write_annotation(
-        make_annotation(
-            unreviewed,
-            labels=PAIR_LABELS,
-            covered_categories=("cabecalho_inicio", "cabecalho_fim"),
-        )
-    )
-    broken_assignment = SplitAssignment(
-        train_ids=assignment.train_ids,
-        val_ids=assignment.val_ids | {unreviewed.document_id},
-        test_ids=assignment.test_ids,
-    )
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        _build(store, split_manifest)
 
-    with pytest.raises(SplitLeakError, match="no accepted review record"):
-        build_dataset_release(
-            store,
-            release_id="segmenter-silver-v8.1",
-            ontology_version="segmenter-ontology-v8.0.0",
-            guideline_version="g1",
-            source_commit="abc123",
-            dependency_lock_hash="lock123",
-            ontology_categories=ONTOLOGY,
-            split_assignment=broken_assignment,
-            iaa_seed=1,
-        )
+    assert "val_test_independently_adjudicated" in {
+        gate.name for gate in exc_info.value.gate_results
+    }
 
 
-def test_build_dataset_release_advisory_gate_waived_by_known_limitation(tmp_path: Path) -> None:
+def test_review_with_missing_annotation_blocks_release(tmp_path: Path) -> None:
     store = SegmenterDatasetStore(tmp_path)
-    assignment = _seed_release(store, n_train=10, n_val=5, n_test=5)
-
-    # multiple_tribunals is never automatically evaluated as failing in this
-    # module (single-tribunal fixtures don't run that gate at all here) —
-    # this test instead verifies a rigid-gate detail: an unrelated known
-    # limitation does not mask a real rigid failure.
-    manifest = build_dataset_release(
-        store,
-        release_id="segmenter-silver-v8.2",
-        ontology_version="segmenter-ontology-v8.0.0",
-        guideline_version="g1",
-        source_commit="abc123",
-        dependency_lock_hash="lock123",
-        ontology_categories=ONTOLOGY,
-        split_assignment=assignment,
-        known_limitations=[KnownLimitation(gate="multiple_tribunals", reason="TJRO-only for v8.1")],
-        iaa_seed=1,
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5)
+    review = store.list_reviews()[0]
+    review_path = store.reviews_dir / review.document_id / f"{review.review_id}.json"
+    broken = review.model_copy(
+        update={
+            "input_annotation_ids": (
+                review.input_annotation_ids[0],
+                "ann_" + "f" * 32,
+            )
+        }
     )
-    assert manifest.known_limitations[0].gate == "multiple_tribunals"
+    review_path.write_text(broken.model_dump_json(indent=2), encoding="utf-8")
+
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        _build(store, split_manifest)
+
+    assert "no_unresolved_annotation_conflicts" in {
+        gate.name for gate in exc_info.value.gate_results
+    }
+
+
+def test_release_recomputes_groups_and_rejects_manual_cross_split_near_duplicate(
+    tmp_path: Path,
+) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5)
+    train_id = split_manifest.train_ids[0]
+    val_id = split_manifest.val_ids[0]
+    train_doc = store.read_document(train_id)
+    val_doc = store.read_document(val_id)
+    val_path = store.documents_dir / f"{val_id}.json"
+    near_duplicate = val_doc.model_copy(update={"text": train_doc.text + " "})
+    val_path.write_text(near_duplicate.model_dump_json(indent=2), encoding="utf-8")
+
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        _build(store, split_manifest)
+
+    assert "split_disjoint_by_group_id_hash" in {gate.name for gate in exc_info.value.gate_results}
+
+
+def test_incomplete_build_provenance_blocks_release(tmp_path: Path) -> None:
+    store = SegmenterDatasetStore(tmp_path)
+    split_manifest = _seed_release(store, n_train=10, n_val=5, n_test=5)
+
+    with pytest.raises(ReleaseBlockedError) as exc_info:
+        _build(store, split_manifest, source_commit="abc123")
+
+    assert "ci_reproducible_build" in {gate.name for gate in exc_info.value.gate_results}

--- a/tests/segmenter_dataset/test_review_lineage.py
+++ b/tests/segmenter_dataset/test_review_lineage.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from conftest import make_annotation, make_document, make_review
+
+from segmenter_dataset.mechanical import validate_review_lineage
+
+
+ONTOLOGY = {"cabecalho_inicio", "cabecalho_fim"}
+
+
+def test_review_lineage_rejects_same_run_and_family() -> None:
+    document = make_document()
+    first = make_annotation(
+        document,
+        annotator_id="same-run",
+        model_family="same-family",
+        completed_at="2026-01-01T00:00:00Z",
+        covered_categories=tuple(sorted(ONTOLOGY)),
+    )
+    second = make_annotation(
+        document,
+        annotator_id="same-run",
+        model_family="same-family",
+        completed_at="2026-01-01T00:00:01Z",
+        covered_categories=tuple(sorted(ONTOLOGY)),
+    )
+    review = make_review(document, [first, second])
+
+    problems = validate_review_lineage(
+        review,
+        {first.annotation_id: first, second.annotation_id: second},
+        ontology_version="segmenter-ontology-v8.0.0",
+        ontology_categories=ONTOLOGY,
+    )
+
+    assert any("independent execution" in problem for problem in problems)

--- a/tests/segmenter_dataset/test_split_manifest.py
+++ b/tests/segmenter_dataset/test_split_manifest.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from conftest import make_document
+
+from segmenter_dataset.splits import (
+    GroupingKeys,
+    SplitAssignment,
+    build_groups,
+    create_split_manifest,
+)
+
+
+def test_grouping_keys_are_loaded_from_document_records() -> None:
+    first = make_document(
+        source_uri="u1",
+        text="documento A",
+        normalized_process_number="0001234",
+    )
+    second = make_document(
+        source_uri="u2",
+        text="documento B completamente diferente",
+        normalized_process_number="0001234",
+    )
+
+    keys = [
+        GroupingKeys.from_document(first),
+        GroupingKeys.from_document(second),
+    ]
+    groups = build_groups([first, second], keys)
+
+    assert len(groups) == 1
+
+
+def test_split_manifest_records_reproducibility_parameters() -> None:
+    assignment = SplitAssignment(
+        train_ids=frozenset({"doc_a"}),
+        val_ids=frozenset({"doc_b"}),
+        test_ids=frozenset({"doc_c"}),
+    )
+    groups = {
+        "doc_a": frozenset({"doc_a"}),
+        "doc_b": frozenset({"doc_b"}),
+        "doc_c": frozenset({"doc_c"}),
+    }
+
+    manifest = create_split_manifest(
+        assignment,
+        groups,
+        seed=42,
+        train_ratio=0.70,
+        val_ratio=0.15,
+        near_duplicate_threshold=0.91,
+    )
+
+    assert manifest.seed == 42
+    assert manifest.train_ratio == 0.70
+    assert manifest.val_ratio == 0.15
+    assert manifest.near_duplicate_threshold == 0.91
+    assert manifest.groups["doc_a"] == ("doc_a",)

--- a/tests/segmenter_dataset/test_store.py
+++ b/tests/segmenter_dataset/test_store.py
@@ -12,15 +12,14 @@ def test_write_and_read_document_round_trips(tmp_path: Path) -> None:
     store = SegmenterDatasetStore(tmp_path)
     document = make_document()
     store.write_document(document)
-    reloaded = store.read_document(document.document_id)
-    assert reloaded == document
+    assert store.read_document(document.document_id) == document
 
 
 def test_write_document_twice_same_content_is_noop(tmp_path: Path) -> None:
     store = SegmenterDatasetStore(tmp_path)
     document = make_document()
     store.write_document(document)
-    store.write_document(document)  # should not raise
+    store.write_document(document)
     assert len(store.list_documents()) == 1
 
 
@@ -28,9 +27,6 @@ def test_write_document_same_id_different_content_raises(tmp_path: Path) -> None
     store = SegmenterDatasetStore(tmp_path)
     document = make_document()
     store.write_document(document)
-
-    # Force a collision: same document_id, different text, bypassing the
-    # normal content-addressing path to simulate a hash-collision bug.
     forged = document.model_copy(update={"text": "different text entirely"})
     with pytest.raises(ImmutabilityError):
         store.write_document(forged)
@@ -44,7 +40,6 @@ def test_list_annotations_filters_by_document(tmp_path: Path) -> None:
     store.write_document(doc_b)
     store.write_annotation(make_annotation(doc_a))
     store.write_annotation(make_annotation(doc_b))
-
     assert len(store.list_annotations()) == 2
     assert len(store.list_annotations(document_id=doc_a.document_id)) == 1
 
@@ -57,11 +52,16 @@ def test_write_release_manifest_refuses_overwrite(tmp_path: Path) -> None:
         release_id="segmenter-silver-v8.1",
         ontology_version="segmenter-ontology-v8.0.0",
         guideline_version="g1",
-        source_commit="abc123",
-        dependency_lock_hash="lock123",
-        split_hashes={"train": "t", "validation": "v", "test": "s"},
+        source_commit="a" * 40,
+        dependency_lock_hash="b" * 64,
+        ci_provider="github-actions",
+        ci_run_id="1",
+        split_manifest_hash="c" * 64,
+        split_hashes={"train": "d" * 64, "validation": "e" * 64, "test": "f" * 64},
         document_resolutions={"train": {}, "validation": {}, "test": {}},
         annotation_quality=AnnotationQuality(),
+        iaa_seed=1,
+        iaa_resamples=1000,
         created_at="2026-01-01T00:00:00Z",
     )
     store.write_release_manifest(manifest)

--- a/tests/segmenter_dataset/test_zero_support.py
+++ b/tests/segmenter_dataset/test_zero_support.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from segmenter_dataset.release import _support_gates
+
+
+def test_support_gates_count_absent_ontology_categories_as_zero() -> None:
+    train_gate, val_gate = _support_gates([], [], {"resultado"})
+
+    assert train_gate.passed is False
+    assert val_gate.passed is False
+    assert "'resultado': 0" in train_gate.detail
+    assert "'resultado': 0" in val_gate.detail


### PR DESCRIPTION
## Description

Stacked fix PR on top of #838. It closes the release-integrity gaps found during review without adding corpus data or training behavior.

### What changed

- support gates now iterate the full ontology, so categories with zero observations fail instead of disappearing from the count map;
- accepted evaluation reviews must resolve real, distinct, independent annotation records from the same document and ontology;
- the release builder recomputes exact/near-duplicate, process, family and parent grouping instead of trusting an editable ID-only split file;
- `DocumentRecord.grouping` makes the RFC grouping keys available to the official CLI;
- split manifests persist seed, ratios, near-duplicate threshold and the group membership used by assignment;
- annotation/review IDs hash all semantically relevant fields, preventing immutable-store collisions;
- unmatched start/end exceptions are persisted as per-pair reasons and validated exactly;
- previously constant gates now validate actual lineage, hashes and full CI build provenance;
- releases publish `manifest.json`, `split_manifest.json`, and a verified `checksums.sha256` sidecar, including the IAA seed/resample count.

### Adversarial tests

Adds regressions for zero-support categories, same-run “independent” annotations, missing review inputs, manually split near-duplicates, invalid build provenance, scoped unmatched-pair reasons, complete artifact IDs, and reproducible split metadata.

## Test plan

- [x] Local isolated package tests: 51 passed
- [x] Repository CI: lint/format/dead-code, TJRO tests, and web lint/test/build

Depends on #838 and should be reviewed/merged after it.