### PR TITLE
RFC 0012 PR2 (docs): annotation guideline revisions v7.1-v7.3 + dataset card generator

### DIFF
--- a/data/segmenter_splits/annotation_guideline_v7.md
+++ b/data/segmenter_splits/annotation_guideline_v7.md
@@ -1,47 +1,7 @@
 # Annotation Guideline — CausaGanha Decision Segmenter v7.3
 
-Revision v7.1 (RFC 0012 §9, guideline-only change per §5 point 1's last
-bullet — does not invalidate v7 annotations, no `ontology_version` bump):
-fixes three gaps a single-document pilot found (see the RFC's PR history
-for the pilot transcript) — header phrase ordering, the
-`relatorio`-without-`capitulo_merito` case, and `ref_processual` scope. A
-second pilot on the same document, run against this revision, confirmed
-convergence on all three and also caught an unrelated production-technique
-failure (text duplication instead of in-place wrapping); Rule 6 was
-extended in response. A verbatim mismatch is a risk signal that routes a
-record to independent review (RFC 0012 §9), not an automatic rejection —
-it isn't a rigid release invariant. Marked inline below as **[v7.1]**.
-
-Revision v7.2 (RFC 0012 §5 point 7, guideline-only change, same
-non-invalidating rule as v7.1): the first real batch (5 documents beyond
-the pilot) showed the "single-anchor = at most one per document" default
-doesn't fit every single-anchor category. `dispositivo_abertura`,
-`resultado`, and `ref_processual` are genuinely singular — they each name
-one fact about the decision as a whole (the operative holding; which case
-this text belongs to). `fundamentacao_legal` and `valor_condenacao` are
-not: a real decision routinely cites the law more than once for different
-points, and can state more than one genuinely different amount (moral vs.
-material damages, an original vs. a corrected figure). Deduplicating those
-down to "first occurrence" — which both ingestion scripts did — silently
-drops real signal; a document citing art. 38 for the relatório waiver and
-art. 55 for custas/honorários has two distinct `fundamentacao_legal`
-spans, not one. `ALLOW_MULTIPLE_SINGLE_ANCHOR` in
-`segmenter_dataset/ontology.py` now names the two categories exempted from
-the one-per-document mechanical check; every `validate_record` call site
-passes it. Marked inline below as **[v7.2]**.
-
-Revision v7.3 (production technique only — Rule 6, no ontology or category
-semantics change): a flat `<relatorio_inicio>`/`<relatorio_fim>` pair is
-two unrelated tag names that happen to share a prefix; XML already has a
-native way to say "these two things bound one region" — nesting. Start/end
-pairs are now produced as one `<base>` wrapper element (named after the
-category, e.g. `relatorio`) with generic `<inicio>`/`<fim>` children
-reused across every pair category, instead of inventing a distinct flat
-tag name per role. Anything else that textually falls inside the region —
-another category's anchor, like `ref_processual` sitting inside a
-document's `cabecalho` — nests inside the wrapper too. Single-anchor
-categories are unaffected; there's no region to express, so they stay
-flat leaf tags exactly as before. Marked inline below as **[v7.3]**.
+Revision history: see `annotation_guideline_v7_CHANGELOG.md`. This file is
+the current rules only.
 
 ## Overview
 
@@ -57,9 +17,9 @@ Mark the **opening cue** only (a few words). The region extends from this
 anchor to the next anchor or end of document. Never label a long region
 as one span.
 
-**[v7.2] Most single-anchor categories name one fact about the decision as
-a whole and take at most one tag per document** — `dispositivo_abertura`
-and `resultado` because only the *operative* mention counts (Rules 2-3),
+Most single-anchor categories name one fact about the decision as a whole
+and take **at most one tag per document** — `dispositivo_abertura` and
+`resultado` because only the *operative* mention counts (Rules 2-3),
 `ref_processual` because its job is linking this text to exactly one case
 (a multi-valued link is useless). `fundamentacao_legal` and
 `valor_condenacao` are different: tag **every** distinct occurrence, not
@@ -69,10 +29,10 @@ just the first. See each row below for specifics.
 |---|---|---|
 | `dispositivo_abertura` | The formulaic opening of the operative part | "Ante o exposto" / "Pelo exposto" / "Posto isso" |
 | `resultado` | The operative verb phrase | "julgo procedente" / "nego provimento" / "extingo o feito" |
-| `ref_processual` | **[v7.2] This document's own docket only** — the case number (CNJ format) or "fls." folio reference identifying the decision being read, for record-linking. Not a generic internal system/attachment ID ("ID 66115008") even when it looks superficially similar; if in doubt whether a number is CNJ-format or a folio pointer, don't tag it. **Leave every *other* case's number untagged** — a prior conviction, a cited precedent's process number — even if it's genuinely CNJ-format; that's expected, not an omission, since this category exists to identify *this* document's case, not to catalog every case number it mentions | "1234567-89.0123.4.56.7890" / "fls. 42" |
-| `valor_condenacao` | Monetary amount in a condemnation — **[v7.2] tag every genuinely distinct amount.** A document with moral damages of R$5.000,00 *and* material damages of R$2.000,00 has two spans, not one; if the same figure is simply restated in a later clause, tag that occurrence too — repeats aren't an error here | "R$ 5.000,00" |
+| `ref_processual` | **This document's own docket only** — the case number (CNJ format) or "fls." folio reference identifying the decision being read, for record-linking. Not a generic internal system/attachment ID ("ID 66115008") even when it looks superficially similar; if in doubt whether a number is CNJ-format or a folio pointer, don't tag it. **Leave every *other* case's number untagged** — a prior conviction, a cited precedent's process number — even if it's genuinely CNJ-format; that's expected, not an omission, since this category exists to identify *this* document's case, not to catalog every case number it mentions | "1234567-89.0123.4.56.7890" / "fls. 42" |
+| `valor_condenacao` | Monetary amount in a condemnation — **tag every genuinely distinct amount.** A document with moral damages of R$5.000,00 *and* material damages of R$2.000,00 has two spans, not one; if the same figure is simply restated in a later clause, tag that occurrence too — repeats aren't an error here | "R$ 5.000,00" |
 | `ref_normativa` | Citation of statute, article, or precedent | "art. 927 do CPC" / "Súmula 331 do TST" |
-| `fundamentacao_legal` | Legal reasoning phrase citing authority — **[v7.2] tag every distinct citation**, not just the first. A decision citing art. 38 to waive the relatório and art. 55 for custas/honorários has two spans | "nos termos do art. 932 do CPC" |
+| `fundamentacao_legal` | Legal reasoning phrase citing authority — **tag every distinct citation**, not just the first. A decision citing art. 38 to waive the relatório and art. 55 for custas/honorários has two spans | "nos termos do art. 932 do CPC" |
 
 ### Start/end pairs (10 region types, 20 categories)
 
@@ -82,10 +42,10 @@ cue exists, the `_inicio` extends to EOD (reconstructed as unmatched).
 
 | Base | `_inicio` example | `_fim` example |
 |---|---|---|
-| `cabecalho` | **[v7.1] Whichever institutional phrase starts the header block first** — "TRIBUNAL DE JUSTIÇA..." and "PODER JUDICIÁRIO" both appear, in either order depending on source; tag the one that comes first in this document, not literally the string "PODER JUDICIÁRIO" | Last party/OAB before SENTENÇA |
+| `cabecalho` | Whichever institutional phrase starts the header block first — "TRIBUNAL DE JUSTIÇA..." and "PODER JUDICIÁRIO" both appear, in either order depending on source; tag the one that comes first in this document, not literally the string "PODER JUDICIÁRIO" | Last party/OAB before SENTENÇA |
 | `ementa` | "EMENTA:" | Last line before RELATÓRIO |
-| `relatorio` | The "Relatório"/"RELATÓRIO:" heading when one is present, even if immediately followed by a waiver clause ("dispensado na forma do art. 38..."); if genuinely no heading word appears, "Trata-se de" | "É o relatório." — **[v7.1] a waiver clause is not a closing cue.** "Relatório dispensado na forma do art. 38..." explains *why* there's no report, it doesn't close one — tag it as `fundamentacao_legal` (it cites a statute) if it qualifies, not `relatorio_fim`. Leave `relatorio_fim` unmatched (declared reason: "relatório dispensado, sem cue de fechamento") when no real closing phrase exists |
-| `capitulo_merito` | "DO MÉRITO:" / "DECIDO" / "Mérito:" — **[v7.1] many documents (short Juizados Especiais decisions especially) have no such heading at all.** That's expected, not an error — don't force a `capitulo_merito` tag onto plain reasoning prose. Zero instances of a category in a document is a valid outcome; `relatorio`'s implicit region simply extends to `dispositivo_abertura` instead | "DISPOSITIVO" / start of dispositivo |
+| `relatorio` | The "Relatório"/"RELATÓRIO:" heading when one is present, even if immediately followed by a waiver clause ("dispensado na forma do art. 38..."); if genuinely no heading word appears, "Trata-se de" | "É o relatório." A waiver clause is not a closing cue — "Relatório dispensado na forma do art. 38..." explains *why* there's no report, it doesn't close one — tag it as `fundamentacao_legal` (it cites a statute) if it qualifies, not `relatorio_fim`. Leave `relatorio_fim` unmatched (declared reason: "relatório dispensado, sem cue de fechamento") when no real closing phrase exists |
+| `capitulo_merito` | "DO MÉRITO:" / "DECIDO" / "Mérito:" — many documents (short Juizados Especiais decisions especially) have no such heading at all. That's expected, not an error — don't force a `capitulo_merito` tag onto plain reasoning prose. Zero instances of a category in a document is a valid outcome; `relatorio`'s implicit region simply extends to `dispositivo_abertura` instead | "DISPOSITIVO" / start of dispositivo |
 | `preliminar` | "DAS PRELIMINARES" / "PRELIMINAR" | End of preliminary analysis |
 | `honorarios` | "HONORÁRIOS:" / "Dos honorários" / "Sem honorários" | End of fee determination |
 | `custas` | "CUSTAS:" / "Das custas" / "Sem custas" | End of costs determination |
@@ -111,7 +71,7 @@ individual `voto` as the decision's operative opening. In a sentença
 4. **Trim whitespace** — span boundaries must not include leading or
    trailing spaces.
 5. **No overlapping spans** — OPF BIOES assigns one label per token.
-6. **[v7.1] Production technique: reproduce, don't compute offsets.**
+6. **Production technique: reproduce, don't compute offsets.**
    Reproduce the ENTIRE document text verbatim — character-for-character,
    no corrections, no normalization — inserting inline XML tags around
    each anchor span. Never report `start`/`end` as integers; they're
@@ -121,12 +81,13 @@ individual `voto` as the decision's operative opening. In a sentença
    trimmed, no overlap) — it's the same span, just placed inline instead
    of reported as offsets.
 
-   **[v7.3] Single-anchor categories** (the 6-category table) get one
-   flat tag named after the category: `<ref_processual>7059080-46.2021.8.22.0001</ref_processual>`.
+   **Single-anchor categories** (the 6-category table) get one flat tag
+   named after the category:
+   `<ref_processual>7059080-46.2021.8.22.0001</ref_processual>`.
 
-   **[v7.3] Start/end pairs nest, using XML's own open/close structure —
-   don't invent a separate tag name per role.** Wrap the whole region in
-   one element named after the category base, with generic `<inicio>` and
+   **Start/end pairs nest, using XML's own open/close structure — don't
+   invent a separate tag name per role.** Wrap the whole region in one
+   element named after the category base, with generic `<inicio>` and
    `<fim>` children (reused across every pair category — never
    `<cabecalho_inicio>`):
 
@@ -146,16 +107,11 @@ individual `voto` as the decision's operative opening. In a sentença
    with one child — `<relatorio><inicio>Relatório</inicio></relatorio>` —
    don't fabricate a closing tag and don't leave the wrapper off.
 
-   **Wrap the existing text in place — never retype or duplicate it.** A
-   second pilot on this same document caught a real failure: the model
-   typed the header phrase once plain, then typed it *again* inside a tag
-   right after, instead of wrapping the one occurrence it had already
-   produced. The output was valid XML but no longer a verbatim
-   reconstruction of the source — a silent corruption that only a
-   text-identity check against the original document catches. Such a
-   mismatch isn't an automatic rejection (RFC 0012 §9) but it does route
-   the record to independent review, so getting it right the first time
-   saves a review cycle. If you notice you already emitted a phrase
+   **Wrap the existing text in place — never retype or duplicate it.**
+   Typing a phrase once plain and then typing it *again* inside a tag,
+   instead of wrapping the occurrence you already produced, gives valid
+   XML that is no longer a verbatim reconstruction of the source — a
+   silent corruption. If you notice you already emitted a phrase
    untagged, go back and add the tag around it — don't emit it a second
    time.
 

--- a/data/segmenter_splits/annotation_guideline_v7_CHANGELOG.md
+++ b/data/segmenter_splits/annotation_guideline_v7_CHANGELOG.md
@@ -1,0 +1,81 @@
+# Annotation Guideline Changelog
+
+Revision history for `annotation_guideline_v7.md`. Kept out of the guideline
+itself so an annotator (LLM or human) reading it fresh gets only the current
+rules, not the narrative of how they got that way — this file is for anyone
+tracing *why* a rule reads the way it does, not for annotation-time reading.
+
+Every entry here is a guideline-only change per RFC 0012 §5 point 1's last
+bullet: none invalidate prior annotations, none bump `ontology_version`.
+
+## v7.1 (RFC 0012 §9)
+
+Fixed three gaps a single-document pilot found (see the RFC's PR history for
+the pilot transcript):
+
+- **Header phrase ordering** — the guideline said to tag literally "PODER
+  JUDICIÁRIO" as `cabecalho_inicio`; real documents sometimes lead with
+  "TRIBUNAL DE JUSTIÇA..." instead, in either order depending on source. Fix:
+  tag whichever institutional phrase starts the header block first.
+- **`relatorio`/`capitulo_merito` gaps** — a waiver clause ("Relatório
+  dispensado na forma do art. 38...") explains why there's no report, it
+  doesn't close one; it isn't a `relatorio_fim` closing cue. Many documents
+  (short Juizados Especiais decisions especially) have no `capitulo_merito`
+  heading at all — zero instances is a valid outcome, not an error.
+- **`ref_processual` scope** — the model had tagged a generic internal
+  attachment ID ("ID 66115008") as if it were a case number. Fix: must be
+  CNJ-format or a genuine `fls.` folio pointer, not a generic internal ID.
+
+A second pilot on the same document, run against this revision, confirmed
+convergence on all three and also caught an unrelated production-technique
+failure: text duplication instead of in-place wrapping (the model typed a
+phrase once plain, then typed it again inside a tag, instead of wrapping the
+occurrence it had already produced). Rule 6 was extended in response with an
+explicit "wrap in place, never retype" instruction. A verbatim mismatch is a
+risk signal that routes a record to independent review (RFC 0012 §9), not an
+automatic rejection — it isn't a rigid release invariant.
+
+## v7.2 (RFC 0012 §5 point 7)
+
+The first real batch (5 documents beyond the pilot) showed the
+"single-anchor = at most one per document" mechanical default doesn't fit
+every single-anchor category. `dispositivo_abertura`, `resultado`, and
+`ref_processual` are genuinely singular — they each name one fact about the
+decision as a whole (the operative holding; which case this text belongs
+to, for record-linking). `fundamentacao_legal` and `valor_condenacao` are
+not: a real decision routinely cites the law more than once for different
+points, and can state more than one genuinely different amount (moral vs.
+material damages, an original vs. a corrected figure). Deduplicating those
+down to "first occurrence" — which both ingestion scripts did at the time —
+silently dropped real signal; a document citing art. 38 for the relatório
+waiver and art. 55 for custas/honorários has two distinct
+`fundamentacao_legal` spans, not one.
+
+`ALLOW_MULTIPLE_SINGLE_ANCHOR` in `segmenter_dataset/ontology.py` now names
+the two categories exempted from the one-per-document mechanical check;
+every `validate_record` call site passes it.
+
+Also narrowed `ref_processual`'s v7.1 fix: the guideline now says "this
+document's own docket only," justified by the record-linking use case, not
+merely "avoid generic internal IDs" (which is a real but separate criterion,
+kept alongside it).
+
+## v7.3 (production technique only — Rule 6, no ontology or category
+semantics change)
+
+A flat `<relatorio_inicio>`/`<relatorio_fim>` pair is two unrelated tag
+names that happen to share a prefix; XML already has a native way to say
+"these two things bound one region" — nesting. Start/end pairs are now
+produced as one `<base>` wrapper element (named after the category, e.g.
+`relatorio`) with generic `<inicio>`/`<fim>` children reused across every
+pair category, instead of inventing a distinct flat tag name per role.
+Anything else that textually falls inside the region — another category's
+anchor, like `ref_processual` sitting inside a document's `cabecalho` —
+nests inside the wrapper too. Single-anchor categories are unaffected;
+there's no region to express, so they stay flat leaf tags exactly as
+before.
+
+Matches `segmenter_dataset/store.py`'s corresponding writer/reader rewrite
+(RFC 0012 §8) — reading is fully backward compatible with the pre-v7.3 flat
+format, so annotations produced under v7.1/v7.2 didn't need re-annotation,
+only the on-disk corpus was regenerated (same content, new serialization).

--- a/data/segmenter_splits/technique1_annotation_prompt.md
+++ b/data/segmenter_splits/technique1_annotation_prompt.md
@@ -1,0 +1,83 @@
+# Technique 1 annotation prompt (canonical)
+
+The prompt to use, verbatim (only the two `{...}` placeholders filled in),
+whenever spawning one subagent per document for Technique 1 — real-document
+LLM annotation (RFC 0012 §8/§9). Improvising this prompt per call is what
+produced batch1's ~45% failure rate; use this template instead so results
+are comparable across documents and across sessions, and so prompt fixes
+get made in one place instead of re-invented ad hoc each time.
+
+## Why it's shaped this way
+
+Batch1 (RFC 0012 §9's changelog) found 8 of 20 subagents produced **zero
+tags** despite being told exactly what to do. Reading the actual
+transcripts (not just final output) showed a consistent shape: read
+guideline, read document, brief thinking, jump straight to a final answer
+that just echoes the source — no tags. One subagent even caught the gap
+mid-generation ("Wait, I need to re-output this with the actual XML tags
+inserted") and then pasted the identical untagged text again anyway.
+
+The common thread: the task was structured as one uninterrupted generation
+with no forced checkpoint between "read the document" and "commit to a
+final answer." This template adds two checkpoints — enumerate expected
+categories *before* tagging, verify the draft *after* — inside the same
+turn, so a subagent that would otherwise silently skip the tagging work
+has to notice it did.
+
+## The prompt
+
+```
+You're producing ONE independent annotation for a Brazilian judicial-decision
+span-labeling dataset (OPF BIOES token classification). This is real
+production annotation work (Technique 1, RFC 0012 §8/§9), not a test.
+
+Do this in explicit, separate steps. Do not skip ahead to the final answer.
+
+1. Read the annotation guideline at
+   `data/segmenter_splits/annotation_guideline_v7.md` (current rules only —
+   you don't need the sibling CHANGELOG to annotate).
+2. Read the document at `{document_path}`. {document_type_hint}
+3. Before writing any tags, list which categories from BOTH anchor schemes
+   (the single-anchor table, the start/end pairs table) you can actually
+   find in this document, and roughly whereabouts. A short sentença
+   typically has 5-12 anchors total; a longer acórdão more. If your list
+   has fewer than ~5 entries for a document longer than a page, re-read
+   the document before continuing — you are very likely under-reading it,
+   not looking at a genuinely sparse one.
+4. Produce the tagged reproduction: the ENTIRE document text verbatim,
+   character-for-character, with inline XML tags per the guideline's
+   Rule 6 — single-anchor categories get one flat tag; start/end pairs
+   nest under a wrapper element with generic `<inicio>`/`<fim>` children
+   (see the guideline for the exact shape and a worked example).
+5. Before finalizing, check your own draft:
+   - Does every category from your step 3 list actually appear as a tag?
+     If you dropped one, go back and add it — don't finalize without it.
+   - Mentally strip every tag from your draft and compare what's left to
+     the document text from step 2, character for character. They must be
+     IDENTICAL. If they differ, you've duplicated or altered text
+     somewhere — find the mismatch and fix it by wrapping the existing
+     occurrence in place. Never fix it by retyping the phrase again.
+   - Zero tags is only a valid outcome for an unusually short or malformed
+     document — if that's genuinely the case here, say so explicitly
+     instead of silently returning the plain, untagged text.
+
+Output ONLY the fully tagged document text as your final answer — no
+preamble, no explanation, no markdown code fences. Steps 1-3 and 5 are
+your own working process; only step 4's verified result belongs in your
+answer.
+```
+
+## Filling the placeholders
+
+- `{document_path}` — absolute path to the plain-text source document.
+- `{document_type_hint}` — one line steering category expectations, e.g.:
+  - `This is a SENTENÇA (single-judge first-instance decision). No voto/acordao_decisorio categories should appear.`
+  - `This is an ACÓRDÃO (collegiate decision). voto and acordao_decisorio may appear alongside the sentença-style categories.`
+
+## After the batch
+
+Verify every returned annotation programmatically before trusting it —
+this prompt reduces the failure rate, it doesn't eliminate the need for
+the checks `scripts/ingest_juris_technique1_batch.py` already runs
+(verbatim-fidelity reconstruction, mechanical validation). A subagent's own
+self-check is a cheap first filter, not a substitute for the real one.

--- a/docs/rfc/0012-segmenter-dataset-confiavel-baseline.md
+++ b/docs/rfc/0012-segmenter-dataset-confiavel-baseline.md
@@ -276,7 +276,6 @@ uma classe inteira de bug estruturalmente impossível — desvio de offset por u
 que toca o texto mas não os rótulos — já que a posição *é* o próprio posicionamento da
 tag, e torna um registro trivialmente auditável por humano (abrir o arquivo, ler o
 documento já marcado).
-
 **Categorias start/end pair usam aninhamento XML de verdade, não convenção de nome.**
 Um par plano `<relatorio_inicio>`/`<relatorio_fim>` são dois nomes de tag sem relação
 estrutural que só coincidem no prefixo; XML já tem uma forma nativa de dizer "estas duas
@@ -481,6 +480,15 @@ achado, tratados de forma diferente:
   numa categoria): não é motivo para alterar a guideline — vira uma nota de risco
   desse lote específico, monitorada no spot-review de risco ("Dados de treino",
   abaixo), não um problema geral do processo de anotação.
+
+**Prompt canônico da Técnica 1.** `data/segmenter_splits/technique1_annotation_prompt.md`
+é o prompt a usar, verbatim, ao acionar um subagente por documento para anotação real
+(Técnica 1). Improvisar esse prompt por chamada foi a causa provável da taxa de falha de
+~45% do primeiro lote real (8 de 20 subagentes produziram zero tags apesar de instrução
+explícita — o próprio arquivo do prompt documenta o diagnóstico via transcript, seção
+"Why it's shaped this way"). O template existe para que resultados sejam comparáveis
+entre documentos e sessões, e para que ajustes de prompt aconteçam num lugar só em vez
+de reinventados ad hoc a cada lote.
 
 ### Dados de treino
 

--- a/src/segmenter_dataset/__main__.py
+++ b/src/segmenter_dataset/__main__.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import typer
 
+from segmenter_dataset.dataset_card import render_dataset_card
 from segmenter_dataset.iaa import DEFAULT_BOOTSTRAP_RESAMPLES
 from segmenter_dataset.ontology import ONTOLOGY_V8, load_categories
 from segmenter_dataset.release import ReleaseBlockedError, build_dataset_release
@@ -145,6 +146,24 @@ def build_release_command(
         raise typer.Exit(code=1) from exc
 
     typer.echo(f"release {release_manifest.release_id!r} written: counts={release_manifest.counts}")
+
+
+@app.command("render-dataset-card")
+def render_dataset_card_command(
+    data_root: Path = typer.Option(..., exists=True, file_okay=False, help="data/segmenter/"),
+    release_id: str = typer.Option(...),
+    output: Path | None = typer.Option(
+        None, help="Where to write the card; defaults to <release dir>/dataset_card.md"
+    ),
+) -> None:
+    """Render the RFC 0012 §15 dataset card for an already-built release."""
+    store = SegmenterDatasetStore(data_root)
+    manifest = store.read_release_manifest(release_id)
+    card = render_dataset_card(manifest)
+    destination = output or (store.release_dir(release_id) / "dataset_card.md")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(card, encoding="utf-8")
+    typer.echo(f"wrote {destination}")
 
 
 def _echo_gate_failures(gate_results: list[GateResult]) -> None:

--- a/src/segmenter_dataset/dataset_card.py
+++ b/src/segmenter_dataset/dataset_card.py
@@ -31,11 +31,16 @@ def _fmt_float(value: float | None) -> str:
     return f"{value:.3f}" if value is not None else "n/a"
 
 
+def _escape_cell(value: str) -> str:
+    """Escape a markdown table cell so a stray ``|`` can't corrupt the row."""
+    return value.replace("\\", "\\\\").replace("|", "\\|")
+
+
 def _counts_table(counts: dict[str, int], header: str) -> list[str]:
     if not counts:
         return [f"_No {header.lower()} recorded._", ""]
     lines = [f"| {header} | Count |", "| --- | --- |"]
-    lines.extend(f"| {key} | {value} |" for key, value in sorted(counts.items()))
+    lines.extend(f"| {_escape_cell(key)} | {value} |" for key, value in sorted(counts.items()))
     lines.append("")
     return lines
 
@@ -63,7 +68,7 @@ def _iaa_section(manifest: ReleaseManifest) -> list[str]:
         lines.append("| Category | IAA span F1 |")
         lines.append("| --- | --- |")
         lines.extend(
-            f"| {category} | {value:.3f} |"
+            f"| {_escape_cell(category)} | {value:.3f} |"
             for category, value in sorted(quality.per_category_iaa.items())
         )
         lines.append("")

--- a/src/segmenter_dataset/dataset_card.py
+++ b/src/segmenter_dataset/dataset_card.py
@@ -1,0 +1,137 @@
+"""Human-readable dataset card generator (RFC 0012 §15 PR2 / §16.1).
+
+RFC 0012 §15's PR2 deliverable list names a "dataset card" as a first-class
+release artifact, distinct from the manifest itself: "resumo legível por
+humano do manifest: escopo (tribunal/fonte/período), IAA agregado e por
+categoria, known limitations, uso pretendido e não-pretendido." The
+manifest already carries every one of those numbers (`ReleaseManifest`); a
+card is a rendering of them for a human deciding whether to use the
+release, not a new source of truth — this module reads a manifest and never
+invents data it does not contain.
+
+One field in §15's wording is not yet representable: **período** (the
+release's temporal coverage). Neither `DocumentRecord` nor `SourceInfo`
+carries a date field today, so there is nothing to render — the period line
+is omitted rather than fabricated. Add it here once that schema gap is
+closed elsewhere; do not backfill it from `created_at` (that is the release
+*build* time, not the underlying documents' dates, and conflating the two
+would misrepresent the corpus).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import ReleaseManifest
+
+
+def _fmt_float(value: float | None) -> str:
+    return f"{value:.3f}" if value is not None else "n/a"
+
+
+def _counts_table(counts: dict[str, int], header: str) -> list[str]:
+    if not counts:
+        return [f"_No {header.lower()} recorded._", ""]
+    lines = [f"| {header} | Count |", "| --- | --- |"]
+    lines.extend(f"| {key} | {value} |" for key, value in sorted(counts.items()))
+    lines.append("")
+    return lines
+
+
+def _split_counts_table(counts: dict[str, int]) -> list[str]:
+    lines = ["| Split | Documents |", "| --- | --- |"]
+    lines.extend(f"| {role} | {counts.get(role, 0)} |" for role in ("train", "validation", "test"))
+    lines.append("")
+    return lines
+
+
+def _iaa_section(manifest: ReleaseManifest) -> list[str]:
+    quality = manifest.annotation_quality
+    lines = ["## Inter-annotator agreement (IAA)", ""]
+    lines.append(
+        f"- **Validation macro-F1:** {_fmt_float(quality.val_iaa_span_f1)} "
+        f"(95% CI lower bound: {_fmt_float(quality.val_iaa_span_f1_ci95_low)})"
+    )
+    lines.append(
+        f"- **Test macro-F1:** {_fmt_float(quality.test_iaa_span_f1)} "
+        f"(95% CI lower bound: {_fmt_float(quality.test_iaa_span_f1_ci95_low)})"
+    )
+    lines.append("")
+    if quality.per_category_iaa:
+        lines.append("| Category | IAA span F1 |")
+        lines.append("| --- | --- |")
+        lines.extend(
+            f"| {category} | {value:.3f} |"
+            for category, value in sorted(quality.per_category_iaa.items())
+        )
+        lines.append("")
+    if quality.unreliable_eval_categories:
+        unreliable = ", ".join(sorted(quality.unreliable_eval_categories))
+        lines.append(
+            f"**Unreliable for per-category evaluation** (below the RFC 0012 §8 floor): "
+            f"{unreliable}"
+        )
+        lines.append("")
+    return lines
+
+
+def _known_limitations_section(manifest: ReleaseManifest) -> list[str]:
+    lines = ["## Known limitations", ""]
+    if manifest.known_limitations:
+        lines.extend(
+            f"- **{limitation.gate}** ({limitation.status}): {limitation.reason}"
+            for limitation in manifest.known_limitations
+        )
+    else:
+        lines.append("_None recorded._")
+    lines.append("")
+    return lines
+
+
+def render_dataset_card(manifest: ReleaseManifest) -> str:
+    """Render the RFC 0012 §15 PR2 dataset card for ``manifest`` as Markdown.
+
+    Pure rendering — every number here is read from ``manifest``, nothing
+    is recomputed or inferred. Callers that want a freshly computed number
+    (e.g. re-running IAA) must do that before building the manifest, not
+    after, so the card and the manifest never disagree.
+    """
+    lines: list[str] = [
+        f"# Dataset Card: {manifest.release_id}",
+        "",
+        f"- **Ontology version:** {manifest.ontology_version}",
+        f"- **Guideline version:** {manifest.guideline_version}",
+        f"- **Source commit:** `{manifest.source_commit}`",
+        f"- **Built:** {manifest.created_at}",
+        f"- **CI:** {manifest.ci_provider} run `{manifest.ci_run_id}`",
+        "",
+        "## Scope",
+        "",
+    ]
+    lines.extend(_counts_table(manifest.tribunals, "Tribunal"))
+    lines.extend(_counts_table(manifest.document_types, "Document type"))
+    lines.append("## Split sizes")
+    lines.append("")
+    lines.extend(_split_counts_table(manifest.counts))
+    lines.extend(_iaa_section(manifest))
+    lines.extend(_known_limitations_section(manifest))
+    lines.append("## Intended use")
+    lines.append("")
+    lines.append(
+        "Training and evaluating the CausaGanha decision segmenter for the tribunal(s) and "
+        "document type(s) listed under Scope above. A release covering a single tribunal is "
+        "described and must be used as tribunal-specific (RFC 0012 §14) — it does not license a "
+        "claim of general applicability to tribunals or document types not represented here."
+    )
+    lines.append("")
+    lines.append("## Not intended for")
+    lines.append("")
+    lines.append(
+        "Any tribunal, document type, or time period not represented under Scope; any claim "
+        "about a *model* trained on this release — dataset acceptance (RFC 0012 §16.1) is "
+        "separate from, and does not imply, model-release acceptance (RFC 0012 §16.2)."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/segmenter_dataset/test_dataset_card.py
+++ b/tests/segmenter_dataset/test_dataset_card.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from segmenter_dataset.dataset_card import render_dataset_card
+from segmenter_dataset.schemas import AnnotationQuality, KnownLimitation, ReleaseManifest
+
+
+SOURCE_COMMIT = "a" * 40
+LOCK_HASH = "b" * 64
+SPLIT_HASH = "c" * 64
+
+
+def _manifest(**overrides: object) -> ReleaseManifest:
+    defaults = {
+        "release_id": "segmenter-silver-v8.1",
+        "ontology_version": "segmenter-ontology-v8.0.0",
+        "guideline_version": "v7.3",
+        "source_commit": SOURCE_COMMIT,
+        "dependency_lock_hash": LOCK_HASH,
+        "ci_provider": "github-actions",
+        "ci_run_id": "123",
+        "split_manifest_hash": SPLIT_HASH,
+        "split_hashes": {"train": SPLIT_HASH, "validation": SPLIT_HASH, "test": SPLIT_HASH},
+        "document_resolutions": {},
+        "counts": {"train": 150, "validation": 30, "test": 30},
+        "tribunals": {"tjro": 210},
+        "document_types": {"acordao": 210},
+        "annotation_quality": AnnotationQuality(
+            val_iaa_span_f1=0.82,
+            val_iaa_span_f1_ci95_low=0.78,
+            test_iaa_span_f1=0.80,
+            test_iaa_span_f1_ci95_low=0.76,
+            per_category_iaa={"resultado": 0.9, "cabecalho_inicio": 0.85},
+            unreliable_eval_categories=("valor_condenacao",),
+        ),
+        "iaa_seed": 1,
+        "iaa_resamples": 1000,
+        "known_limitations": (),
+        "created_at": "2026-07-18T00:00:00Z",
+    }
+    defaults.update(overrides)
+    return ReleaseManifest(**defaults)
+
+
+def test_card_includes_release_id_and_versions() -> None:
+    card = render_dataset_card(_manifest())
+
+    assert "# Dataset Card: segmenter-silver-v8.1" in card
+    assert "segmenter-ontology-v8.0.0" in card
+    assert "v7.3" in card
+
+
+def test_card_includes_scope_tables() -> None:
+    card = render_dataset_card(_manifest())
+
+    assert "| tjro | 210 |" in card
+    assert "| acordao | 210 |" in card
+
+
+def test_card_includes_split_sizes() -> None:
+    card = render_dataset_card(_manifest())
+
+    assert "| train | 150 |" in card
+    assert "| validation | 30 |" in card
+    assert "| test | 30 |" in card
+
+
+def test_card_includes_iaa_aggregate_and_per_category() -> None:
+    card = render_dataset_card(_manifest())
+
+    assert "0.820" in card  # val macro-F1
+    assert "0.780" in card  # val CI low
+    assert "| resultado | 0.900 |" in card
+    assert "valor_condenacao" in card
+    assert "Unreliable for per-category evaluation" in card
+
+
+def test_card_reports_no_limitations_when_none_recorded() -> None:
+    card = render_dataset_card(_manifest())
+
+    assert "_None recorded._" in card
+
+
+def test_card_lists_known_limitations() -> None:
+    manifest = _manifest(
+        known_limitations=(
+            KnownLimitation(gate="iaa_per_category_floor", reason="low support for X"),
+        )
+    )
+
+    card = render_dataset_card(manifest)
+
+    assert "iaa_per_category_floor" in card
+    assert "low support for X" in card
+
+
+def test_card_never_fabricates_a_temporal_period_line() -> None:
+    """RFC 0012 §15 mentions 'período' in scope, but no schema field carries it yet --
+    the card must not invent one (e.g. from created_at, which is build time not corpus time).
+    """
+    card = render_dataset_card(_manifest())
+
+    assert "período" not in card.lower()
+    assert "**period" not in card.lower()
+
+
+def test_card_does_not_fabricate_iaa_numbers_when_absent() -> None:
+    manifest = _manifest(
+        annotation_quality=AnnotationQuality(),
+    )
+
+    card = render_dataset_card(manifest)
+
+    assert "n/a" in card

--- a/tests/segmenter_dataset/test_dataset_card.py
+++ b/tests/segmenter_dataset/test_dataset_card.py
@@ -111,3 +111,33 @@ def test_card_does_not_fabricate_iaa_numbers_when_absent() -> None:
     card = render_dataset_card(manifest)
 
     assert "n/a" in card
+
+
+def test_card_escapes_pipe_in_tribunal_name_so_table_stays_well_formed() -> None:
+    manifest = _manifest(tribunals={"TJRO|fake": 1})
+
+    card = render_dataset_card(manifest)
+
+    assert "| TJRO\\|fake | 1 |" in card
+    # every table row must have exactly the 3 unescaped pipes a 2-column row needs
+    row = next(line for line in card.splitlines() if "TJRO" in line)
+    assert row.count("|") - row.count("\\|") == 3
+
+
+def test_card_escapes_pipe_in_iaa_category_name() -> None:
+    manifest = _manifest(
+        annotation_quality=AnnotationQuality(per_category_iaa={"weird|category": 0.5})
+    )
+
+    card = render_dataset_card(manifest)
+
+    assert "| weird\\|category | 0.500 |" in card
+
+
+def test_card_reports_no_tribunals_when_scope_is_empty() -> None:
+    manifest = _manifest(tribunals={}, document_types={})
+
+    card = render_dataset_card(manifest)
+
+    assert "_No tribunal recorded._" in card
+    assert "_No document type recorded._" in card


### PR DESCRIPTION
## Description

Split out of #840 per review feedback (that PR had accumulated 20 commits against a 3-commit description — see [the review thread](https://github.com/franklinbaldo/causaganha/pull/840) and the #832/#837 precedent it cites). This PR carries the annotation-guideline and dataset-card half of what had drifted onto that branch. It's a sibling to #841 (`claude/segmenter-pr2-corpus-ingestion`, the actual corpus ingestion) — both are RFC 0012 §15 PR2 scope, split for reviewability rather than one being a subset of the other.

**Note on history:** this branch was squashed to a single commit (`23810dc4`, on top of `d8f1512b`) when it got rebased onto #840's reconciled tip (see #840's thread for why). The individual-commit narrative below describes what the diff *contains*, not commits you can `git show` on this branch anymore — verify against the file diff, not commit hashes.

### Guideline revisions (v7.1 → v7.3, from real pilot findings)

- RFC updates recommending inline-tag rewriting as the LLM annotation technique, and carving out span-anchor augmentation from the synthetic-data gate.
- Guideline v7.1 revision from pilot findings.
- Records the pilot-before-batch practice and re-pilot findings in the RFC (§9).
- Reframes verbatim-fidelity mismatch as a risk signal to catch during ingestion, not a hard blocker.
- Splits the guideline into current-rules-only (`annotation_guideline_v7.md`) vs. a separate revision changelog (`annotation_guideline_v7_CHANGELOG.md`), since inline `[v7.X]` markers were dead weight for an annotator reading the guideline fresh.
- Adds the canonical Technique 1 annotation prompt (`data/segmenter_splits/technique1_annotation_prompt.md`) with explicit self-verification checkpoints. Written after diagnosing a real ~45% zero-tag failure rate in a first annotation batch (8/20 subagents produced zero tags despite explicit instruction) via subagent transcripts, not guesswork — the prompt file's own "Why it's shaped this way" section documents the diagnosis.

Also carries the guideline-doc prose that came bundled with #840's storage-format commits (the worked XML-nesting example in Rule 6, the `fundamentacao_legal`/`valor_condenacao` multiplicity-policy writeup) — those commits' *code* stayed on #840; their guideline-prose portions moved here since the guideline is annotator-facing material, not part of #840's artifact-contract code.

### Dataset card generator (RFC 0012 §15 PR2 deliverable)

- `dataset_card.py` — pure rendering of an already-built `ReleaseManifest` into Markdown: scope (tribunal/document type), split sizes, IAA aggregate and per-category, known limitations, intended/not-intended use. Deliberately omits the "período" (temporal coverage) field RFC 0012 §15's wording mentions — neither `DocumentRecord` nor `SourceInfo` carries a date today, so that line is omitted rather than fabricated from `created_at` (which is release build time, not corpus time). Table cells escape `|` so a tribunal/category name can't corrupt the rendered markdown table.
- `render-dataset-card` CLI command wiring it into `segmenter-dataset`.

## Test plan

- [x] `uv run ruff check src/segmenter_dataset tests/segmenter_dataset` — all checks passed
- [x] `uv run ruff format --check src/segmenter_dataset tests/segmenter_dataset` — all formatted
- [x] `uv run pytest tests/segmenter_dataset/ -q` — 104 passed

Depends on #840 (this branch is based on its reconciled tip).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPCj1EM3pvwqZS4CQyjvSH)_