### PR TITLE
RFC 0012 PR3: training runner + gated test-eval script + model-acceptance gate

### DIFF
--- a/scripts/run_segmenter_test_eval.py
+++ b/scripts/run_segmenter_test_eval.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+r"""Evaluate the CausaGanha segmenter against the locked test set -- EXACTLY ONCE.
+
+This is the separately gated step RFC 0012 §3.3/§13.1 requires: training
+(`scripts/run_segmenter_training.py`) never touches `test.jsonl`; this
+script is the only place that does, and it is meant to run once per model
+release, not per commit. It refuses to run without an explicit
+`--i-understand-this-consumes-the-locked-test-set` flag, and refuses to
+overwrite an existing model card without `--force` -- neither is real
+cryptographic locking (RFC 0012 §13.2's `age`/`gpg`-encrypted test blob is
+still TODO), but both make an accidental second "final" evaluation loud
+instead of silent.
+
+Computes, against the RFC 0012 §16.2 gate:
+
+- macro-F1(model) vs. macro-F1(trivial baseline) on the same locked test
+  set, with a document-level bootstrap 95% CI of the difference
+  (`segmenter_dataset.model_eval`);
+- point-estimate floor on the four RFC-fixed critical categories.
+
+...and writes a `ModelCard` (distinct from the dataset's `ReleaseManifest`)
+recording that evidence plus who/when unlocked the test set and a hash of
+the result, per RFC 0012 §13.2's "registered operation" requirement.
+
+Usage:
+    uv run python scripts/run_segmenter_test_eval.py \
+        --experiment-manifest training-runs/segmenter-real-v8.1/experiment_manifest.json \
+        --data-dir dataset-releases/segmenter-real-v8.1/opf-export \
+        --dataset-release-id segmenter-real-v8.1 \
+        --model-release-id segmenter-model-v8.1 \
+        --output-dir model-releases/segmenter-model-v8.1 \
+        --executor "$(whoami)" \
+        --i-understand-this-consumes-the-locked-test-set
+
+Not runnable in this environment (no `opf`/`transformers` inference
+available, and no val/test data exists yet) -- written ahead of time per
+explicit instruction; run once a real locked test set and trained
+checkpoint exist. Confirm the `transformers` token-classification pipeline
+call against the actual `opf` checkpoint format before the first real run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from segmenter_dataset.model_eval import DocumentModelPrediction, evaluate_model_acceptance
+from segmenter_dataset.schemas import ExperimentManifest, Label, ModelCard
+
+
+logger = structlog.get_logger()
+
+
+def _detect_device() -> str:
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+    except ImportError:
+        pass
+    return "cpu"
+
+
+def _load_test_jsonl(path: Path) -> tuple[list[str], dict[str, tuple[Label, ...]], dict[str, str]]:
+    document_ids: list[str] = []
+    gold_by_document: dict[str, tuple[Label, ...]] = {}
+    text_by_document: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        document_id = record["info"]["document_id"]
+        labels = tuple(
+            Label(start=item["start"], end=item["end"], category=item["category"])
+            for item in record["label"]
+        )
+        document_ids.append(document_id)
+        gold_by_document[document_id] = labels
+        text_by_document[document_id] = record["text"]
+    return document_ids, gold_by_document, text_by_document
+
+
+def _run_opf_inference(
+    text_by_document: dict[str, str], checkpoint_dir: Path, device: str
+) -> dict[str, tuple[Label, ...]]:
+    """Span predictions per document via a token-classification pipeline over the checkpoint.
+
+    Uses `aggregation_strategy="simple"` so the pipeline returns entity-level
+    spans with character offsets directly (`entity_group`, `start`, `end`) --
+    matching this project's `Label` shape without extra BIOES decoding here.
+    """
+    from transformers import pipeline
+
+    classifier = pipeline(
+        "token-classification",
+        model=str(checkpoint_dir),
+        aggregation_strategy="simple",
+        device=0 if device == "cuda" else -1,
+    )
+    predictions: dict[str, tuple[Label, ...]] = {}
+    for document_id, text in text_by_document.items():
+        entities = classifier(text)
+        predictions[document_id] = tuple(
+            Label(
+                start=int(entity["start"]),
+                end=int(entity["end"]),
+                category=str(entity["entity_group"]),
+            )
+            for entity in entities
+            if entity.get("start") is not None and entity.get("end") is not None
+        )
+    return predictions
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the segmenter against the locked test set exactly once (§13/§16.2)"
+    )
+    parser.add_argument("--experiment-manifest", required=True)
+    parser.add_argument("--data-dir", required=True, help="Dir containing the unlocked test.jsonl")
+    parser.add_argument(
+        "--dataset-release-id", required=True, help="segmenter-real-vX.Y this test belongs to"
+    )
+    parser.add_argument(
+        "--model-release-id", required=True, help="segmenter-model-vX.Y being evaluated"
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--executor", required=True, help="Who/what unlocked the test (RFC 0012 §13.2)"
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--resamples", type=int, default=1000)
+    parser.add_argument("--device", default=None)
+    parser.add_argument(
+        "--i-understand-this-consumes-the-locked-test-set",
+        action="store_true",
+        help=(
+            "Required. Confirms this run is THE single registered test evaluation for this "
+            "model release (RFC 0012 §13.1) -- not a diagnostic re-check."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing model card at --output-dir. Refused by default.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.i_understand_this_consumes_the_locked_test_set:
+        print(
+            "Refusing to run: pass --i-understand-this-consumes-the-locked-test-set to confirm "
+            "this is THE single registered test evaluation for this model release (RFC 0012 "
+            "§13.1). A second evaluation against the same holdout is a regression diagnostic, "
+            "never a new performance claim.",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_dir = Path(args.output_dir)
+    model_card_path = output_dir / "model_card.json"
+    if model_card_path.exists() and not args.force:
+        print(
+            f"Refusing to overwrite existing model card at {model_card_path} without --force. "
+            "A genuinely new evaluation (RFC 0012 §13.1's 'reação a teste' or 'novo candidato' "
+            "trigger) belongs under a new --output-dir with its own holdout, not a second write "
+            "here.",
+            file=sys.stderr,
+        )
+        return 1
+
+    experiment_manifest_path = Path(args.experiment_manifest)
+    if not experiment_manifest_path.exists():
+        print(f"Error: experiment manifest {experiment_manifest_path} not found.", file=sys.stderr)
+        return 1
+    experiment_manifest = ExperimentManifest.model_validate_json(
+        experiment_manifest_path.read_text(encoding="utf-8")
+    )
+
+    test_jsonl = Path(args.data_dir) / "test.jsonl"
+    if not test_jsonl.exists():
+        print(f"Error: {test_jsonl} not found.", file=sys.stderr)
+        return 1
+
+    document_ids, gold_by_document, text_by_document = _load_test_jsonl(test_jsonl)
+    device = args.device or _detect_device()
+
+    unlocked_at = datetime.now(UTC)
+    logger.info(
+        "test_unlocked",
+        executor=args.executor,
+        at=unlocked_at.isoformat(),
+        documents=len(document_ids),
+    )
+
+    model_predicted = _run_opf_inference(
+        text_by_document, Path(experiment_manifest.checkpoint_dir), device
+    )
+    predictions = [
+        DocumentModelPrediction(
+            document_id=document_id,
+            gold=gold_by_document[document_id],
+            model_predicted=model_predicted.get(document_id, ()),
+            baseline_predicted=(),
+        )
+        for document_id in document_ids
+    ]
+
+    evidence = evaluate_model_acceptance(predictions, seed=args.seed, resamples=args.resamples)
+    result_hash = hashlib.sha256(evidence.model_dump_json().encode("utf-8")).hexdigest()
+
+    model_card = ModelCard(
+        release_id=args.model_release_id,
+        dataset_release_id=args.dataset_release_id,
+        experiment_id=experiment_manifest.experiment_id,
+        test_release_used=args.dataset_release_id,
+        test_unlocked_at=unlocked_at.isoformat(),
+        test_unlocked_by=args.executor,
+        test_result_hash=result_hash,
+        acceptance=evidence,
+        intended_use=(
+            "TJRO acórdão segmentation into the RFC 0012 ontology regions; not validated on "
+            "other tribunals or document types."
+        ),
+        known_limitations=(
+            "Test-set support for critical categories is low (~30 documents); a point-estimate "
+            "floor is used instead of a CI bound, per RFC 0012 §5 point 6.",
+            "The baseline is majority-class (predicts no spans), per RFC 0012 §5 point 6's "
+            "fallback -- no existing heuristic extractor was substituted in for this run.",
+        ),
+        created_at=unlocked_at.isoformat(),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model_card_path.write_text(model_card.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    print(f"Model card: {model_card_path}")
+    print(f"macro-F1 (model): {evidence.macro_f1_model}")
+    print(f"macro-F1 (baseline): {evidence.macro_f1_baseline}")
+    print(f"baseline diff CI95 low: {evidence.baseline_diff_ci95_low}")
+    print(f"beats baseline: {evidence.beats_baseline}")
+    print(f"critical categories: {evidence.critical_category_f1}")
+    print(f"critical categories passed: {evidence.critical_categories_passed}")
+    print(f"ELIGIBLE FOR DEPLOY: {evidence.eligible_for_deploy}")
+    return 0 if evidence.eligible_for_deploy else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_segmenter_training.py
+++ b/scripts/run_segmenter_training.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+r"""Train the CausaGanha segmenter baseline against train+val ONLY (RFC 0012 §13/§15 PR3).
+
+Deliberately narrower than the pre-RFC `scripts/train_decision_segmenter.py`:
+this script never opens `test.jsonl`, even if it happens to exist alongside
+`train.jsonl`/`val.jsonl` in `--data-dir`. RFC 0012 §3.3 ("o teste e
+avaliado uma unica vez") is a process rule about what the *test data* is
+used for, not about who is running the script -- a trainer that reads test
+every epoch violates it regardless of intent, which is exactly what the
+pre-RFC script did (it called `opf eval` on test.jsonl in the same run as
+training). Test evaluation is a separate, explicitly gated step: see
+`scripts/run_segmenter_test_eval.py`.
+
+Expects `--data-dir` to already contain `train.jsonl`, `val.jsonl`, and
+`label_space.json` -- the output of
+`segmenter_dataset.opf_export.export_release_for_training`. This script
+does not derive those from a release itself; it consumes a frozen export.
+
+Loops epoch-by-epoch with an explicit checkpoint hand-off between `opf
+train` subprocess calls, rather than one `--epochs N` call -- a mechanical
+lesson RFC 0012 §13.2 carries over from PR #832: the opf trainer leaks RAM
+in a long-lived process. Checkpoint selection is macro-F1 on validation
+only (RFC 0012 §5 point 5): highest wins; ties broken by lowest epoch, then
+by lowest validation loss.
+
+Usage:
+    uv run python scripts/run_segmenter_training.py \
+        --data-dir dataset-releases/segmenter-real-v8.1/opf-export \
+        --output-dir training-runs/segmenter-real-v8.1 \
+        --release-id segmenter-real-v8.1 \
+        --ontology-version segmenter-ontology-v8.0.0 \
+        --guideline-version v7.3 \
+        --dependency-lock-hash <sha256 of uv.lock>
+
+Not runnable in this environment (no `opf` CLI installed) -- written ahead
+of the val/test corpus existing, per explicit instruction to write the
+trainer now and run it once real validation data is available. Confirm the
+`opf train`/`opf eval` flags below against `opf train --help` /
+`opf eval --help` before the first real run; they are carried over from
+`train_decision_segmenter.py`, not independently re-verified here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from segmenter_dataset.schemas import CheckpointSelection, ExperimentManifest
+
+
+logger = structlog.get_logger()
+
+REQUIRED_TRAIN_ARTIFACTS = ("train.jsonl", "val.jsonl", "label_space.json")
+
+
+def _detect_device() -> str:
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+    except ImportError:
+        pass
+    return "cpu"
+
+
+def _load_label_space(path: Path) -> dict:
+    label_space = json.loads(path.read_text(encoding="utf-8"))
+    names = label_space.get("span_class_names", [])
+    if not names or names[0] != "O":
+        msg = f"Invalid label space: O must be first in span_class_names (got {names[:3]})"
+        raise ValueError(msg)
+    return label_space
+
+
+def _run_opf_train_epoch(
+    train_jsonl: Path,
+    val_jsonl: Path,
+    label_space_json: Path,
+    epoch_dir: Path,
+    *,
+    resume_from: Path | None,
+    batch_size: int,
+    seed: int,
+    device: str,
+) -> int:
+    cmd = [
+        sys.executable,
+        "-m",
+        "opf",
+        "train",
+        str(train_jsonl),
+        "--validation-dataset",
+        str(val_jsonl),
+        "--label-space-json",
+        str(label_space_json),
+        "--output-dir",
+        str(epoch_dir),
+        "--device",
+        device,
+        "--epochs",
+        "1",
+        "--batch-size",
+        str(batch_size),
+        "--seed",
+        str(seed),
+    ]
+    if resume_from is not None:
+        cmd += ["--checkpoint", str(resume_from)]
+    logger.info("opf_train_epoch_start", cmd=" ".join(cmd))
+    result = subprocess.run(cmd, check=False)
+    logger.info("opf_train_epoch_done", returncode=result.returncode)
+    return result.returncode
+
+
+def _run_opf_eval(
+    jsonl_path: Path, checkpoint_dir: Path, metrics_output: Path, device: str
+) -> dict | None:
+    """Run `opf eval`. Caller is responsible for never pointing this at test.jsonl."""
+    metrics_output.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "opf",
+        "eval",
+        str(jsonl_path),
+        "--checkpoint",
+        str(checkpoint_dir),
+        "--device",
+        device,
+        "--per-class",
+        "--metrics-out",
+        str(metrics_output),
+    ]
+    logger.info("opf_eval_start", cmd=" ".join(cmd), target=str(jsonl_path))
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0 or not metrics_output.exists():
+        return None
+    try:
+        return json.loads(metrics_output.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _macro_f1_from_metrics(metrics: dict, categories: list[str]) -> float:
+    """Mean of per-class span F1 over trainable categories (RFC 0012 §5 point 5's metric)."""
+    f1s = []
+    for category in categories:
+        f1 = metrics.get(f"by_class.{category}.span.f1")
+        if f1 is None:
+            category_metrics = metrics.get(category, {})
+            f1 = category_metrics.get("f1-score") if category_metrics else None
+        if f1 is not None:
+            f1s.append(f1)
+    return sum(f1s) / len(f1s) if f1s else 0.0
+
+
+@dataclass(frozen=True)
+class _EpochResult:
+    epoch: int
+    macro_f1: float
+    val_loss: float | None
+    checkpoint_dir: Path
+
+
+def _select_best_epoch(results: list[_EpochResult]) -> _EpochResult:
+    """RFC 0012 §5 point 5: highest val macro-F1; tie -> lowest epoch; tie -> lowest val loss."""
+
+    def sort_key(result: _EpochResult) -> tuple[float, int, float]:
+        loss = result.val_loss if result.val_loss is not None else float("inf")
+        return (-result.macro_f1, result.epoch, loss)
+
+    return min(results, key=sort_key)
+
+
+def train_and_select_checkpoint(
+    data_dir: Path,
+    output_dir: Path,
+    *,
+    epochs: int,
+    batch_size: int,
+    seed: int,
+    device: str,
+) -> tuple[CheckpointSelection, Path]:
+    """Train epoch-by-epoch, evaluating ONLY on val.jsonl; return the winning checkpoint.
+
+    Never opens `data_dir / "test.jsonl"`, even if present.
+    """
+    train_jsonl = data_dir / "train.jsonl"
+    val_jsonl = data_dir / "val.jsonl"
+    label_space_json = data_dir / "label_space.json"
+    label_space = _load_label_space(label_space_json)
+    categories = [c for c in label_space["span_class_names"] if c != "O"]
+
+    results: list[_EpochResult] = []
+    resume_from: Path | None = None
+
+    for epoch in range(1, epochs + 1):
+        epoch_dir = output_dir / f"epoch-{epoch}"
+        returncode = _run_opf_train_epoch(
+            train_jsonl,
+            val_jsonl,
+            label_space_json,
+            epoch_dir,
+            resume_from=resume_from,
+            batch_size=batch_size,
+            seed=seed,
+            device=device,
+        )
+        if returncode != 0:
+            msg = f"opf train failed at epoch {epoch} (returncode {returncode})"
+            raise RuntimeError(msg)
+
+        metrics_path = output_dir / f"val_metrics_epoch_{epoch}.json"
+        metrics = _run_opf_eval(val_jsonl, epoch_dir, metrics_path, device)
+        if metrics is None:
+            msg = f"opf eval on val.jsonl failed at epoch {epoch}"
+            raise RuntimeError(msg)
+
+        macro = _macro_f1_from_metrics(metrics, categories)
+        val_loss = metrics.get("loss")
+        logger.info("epoch_val_macro_f1", epoch=epoch, macro_f1=macro, val_loss=val_loss)
+        results.append(
+            _EpochResult(epoch=epoch, macro_f1=macro, val_loss=val_loss, checkpoint_dir=epoch_dir)
+        )
+        resume_from = epoch_dir
+
+    if not results:
+        msg = "no epochs completed"
+        raise RuntimeError(msg)
+
+    best = _select_best_epoch(results)
+    selection = CheckpointSelection(
+        selected_epoch=best.epoch,
+        val_macro_f1=best.macro_f1,
+        val_loss=best.val_loss,
+        per_epoch_val_macro_f1={result.epoch: result.macro_f1 for result in results},
+    )
+    return selection, best.checkpoint_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Train the CausaGanha segmenter baseline (train+val only, RFC 0012 §13)"
+    )
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--release-id", required=True)
+    parser.add_argument("--ontology-version", required=True)
+    parser.add_argument("--guideline-version", required=True)
+    parser.add_argument("--dependency-lock-hash", required=True, help="sha256 hex of the lockfile")
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--device", default=None, help="cuda|cpu; default: auto-detect")
+    parser.add_argument("--experiment-id", default=None)
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    output_dir = Path(args.output_dir)
+
+    missing = [name for name in REQUIRED_TRAIN_ARTIFACTS if not (data_dir / name).exists()]
+    if missing:
+        print(
+            f"Error: missing {missing} in {data_dir}. "
+            "Run segmenter_dataset.opf_export.export_release_for_training first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    device = args.device or _detect_device()
+    selection, checkpoint_dir = train_and_select_checkpoint(
+        data_dir,
+        output_dir,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        seed=args.seed,
+        device=device,
+    )
+
+    timestamp = datetime.now(UTC)
+    experiment_id = args.experiment_id or f"{args.release_id}-train-{timestamp:%Y%m%dT%H%M%SZ}"
+    manifest = ExperimentManifest(
+        experiment_id=experiment_id,
+        release_id=args.release_id,
+        ontology_version=args.ontology_version,
+        guideline_version=args.guideline_version,
+        seed=args.seed,
+        dependency_lock_hash=args.dependency_lock_hash,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        device=device,
+        checkpoint_dir=str(checkpoint_dir),
+        checkpoint_selection=selection,
+        created_at=timestamp.isoformat(),
+    )
+    manifest_path = output_dir / "experiment_manifest.json"
+    manifest_path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    print(f"Selected epoch {selection.selected_epoch} (val macro-F1={selection.val_macro_f1:.3f})")
+    print(f"Checkpoint: {checkpoint_dir}")
+    print(f"Experiment manifest: {manifest_path}")
+    print("\ntest.jsonl was not read by this script.")
+    print("To evaluate against the locked test set (exactly once), run:")
+    print(
+        f"  uv run python scripts/run_segmenter_test_eval.py --experiment-manifest {manifest_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_segmenter_training.py
+++ b/scripts/run_segmenter_training.py
@@ -246,7 +246,7 @@ def train_and_select_checkpoint(
     return selection, best.checkpoint_dir
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Train the CausaGanha segmenter baseline (train+val only, RFC 0012 §13)"
     )
@@ -261,7 +261,7 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--device", default=None, help="cuda|cpu; default: auto-detect")
     parser.add_argument("--experiment-id", default=None)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     data_dir = Path(args.data_dir)
     output_dir = Path(args.output_dir)

--- a/src/segmenter_dataset/model_eval.py
+++ b/src/segmenter_dataset/model_eval.py
@@ -1,0 +1,177 @@
+"""Test-set model-release acceptance gate (RFC 0012 §16.2 / §5 point 6).
+
+Passing the dataset gates (§16.1, ``release.py``) says the *data* is
+trustworthy; it says nothing about whether a checkpoint trained on it is
+worth deploying — a perfectly reproducible model with near-zero test F1
+clears every §16.1 gate and is still useless. §16.2 fixes two additional,
+non-waivable checks against the single, locked test evaluation:
+
+- **beats a trivial baseline**: the lower bound of a document-level
+  bootstrap 95% CI of macro-F1(model) minus macro-F1(baseline) must be
+  strictly greater than 0 — not a margin the release picks after seeing the
+  result;
+- **critical-category floor**: ``ontology.CRITICAL_CATEGORIES`` — the
+  categories carrying the decision's operative outcome — must each clear
+  ``ontology.CRITICAL_CATEGORY_FLOOR`` macro-F1 as a **point estimate** (not
+  a CI bound; test-set support for these categories is too low at ~30
+  documents for a CI to discriminate, the same reasoning IAA's per-category
+  gate uses at low support, §8).
+
+The statistics reuse :mod:`segmenter_dataset.iaa`'s pooled exact-match F1
+machinery: a (gold, model-prediction) pair is structurally the same thing as
+an IAA (annotator-A, annotator-B) pair, so ``DocumentAnnotationPair``,
+``pooled_counts``, ``f1_from_counts``, and ``macro_f1`` all apply unchanged.
+Only the *paired* baseline-vs-model bootstrap is new here — it must resample
+the same document indices for both predictors in the same draw, or it
+overstates the CI width by ignoring that both predictors' errors are
+correlated within a document.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from segmenter_dataset.iaa import (
+    MIN_REPORT_SUPPORT,
+    DocumentAnnotationPair,
+    f1_from_counts,
+    macro_f1,
+    pooled_counts,
+)
+from segmenter_dataset.ontology import CRITICAL_CATEGORIES, CRITICAL_CATEGORY_FLOOR
+from segmenter_dataset.schemas import ModelAcceptanceEvidence
+
+
+if TYPE_CHECKING:
+    from segmenter_dataset.schemas import Label
+
+
+DEFAULT_BOOTSTRAP_RESAMPLES = 1000
+
+
+@dataclass(frozen=True)
+class DocumentModelPrediction:
+    """One test document's gold labels plus model and trivial-baseline predictions."""
+
+    document_id: str
+    gold: tuple[Label, ...]
+    model_predicted: tuple[Label, ...]
+    baseline_predicted: tuple[Label, ...]
+
+    @property
+    def model_pair(self) -> DocumentAnnotationPair:
+        """Gold-vs-model as an IAA-shaped pair, for reusing ``iaa``'s pooled F1."""
+        return DocumentAnnotationPair(self.document_id, self.gold, self.model_predicted)
+
+    @property
+    def baseline_pair(self) -> DocumentAnnotationPair:
+        """Gold-vs-baseline as an IAA-shaped pair, for reusing ``iaa``'s pooled F1."""
+        return DocumentAnnotationPair(self.document_id, self.gold, self.baseline_predicted)
+
+
+def trivial_baseline_predictions(
+    document_ids: list[str], gold_by_document: dict[str, tuple[Label, ...]]
+) -> list[DocumentModelPrediction]:
+    """RFC 0012 §5 point 6's fallback baseline: majority-class, i.e. predict no spans.
+
+    Used "na ausência de" an existing heuristic/deterministic extractor. In
+    BIOES span tagging the majority class is overwhelmingly ``O`` (outside
+    any span), so the majority-class predictor never emits a span — every
+    category scores F1=0 against it, which is what makes "beats baseline"
+    a meaningful bar rather than a rubber stamp: it only asks that the model
+    reliably finds real spans, not that it beats a strong competitor.
+    """
+    return [
+        DocumentModelPrediction(
+            document_id=document_id,
+            gold=gold_by_document[document_id],
+            model_predicted=(),
+            baseline_predicted=(),
+        )
+        for document_id in document_ids
+    ]
+
+
+def bootstrap_diff_ci_low(
+    predictions: list[DocumentModelPrediction],
+    *,
+    resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    seed: int,
+    min_support: int = MIN_REPORT_SUPPORT,
+) -> float | None:
+    """Lower 95% CI bound of macro-F1(model) minus macro-F1(baseline), paired per document.
+
+    Resamples document indices once per draw and applies the **same**
+    indices to both the model pair list and the baseline pair list, so the
+    within-document correlation between the two predictors' errors is
+    preserved (an unpaired bootstrap — resampling each side independently —
+    would overstate the CI width). Mirrors ``iaa.bootstrap_ci_low``'s
+    document-level resampling discipline (RFC 0012 §8).
+    """
+    rng = random.Random(seed)  # noqa: S311 - deterministic statistical resampling, not cryptography
+    n = len(predictions)
+    if n == 0:
+        return None
+    diffs: list[float] = []
+    for _ in range(resamples):
+        sample = [predictions[rng.randrange(n)] for _ in range(n)]
+        model_f1 = macro_f1([item.model_pair for item in sample], min_support=min_support)
+        baseline_f1 = macro_f1([item.baseline_pair for item in sample], min_support=min_support)
+        if model_f1 is not None and baseline_f1 is not None:
+            diffs.append(model_f1 - baseline_f1)
+    if not diffs:
+        return None
+    diffs.sort()
+    low_index = int(0.025 * len(diffs))
+    return diffs[low_index]
+
+
+def critical_category_f1(predictions: list[DocumentModelPrediction]) -> dict[str, float]:
+    """Point-estimate pooled F1 (model vs. gold) for each RFC-fixed critical category."""
+    pairs = [item.model_pair for item in predictions]
+    counts = pooled_counts(pairs)
+    return {
+        category: f1_from_counts(*counts.get(category, (0, 0, 0)))
+        for category in sorted(CRITICAL_CATEGORIES)
+    }
+
+
+def evaluate_model_acceptance(
+    predictions: list[DocumentModelPrediction],
+    *,
+    seed: int,
+    resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    min_support: int = MIN_REPORT_SUPPORT,
+) -> ModelAcceptanceEvidence:
+    """Run the full RFC 0012 §16.2 gate against one locked test evaluation.
+
+    Call this exactly once per test unlock (RFC 0012 §13.1/§13.2) — the
+    function itself is pure and re-runnable, but the *evaluation it
+    describes* is not: a second call against the same test predictions is a
+    diagnostic re-check, never a new performance claim.
+    """
+    model_pairs = [item.model_pair for item in predictions]
+    baseline_pairs = [item.baseline_pair for item in predictions]
+    macro_model = macro_f1(model_pairs, min_support=min_support)
+    macro_baseline = macro_f1(baseline_pairs, min_support=min_support)
+    diff_ci_low = bootstrap_diff_ci_low(
+        predictions, resamples=resamples, seed=seed, min_support=min_support
+    )
+    beats_baseline = diff_ci_low is not None and diff_ci_low > 0
+
+    per_critical = critical_category_f1(predictions)
+    critical_passed = all(f1 >= CRITICAL_CATEGORY_FLOOR for f1 in per_critical.values())
+
+    return ModelAcceptanceEvidence(
+        macro_f1_model=macro_model,
+        macro_f1_baseline=macro_baseline,
+        baseline_diff_ci95_low=diff_ci_low,
+        beats_baseline=beats_baseline,
+        critical_category_f1=per_critical,
+        critical_categories_passed=critical_passed,
+        eligible_for_deploy=beats_baseline and critical_passed,
+        bootstrap_seed=seed,
+        bootstrap_resamples=resamples,
+    )

--- a/src/segmenter_dataset/ontology.py
+++ b/src/segmenter_dataset/ontology.py
@@ -57,6 +57,21 @@ ONTOLOGY_V8 = "segmenter-ontology-v8.0.0"
 # this set, not decide independently, or the policy drifts.
 ALLOW_MULTIPLE_SINGLE_ANCHOR = frozenset({"fundamentacao_legal", "valor_condenacao"})
 
+# RFC 0012 §5 point 6 / §16.2: the model-release floor for v8.1, fixed by
+# this RFC rather than left for a release to declare. These four categories
+# carry the decision's operative outcome — a model that gets the aggregate
+# macro-F1 right while missing these is not useful even though it passes
+# every dataset-level gate (§16.1 vs §16.2's distinction).
+CRITICAL_CATEGORIES = frozenset(
+    {
+        "dispositivo_abertura",
+        "resultado",
+        "acordao_decisorio_inicio",
+        "acordao_decisorio_fim",
+    }
+)
+CRITICAL_CATEGORY_FLOOR = 0.5
+
 
 class MigrationImpact(StrEnum):
     """Semver bump class for an ontology change (RFC 0012 §5.1)."""

--- a/src/segmenter_dataset/opf_export.py
+++ b/src/segmenter_dataset/opf_export.py
@@ -1,0 +1,158 @@
+"""Bridge a built release (RFC 0012 §8/§12) to OPF's training JSONL format (RFC 0012 §15 PR3).
+
+OPF (``openai/privacy-filter``) trains from JSONL where each line is
+``{"text": ..., "label": [{"category", "start", "end"}], "info": {...}}`` plus a
+sibling ``label_space.json`` (``span_class_names`` with ``"O"`` first). This module
+produces exactly that from a :class:`~segmenter_dataset.schemas.ReleaseManifest` —
+never from "whatever the store's latest annotations happen to be", because a release
+is immutable (RFC 0012 §3.1/§12) and re-deriving training data for it after the fact
+must reproduce the *exact* records the release pinned, not drift with later edits to
+the store. ``document_resolutions`` is exactly what makes that possible: it names the
+specific ``annotation_id`` (train) or ``review_id`` (validation/test) each document
+resolved to, so :func:`resolve_release_documents` looks those up by ID rather than
+asking the store for "the latest one".
+
+Train exports every category the ontology defines, using ``AnnotationRecord.labels``
+as-is; validation/test export ``ReviewRecord.final_labels`` — the adjudicated result,
+never a raw pre-adjudication annotation (RFC 0012 §9's independence requirement would
+be meaningless if training data leaked back in through the eval split).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from segmenter_dataset.schemas import (
+        AnnotationRecord,
+        DocumentRecord,
+        Label,
+        ReleaseManifest,
+        ReviewRecord,
+    )
+    from segmenter_dataset.store import SegmenterDatasetStore
+
+
+# RFC 0012 §10/§12: role names as they appear in ReleaseManifest.document_resolutions
+# vs. the file names OPF-facing tooling in this repo already uses
+# (scripts/train_decision_segmenter.py) — kept distinct so a manifest role rename
+# doesn't silently rename files a training script hardcodes.
+_ROLE_TO_FILENAME = {"train": "train", "validation": "val", "test": "test"}
+
+
+class ReleaseResolutionError(LookupError):
+    """A release's ``document_resolutions`` names an annotation/review the store no longer has.
+
+    Should be impossible for an immutable store (RFC 0012 §3.1) — records are never
+    deleted — so this indicates store corruption or a release manifest from a
+    different store, not an expected runtime condition.
+    """
+
+
+def _find_annotation(
+    store: SegmenterDatasetStore, document_id: str, annotation_id: str
+) -> AnnotationRecord:
+    for annotation in store.list_annotations(document_id=document_id):
+        if annotation.annotation_id == annotation_id:
+            return annotation
+    message = f"annotation {annotation_id!r} for document {document_id!r} not found in store"
+    raise ReleaseResolutionError(message)
+
+
+def _find_review(store: SegmenterDatasetStore, document_id: str, review_id: str) -> ReviewRecord:
+    for review in store.list_reviews(document_id=document_id):
+        if review.review_id == review_id:
+            return review
+    message = f"review {review_id!r} for document {document_id!r} not found in store"
+    raise ReleaseResolutionError(message)
+
+
+def resolve_release_documents(
+    store: SegmenterDatasetStore, manifest: ReleaseManifest
+) -> dict[str, list[tuple[DocumentRecord, list[Label]]]]:
+    """Re-read the exact ``(document, labels)`` pairs a built release pinned.
+
+    Keyed by role ("train"/"validation"/"test"), each list holding the resolved
+    document plus the labels from the *specific* annotation/review
+    ``document_resolutions`` names — not the store's current latest.
+    """
+    resolved: dict[str, list[tuple[DocumentRecord, list[Label]]]] = {}
+    for role, resolutions in manifest.document_resolutions.items():
+        items: list[tuple[DocumentRecord, list[Label]]] = []
+        for document_id, resolution_id in sorted(resolutions.items()):
+            document = store.read_document(document_id)
+            if role == "train":
+                labels = _find_annotation(store, document_id, resolution_id).labels
+            else:
+                labels = _find_review(store, document_id, resolution_id).final_labels
+            items.append((document, list(labels)))
+        resolved[role] = items
+    return resolved
+
+
+def to_opf_record(document: DocumentRecord, labels: list[Label]) -> dict:
+    """One OPF JSONL record for ``document`` — spans sorted by position for readability."""
+    ordered = sorted(labels, key=lambda label: (label.start, label.end))
+    return {
+        "text": document.text,
+        "label": [
+            {"category": label.category, "start": label.start, "end": label.end}
+            for label in ordered
+        ],
+        "info": {
+            "document_id": document.document_id,
+            "source_uri": document.source.source_uri,
+            "tribunal": document.source.tribunal,
+            "document_type": document.source.document_type,
+        },
+    }
+
+
+def write_jsonl(path: Path, records: list[dict]) -> None:
+    """Write ``records`` to ``path`` as one JSON object per line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False))
+            handle.write("\n")
+
+
+def write_label_space(path: Path, ontology_categories: set[str], ontology_version: str) -> None:
+    """``O`` first, then every trainable category sorted — the opf-finetune skill's contract."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "span_class_names": ["O", *sorted(ontology_categories)],
+        "category_version": ontology_version,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def export_release_for_training(
+    store: SegmenterDatasetStore,
+    manifest: ReleaseManifest,
+    output_dir: Path,
+    ontology_categories: set[str],
+) -> dict[str, int]:
+    """Write ``train.jsonl``/``val.jsonl``/``test.jsonl`` + ``label_space.json`` to ``output_dir``.
+
+    Returns record counts per file, for the caller to log/verify against the
+    release manifest's own ``counts`` field. Writing ``test.jsonl`` here does not
+    grant permission to read it — RFC 0012 §3.3/§13.1 gate that separately; this
+    function's job is reproducing the release's data, not enforcing who may look
+    at which file.
+    """
+    resolved = resolve_release_documents(store, manifest)
+    counts: dict[str, int] = {}
+    for role, filename in _ROLE_TO_FILENAME.items():
+        items = resolved.get(role, [])
+        records = [to_opf_record(document, labels) for document, labels in items]
+        write_jsonl(output_dir / f"{filename}.jsonl", records)
+        counts[filename] = len(records)
+    write_label_space(
+        output_dir / "label_space.json", ontology_categories, manifest.ontology_version
+    )
+    return counts

--- a/src/segmenter_dataset/schemas.py
+++ b/src/segmenter_dataset/schemas.py
@@ -315,3 +315,88 @@ class ReleaseManifest(BaseModel):
     iaa_resamples: int
     known_limitations: tuple[KnownLimitation, ...] = ()
     created_at: str
+
+
+class CheckpointSelection(BaseModel):
+    """Outcome of RFC 0012 §5 point 5's checkpoint-selection rule.
+
+    ``rule`` is fixed prose rather than a free-form field, so a manifest
+    cannot quietly redefine the selection rule after the fact — it exists
+    to be compared against, not edited per run.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rule: str = (
+        "primary: highest validation macro-F1 over trainable categories; "
+        "tie-break 1: lowest epoch; tie-break 2: lowest validation loss"
+    )
+    selected_epoch: int
+    val_macro_f1: float
+    val_loss: float | None = None
+    per_epoch_val_macro_f1: dict[int, float] = Field(default_factory=dict)
+
+
+class ExperimentManifest(BaseModel):
+    """One training run against a frozen dataset release export (RFC 0012 §13/§15 PR3).
+
+    Written once training finishes and a checkpoint is selected — before any
+    test data is touched. This is what lets a later, separately-gated test
+    evaluation (RFC 0012 §3.3/§13.1) point at an already-frozen configuration
+    instead of a moving target.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    experiment_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+    release_id: str
+    ontology_version: str
+    guideline_version: str
+    seed: int
+    dependency_lock_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    epochs: int
+    batch_size: int
+    device: str
+    checkpoint_dir: str
+    checkpoint_selection: CheckpointSelection
+    created_at: str
+
+
+class ModelAcceptanceEvidence(BaseModel):
+    """RFC 0012 §16.2 gate evidence — the numbers a model card must show, never a bare F1."""
+
+    model_config = ConfigDict(frozen=True)
+
+    macro_f1_model: float | None
+    macro_f1_baseline: float | None
+    baseline_diff_ci95_low: float | None
+    beats_baseline: bool
+    critical_category_f1: dict[str, float]
+    critical_categories_passed: bool
+    eligible_for_deploy: bool
+    bootstrap_seed: int
+    bootstrap_resamples: int
+
+
+class ModelCard(BaseModel):
+    """Model-release artifact (RFC 0012 §16.2) — distinct from a dataset's ReleaseManifest.
+
+    ``release_id`` here is the model-release id (``segmenter-model-vX.Y``),
+    separate from ``dataset_release_id`` (``segmenter-real-vX.Y``) — §16.2's
+    explicit point that dataset acceptance and model acceptance are versioned,
+    and can be accepted, independently.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    release_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+    dataset_release_id: str
+    experiment_id: str
+    test_release_used: str
+    test_unlocked_at: str
+    test_unlocked_by: str
+    test_result_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    acceptance: ModelAcceptanceEvidence
+    intended_use: str
+    known_limitations: tuple[str, ...] = ()
+    created_at: str

--- a/tests/segmenter_dataset/test_model_eval.py
+++ b/tests/segmenter_dataset/test_model_eval.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from segmenter_dataset.model_eval import (
+    DocumentModelPrediction,
+    bootstrap_diff_ci_low,
+    critical_category_f1,
+    evaluate_model_acceptance,
+    trivial_baseline_predictions,
+)
+from segmenter_dataset.ontology import CRITICAL_CATEGORIES
+from segmenter_dataset.schemas import Label
+
+
+def _labels(spans: list[tuple[int, int, str]]) -> tuple[Label, ...]:
+    return tuple(Label(start=s, end=e, category=c) for s, e, c in spans)
+
+
+def _prediction(
+    doc_id: str,
+    gold: list[tuple[int, int, str]],
+    model_predicted: list[tuple[int, int, str]],
+    baseline_predicted: list[tuple[int, int, str]] | None = None,
+) -> DocumentModelPrediction:
+    return DocumentModelPrediction(
+        document_id=doc_id,
+        gold=_labels(gold),
+        model_predicted=_labels(model_predicted),
+        baseline_predicted=_labels(baseline_predicted or []),
+    )
+
+
+def _perfect_predictions(n: int, category: str = "resultado") -> list[DocumentModelPrediction]:
+    return [_prediction(f"d{i}", [(0, 5, category)], [(0, 5, category)]) for i in range(n)]
+
+
+def test_trivial_baseline_predicts_no_spans() -> None:
+    gold_by_document = {"d1": _labels([(0, 5, "resultado")])}
+    predictions = trivial_baseline_predictions(["d1"], gold_by_document)
+
+    assert predictions[0].baseline_predicted == ()
+    assert predictions[0].model_predicted == ()
+    assert predictions[0].gold == gold_by_document["d1"]
+
+
+def test_bootstrap_diff_ci_low_empty_predictions_is_none() -> None:
+    assert bootstrap_diff_ci_low([], resamples=10, seed=1) is None
+
+
+def test_bootstrap_diff_ci_low_positive_when_model_perfect_and_baseline_empty() -> None:
+    predictions = [
+        _prediction("d1", [(0, 5, "resultado")], [(0, 5, "resultado")], baseline_predicted=[]),
+        _prediction("d2", [(0, 5, "resultado")], [(0, 5, "resultado")], baseline_predicted=[]),
+        _prediction("d3", [(0, 5, "resultado")], [(0, 5, "resultado")], baseline_predicted=[]),
+        _prediction("d4", [(0, 5, "resultado")], [(0, 5, "resultado")], baseline_predicted=[]),
+        _prediction("d5", [(0, 5, "resultado")], [(0, 5, "resultado")], baseline_predicted=[]),
+    ]
+
+    ci_low = bootstrap_diff_ci_low(predictions, resamples=200, seed=7, min_support=1)
+
+    assert ci_low is not None
+    assert ci_low > 0
+
+
+def test_bootstrap_diff_ci_low_zero_when_model_equals_baseline() -> None:
+    predictions = [
+        _prediction("d1", [(0, 5, "resultado")], [(0, 5, "resultado")], [(0, 5, "resultado")]),
+        _prediction("d2", [(0, 5, "resultado")], [(0, 5, "resultado")], [(0, 5, "resultado")]),
+    ]
+
+    ci_low = bootstrap_diff_ci_low(predictions, resamples=50, seed=3, min_support=1)
+
+    assert ci_low == 0.0
+
+
+def test_critical_category_f1_covers_every_fixed_category_even_with_zero_support() -> None:
+    predictions = [_prediction("d1", [(0, 5, "resultado")], [(0, 5, "resultado")])]
+
+    per_category = critical_category_f1(predictions)
+
+    assert set(per_category) == set(CRITICAL_CATEGORIES)
+    assert per_category["resultado"] == 1.0
+    assert per_category["dispositivo_abertura"] == 0.0
+
+
+def test_evaluate_model_acceptance_passes_when_model_beats_baseline_and_clears_floor() -> None:
+    predictions = []
+    for category in sorted(CRITICAL_CATEGORIES):
+        predictions.extend(_perfect_predictions(6, category=category))
+
+    report = evaluate_model_acceptance(predictions, seed=1, resamples=200, min_support=1)
+
+    assert report.beats_baseline is True
+    assert report.critical_categories_passed is True
+    assert report.eligible_for_deploy is True
+    assert report.macro_f1_model == 1.0
+    assert report.macro_f1_baseline == 0.0
+
+
+def test_evaluate_model_acceptance_fails_critical_floor_when_model_misses_spans() -> None:
+    predictions = [_prediction(f"d{i}", [(0, 5, "resultado")], []) for i in range(6)]
+
+    report = evaluate_model_acceptance(predictions, seed=1, resamples=100, min_support=1)
+
+    assert report.critical_categories_passed is False
+    assert report.eligible_for_deploy is False

--- a/tests/segmenter_dataset/test_opf_export.py
+++ b/tests/segmenter_dataset/test_opf_export.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import make_annotation, make_document, make_review
+
+from segmenter_dataset.opf_export import (
+    export_release_for_training,
+    resolve_release_documents,
+    to_opf_record,
+    write_label_space,
+)
+from segmenter_dataset.release import build_dataset_release
+from segmenter_dataset.schemas import KnownLimitation, Label
+from segmenter_dataset.splits import (
+    GroupingKeys,
+    SplitAssignment,
+    build_groups,
+    create_split_manifest,
+)
+from segmenter_dataset.store import SegmenterDatasetStore
+
+
+ONTOLOGY = {"cabecalho_inicio", "cabecalho_fim"}
+PAIR_LABELS = [
+    Label(start=0, end=5, category="cabecalho_inicio"),
+    Label(start=10, end=15, category="cabecalho_fim"),
+]
+SOURCE_COMMIT = "a" * 40
+LOCK_HASH = "b" * 64
+SINGLE_TRIBUNAL_KNOWN_LIMITATIONS = [
+    KnownLimitation(gate="multiple_tribunals", reason="TJRO-only for v8.1"),
+    KnownLimitation(gate="multiple_source_systems", reason="tjro_juris-only for v8.1"),
+]
+
+
+def _text_for(role: str, index: int) -> str:
+    return f"0123{role}{index:03d}89ABCDEFGHIJ"
+
+
+def _build_release(tmp_path: Path):
+    store = SegmenterDatasetStore(tmp_path)
+    train_ids: set[str] = set()
+    val_ids: set[str] = set()
+    test_ids: set[str] = set()
+
+    for index in range(10):
+        document = make_document(text=_text_for("train", index), source_uri=f"train-{index}")
+        store.write_document(document)
+        store.write_annotation(
+            make_annotation(
+                document, labels=PAIR_LABELS, covered_categories=tuple(sorted(ONTOLOGY))
+            )
+        )
+        train_ids.add(document.document_id)
+
+    for role, count, ids in (("val", 5, val_ids), ("test", 5, test_ids)):
+        for index in range(count):
+            document = make_document(text=_text_for(role, index), source_uri=f"{role}-{index}")
+            store.write_document(document)
+            annotation_a = make_annotation(
+                document,
+                annotator_id="run-a",
+                model_family="fam-a",
+                completed_at="2026-01-01T00:00:00Z",
+                labels=PAIR_LABELS,
+                covered_categories=tuple(sorted(ONTOLOGY)),
+            )
+            annotation_b = make_annotation(
+                document,
+                annotator_id="run-b",
+                model_family="fam-b",
+                completed_at="2026-01-01T00:00:01Z",
+                labels=PAIR_LABELS,
+                covered_categories=tuple(sorted(ONTOLOGY)),
+            )
+            store.write_annotation(annotation_a)
+            store.write_annotation(annotation_b)
+            store.write_review(
+                make_review(document, [annotation_a, annotation_b], final_labels=PAIR_LABELS)
+            )
+            ids.add(document.document_id)
+
+    assignment = SplitAssignment(
+        train_ids=frozenset(train_ids), val_ids=frozenset(val_ids), test_ids=frozenset(test_ids)
+    )
+    documents = store.list_documents()
+    keys = [GroupingKeys.from_document(document) for document in documents]
+    groups = build_groups(documents, keys, near_duplicate_threshold=0.99)
+    split_manifest = create_split_manifest(
+        assignment, groups, seed=7, train_ratio=0.70, val_ratio=0.15, near_duplicate_threshold=0.99
+    )
+    manifest = build_dataset_release(
+        store,
+        release_id="segmenter-silver-v8.1",
+        ontology_version="segmenter-ontology-v8.0.0",
+        guideline_version="g1",
+        source_commit=SOURCE_COMMIT,
+        dependency_lock_hash=LOCK_HASH,
+        ci_provider="github-actions",
+        ci_run_id="1",
+        ontology_categories=ONTOLOGY,
+        split_manifest=split_manifest,
+        known_limitations=SINGLE_TRIBUNAL_KNOWN_LIMITATIONS,
+        iaa_seed=1,
+        iaa_resamples=50,
+    )
+    return store, manifest
+
+
+def test_resolve_release_documents_matches_pinned_resolutions(tmp_path: Path) -> None:
+    store, manifest = _build_release(tmp_path)
+    resolved = resolve_release_documents(store, manifest)
+
+    assert len(resolved["train"]) == 10
+    assert len(resolved["validation"]) == 5
+    assert len(resolved["test"]) == 5
+    for _document, labels in resolved["train"] + resolved["validation"] + resolved["test"]:
+        assert labels == PAIR_LABELS
+
+
+def test_resolve_release_documents_ignores_later_store_edits(tmp_path: Path) -> None:
+    """A release pins specific annotation/review IDs -- edits to the store after the
+    release was built (e.g. a later re-annotation) must not silently change what a
+    training export produces for that release.
+    """
+    store, manifest = _build_release(tmp_path)
+
+    document = make_document(text=_text_for("train", 0), source_uri="train-0")
+    later_labels = [Label(start=0, end=5, category="cabecalho_inicio")]
+    store.write_annotation(
+        make_annotation(
+            document,
+            annotator_id="run-later",
+            labels=later_labels,
+            covered_categories=tuple(sorted(ONTOLOGY)),
+            completed_at="2027-01-01T00:00:00Z",
+        )
+    )
+
+    resolved = resolve_release_documents(store, manifest)
+    train_labels_by_doc = {doc.document_id: labels for doc, labels in resolved["train"]}
+    assert train_labels_by_doc[document.document_id] == PAIR_LABELS
+
+
+def test_to_opf_record_sorts_labels_and_carries_provenance() -> None:
+    document = make_document(text="0123456789ABCDEF")
+    unsorted_labels = [
+        Label(start=10, end=15, category="cabecalho_fim"),
+        Label(start=0, end=5, category="cabecalho_inicio"),
+    ]
+
+    record = to_opf_record(document, unsorted_labels)
+
+    assert record["text"] == document.text
+    assert record["label"] == [
+        {"category": "cabecalho_inicio", "start": 0, "end": 5},
+        {"category": "cabecalho_fim", "start": 10, "end": 15},
+    ]
+    assert record["info"]["document_id"] == document.document_id
+    assert record["info"]["tribunal"] == document.source.tribunal
+
+
+def test_write_label_space_puts_o_first_and_sorts_categories(tmp_path: Path) -> None:
+    path = tmp_path / "label_space.json"
+    write_label_space(path, {"resultado", "dispositivo_abertura"}, "segmenter-ontology-v8.0.0")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["span_class_names"] == ["O", "dispositivo_abertura", "resultado"]
+    assert payload["category_version"] == "segmenter-ontology-v8.0.0"
+
+
+def test_export_release_for_training_writes_expected_files_and_counts(tmp_path: Path) -> None:
+    store, manifest = _build_release(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    counts = export_release_for_training(store, manifest, output_dir, ONTOLOGY)
+
+    assert counts == {"train": 10, "val": 5, "test": 5}
+    for filename, expected_count in (("train", 10), ("val", 5), ("test", 5)):
+        lines = (output_dir / f"{filename}.jsonl").read_text(encoding="utf-8").splitlines()
+        assert len(lines) == expected_count
+        for line in lines:
+            record = json.loads(line)
+            assert record["label"] == [
+                {"category": "cabecalho_inicio", "start": 0, "end": 5},
+                {"category": "cabecalho_fim", "start": 10, "end": 15},
+            ]
+
+    label_space = json.loads((output_dir / "label_space.json").read_text(encoding="utf-8"))
+    assert label_space["span_class_names"][0] == "O"
+    assert set(label_space["span_class_names"][1:]) == ONTOLOGY

--- a/tests/segmenter_dataset/test_run_segmenter_test_eval.py
+++ b/tests/segmenter_dataset/test_run_segmenter_test_eval.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+
+from scripts.run_segmenter_test_eval import _load_test_jsonl, main
+
+
+def _write_jsonl(path, records):
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record))
+            handle.write("\n")
+
+
+def test_load_test_jsonl_reads_gold_labels_and_text(tmp_path):
+    path = tmp_path / "test.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "text": "hello world",
+                "label": [{"category": "resultado", "start": 0, "end": 5}],
+                "info": {"document_id": "d1"},
+            },
+            {
+                "text": "second doc",
+                "label": [],
+                "info": {"document_id": "d2"},
+            },
+        ],
+    )
+
+    document_ids, gold_by_document, text_by_document = _load_test_jsonl(path)
+
+    assert document_ids == ["d1", "d2"]
+    assert len(gold_by_document["d1"]) == 1
+    assert gold_by_document["d1"][0].category == "resultado"
+    assert gold_by_document["d2"] == ()
+    assert text_by_document["d1"] == "hello world"
+
+
+def test_load_test_jsonl_skips_blank_lines(tmp_path):
+    path = tmp_path / "test.jsonl"
+    path.write_text(
+        '{"text": "a", "label": [], "info": {"document_id": "d1"}}\n\n',
+        encoding="utf-8",
+    )
+
+    document_ids, _gold, _text = _load_test_jsonl(path)
+
+    assert document_ids == ["d1"]
+
+
+def test_main_refuses_without_confirmation_flag(tmp_path, capsys):
+    exit_code = main(
+        [
+            "--experiment-manifest",
+            str(tmp_path / "missing.json"),
+            "--data-dir",
+            str(tmp_path),
+            "--dataset-release-id",
+            "segmenter-real-v8.1",
+            "--model-release-id",
+            "segmenter-model-v8.1",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--executor",
+            "test-runner",
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "--i-understand-this-consumes-the-locked-test-set" in captured.err
+
+
+def test_main_refuses_to_overwrite_existing_model_card_without_force(tmp_path, capsys):
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "model_card.json").write_text("{}", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--experiment-manifest",
+            str(tmp_path / "missing.json"),
+            "--data-dir",
+            str(tmp_path),
+            "--dataset-release-id",
+            "segmenter-real-v8.1",
+            "--model-release-id",
+            "segmenter-model-v8.1",
+            "--output-dir",
+            str(output_dir),
+            "--executor",
+            "test-runner",
+            "--i-understand-this-consumes-the-locked-test-set",
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Refusing to overwrite" in captured.err
+
+
+def test_main_errors_when_experiment_manifest_missing(tmp_path, capsys):
+    exit_code = main(
+        [
+            "--experiment-manifest",
+            str(tmp_path / "missing.json"),
+            "--data-dir",
+            str(tmp_path),
+            "--dataset-release-id",
+            "segmenter-real-v8.1",
+            "--model-release-id",
+            "segmenter-model-v8.1",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--executor",
+            "test-runner",
+            "--i-understand-this-consumes-the-locked-test-set",
+        ]
+    )
+
+    assert exit_code != 0

--- a/tests/segmenter_dataset/test_run_segmenter_training.py
+++ b/tests/segmenter_dataset/test_run_segmenter_training.py
@@ -9,6 +9,7 @@ from scripts.run_segmenter_training import (
     _load_label_space,
     _macro_f1_from_metrics,
     _select_best_epoch,
+    main,
 )
 
 
@@ -82,3 +83,40 @@ def test_select_best_epoch_falls_back_to_lowest_val_loss_on_full_tie():
     best = _select_best_epoch(results)
 
     assert best.checkpoint_dir == "b"
+
+
+def _main_args(tmp_path, **overrides: str):
+    args = {
+        "--data-dir": str(tmp_path),
+        "--output-dir": str(tmp_path / "out"),
+        "--release-id": "segmenter-real-v8.1",
+        "--ontology-version": "segmenter-ontology-v8.0.0",
+        "--guideline-version": "g1",
+        "--dependency-lock-hash": "a" * 64,
+    }
+    args.update(overrides)
+    flat = []
+    for key, value in args.items():
+        flat.extend([key, value])
+    return flat
+
+
+def test_main_errors_when_train_artifacts_are_missing(tmp_path, capsys):
+    exit_code = main(_main_args(tmp_path))
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "missing" in captured.err
+    assert "train.jsonl" in captured.err
+
+
+def test_main_reports_all_missing_artifacts_not_just_the_first(tmp_path, capsys):
+    (tmp_path / "train.jsonl").write_text("", encoding="utf-8")
+
+    exit_code = main(_main_args(tmp_path))
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "val.jsonl" in captured.err
+    assert "label_space.json" in captured.err
+    assert "train.jsonl" not in captured.err

--- a/tests/segmenter_dataset/test_run_segmenter_training.py
+++ b/tests/segmenter_dataset/test_run_segmenter_training.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.run_segmenter_training import (
+    _EpochResult,
+    _load_label_space,
+    _macro_f1_from_metrics,
+    _select_best_epoch,
+)
+
+
+def test_load_label_space_requires_o_first(tmp_path):
+    path = tmp_path / "label_space.json"
+    path.write_text(json.dumps({"span_class_names": ["resultado", "O"]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="O must be first"):
+        _load_label_space(path)
+
+
+def test_load_label_space_reads_valid_file(tmp_path):
+    path = tmp_path / "label_space.json"
+    payload = {"span_class_names": ["O", "resultado"], "category_version": "v8"}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    label_space = _load_label_space(path)
+
+    assert label_space["span_class_names"] == ["O", "resultado"]
+
+
+def test_macro_f1_from_metrics_averages_by_class_keys():
+    metrics = {"by_class.resultado.span.f1": 0.8, "by_class.dispositivo_abertura.span.f1": 0.6}
+
+    macro = _macro_f1_from_metrics(metrics, ["resultado", "dispositivo_abertura"])
+
+    assert macro == pytest.approx(0.7)
+
+
+def test_macro_f1_from_metrics_falls_back_to_nested_f1_score():
+    metrics = {"resultado": {"f1-score": 0.5}}
+
+    macro = _macro_f1_from_metrics(metrics, ["resultado"])
+
+    assert macro == pytest.approx(0.5)
+
+
+def test_macro_f1_from_metrics_zero_when_no_category_found():
+    assert _macro_f1_from_metrics({}, ["resultado"]) == 0.0
+
+
+def test_select_best_epoch_picks_highest_macro_f1():
+    results = [
+        _EpochResult(epoch=1, macro_f1=0.5, val_loss=0.9, checkpoint_dir="epoch-1"),
+        _EpochResult(epoch=2, macro_f1=0.8, val_loss=0.7, checkpoint_dir="epoch-2"),
+        _EpochResult(epoch=3, macro_f1=0.6, val_loss=0.5, checkpoint_dir="epoch-3"),
+    ]
+
+    best = _select_best_epoch(results)
+
+    assert best.epoch == 2
+
+
+def test_select_best_epoch_ties_broken_by_lowest_epoch():
+    results = [
+        _EpochResult(epoch=1, macro_f1=0.8, val_loss=0.9, checkpoint_dir="epoch-1"),
+        _EpochResult(epoch=2, macro_f1=0.8, val_loss=0.1, checkpoint_dir="epoch-2"),
+    ]
+
+    best = _select_best_epoch(results)
+
+    assert best.epoch == 1
+
+
+def test_select_best_epoch_falls_back_to_lowest_val_loss_on_full_tie():
+    results = [
+        _EpochResult(epoch=1, macro_f1=0.8, val_loss=0.9, checkpoint_dir="a"),
+        _EpochResult(epoch=1, macro_f1=0.8, val_loss=0.2, checkpoint_dir="b"),
+    ]
+
+    best = _select_best_epoch(results)
+
+    assert best.checkpoint_dir == "b"


### PR DESCRIPTION
## Description

Split out of #840 per review feedback (that PR had accumulated 20 commits against a 3-commit description — see [the review thread](https://github.com/franklinbaldo/causaganha/pull/840) and the #832/#837 precedent it cites). This PR carries the RFC 0012 §15 PR3 deliverable: the trainer, the separately-gated test evaluation, and the §16.2 model-acceptance gate, none of which #840's description ever mentioned.

**Not yet run for real.** No `opf`/`transformers` inference is available in this environment, and the dataset store has zero validation/test-eligible documents yet (see #841 for that gap). This is deliberately "write the trainer code now, run it later" — the pure-logic pieces are unit-tested; the actual training/eval subprocess calls to `opf` are not exercised here.

### `opf_export.py` — release → OPF training format bridge

`resolve_release_documents()` re-reads the exact `(document, labels)` pairs a release pinned via `document_resolutions` — a later re-annotation in the store never changes what an already-built release exports. `export_release_for_training()` writes `train/val/test.jsonl` + `label_space.json` in the format OPF's fine-tune CLI expects (`O` first, categories sorted).

### `model_eval.py` — RFC 0012 §16.2 model-acceptance gate

Reuses `iaa.py`'s pooled exact-match F1 machinery (a gold-vs-prediction pair is structurally the same as an IAA annotator pair) and adds a **paired** document-level bootstrap CI of macro-F1(model) − macro-F1(baseline) — same document indices resampled on both sides in each draw, preserving within-document correlation between the two predictors' errors. Plus the point-estimate floor check on the four RFC-fixed critical categories (`dispositivo_abertura`, `resultado`, `acordao_decisorio_inicio`, `acordao_decisorio_fim`). New `ontology.CRITICAL_CATEGORIES`/`CRITICAL_CATEGORY_FLOOR` and `schemas.ExperimentManifest`/`ModelCard`.

### Training + evaluation scripts

- `scripts/run_segmenter_training.py` — trains epoch-by-epoch against train+val only, **never opens `test.jsonl`** even if present in the same directory. RFC 0012 §3.3 ("the test is evaluated exactly once") is a rule about what the test data is used for, not about intent — the pre-RFC `train_decision_segmenter.py` violated it by calling `opf eval` on test every run. Checkpoint selection is validation macro-F1 with the RFC 0012 §5 point 5 tie-break (lowest epoch, then lowest val loss).
- `scripts/run_segmenter_test_eval.py` — the separately gated step that *does* touch test.jsonl: refuses to run without an explicit `--i-understand-this-consumes-the-locked-test-set` flag, refuses to overwrite an existing model card without `--force`, runs inference via a `transformers` token-classification pipeline, and applies the `model_eval` gate to write a `ModelCard`.

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all formatted
- [x] `uv run pytest tests/segmenter_dataset/ -q` — 115 passed (pure-logic pieces only — checkpoint selection, JSONL parsing, CLI gating, bootstrap statistics; no real `opf`/`transformers` run)

Depends on #840 (this branch is based on its reduced tip). Sibling to the guideline/dataset-card PR, not stacked on it — this code doesn't need the guideline docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPCj1EM3pvwqZS4CQyjvSH)_