### PR TITLE
fix: corrige gate acidental de env e descrição do --mes (review PR #848)

### DIFF
--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -70,10 +70,22 @@ Testes de caracterização por pacote, sem tocar em código de produção:
    `Command.make_context` (só parsing — nunca invoca o callback, sem rede,
    sem I/O), com o `ctx.params` resultante comparado ao valor esperado hoje.
 
-Esses testes não prevêem a API do Cyclopts; travam o comportamento atual do
-Typer para que, na Fase 4, a mesma bateria sirva de portão de aceitação —
-qualquer divergência de nome, default ou negação de flag quebra o teste antes
-de chegar a produção.
+Esses testes travam o comportamento atual do Typer, mas fazem isso via
+introspecção de `Command`/`Parameter` do Click (`opts`, `secondary_opts`,
+`param.type`, `Command.make_context`) — infraestrutura que desaparece com o
+Cyclopts. Não sobrevivem verbatim à Fase 4: são caracterização transitória
+do Typer, não o portão de aceitação durável da migração. Congelam também
+detalhes de implementação do Click sem relevância para os workflows (`tuple`
+vs. `list`, `Path` vs. `str` cru, a representação interna de
+`secondary_opts`), o que os torna frágeis a mudanças que não afetam nenhum
+cron.
+
+O portão durável — a construir na Fase 2, depois que a camada de serviço
+existir — é framework-neutro: casos no formato `argv → configuração
+semântica esperada`, exercitando a CLI com a camada de serviço mockada e
+comparando a configuração entregue a ela. Typer e Cyclopts precisam então
+apenas de um adaptador fino para rodar os mesmos casos; a Fase 4 reexecuta
+essa bateria (não a desta Fase 1) contra a CLI já migrada.
 
 ### Fase 2 — camada de serviço
 
@@ -92,9 +104,11 @@ tool.
 
 ### Fase 4 — Typer → Cyclopts
 
-Com os testes da Fase 1 como portão: re-executar contra a CLI migrada antes
-de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
-`default_command` explícito equivalente a `invoke_without_command=True`.
+Com os testes framework-neutros da Fase 2 como portão (não os desta Fase 1,
+que são introspecção Click e não sobrevivem à troca de framework):
+re-executar contra a CLI migrada antes de mudar qualquer workflow. O
+callback bare de `djen-backup` precisa de um `default_command` explícito
+equivalente a `invoke_without_command=True`.
 
 ## 3. Critérios de aceitação (desta Fase 1)
 

--- a/tests/stj_acordaos/test_stj_cli_contract.py
+++ b/tests/stj_acordaos/test_stj_cli_contract.py
@@ -38,7 +38,7 @@ def test_stj_sync_argv_download() -> None:
     }
 
 
-def test_stj_sync_argv_upload() -> None:
+def test_stj_sync_argv_upload(monkeypatch) -> None:
     """Reproduz `stj-sync.yml`: `stj-acordaos upload --data-dir ... --manifest-path ...`.
 
     O workflow não passa `--parquet-path`/`--ia-key`/`--ia-secret` no argv —
@@ -46,7 +46,18 @@ def test_stj_sync_argv_upload() -> None:
     (não do `--data-dir` informado: são opções independentes, não há
     recomputação), e as credenciais vêm só de env (`IA_ACCESS_KEY`/
     `IA_SECRET_KEY`, injetadas pelo workflow via `env:` do step).
+
+    `ia_key`/`ia_secret` usam `envvar=...`, e `Command.make_context` lê essas
+    variáveis do processo de verdade — `monkeypatch.setenv` com valores
+    sentinela reproduz a injeção do workflow e confirma que elas chegam a
+    `ctx.params`, em vez de assumir que ficam vazias (isso só valia por
+    acidente, porque o job de CI não tinha essas variáveis no ambiente; numa
+    máquina com `IA_ACCESS_KEY`/`IA_SECRET_KEY` exportadas, o teste antigo
+    quebrava).
     """
+    monkeypatch.setenv("IA_ACCESS_KEY", "sentinel-ia-key")
+    monkeypatch.setenv("IA_SECRET_KEY", "sentinel-ia-secret")
+
     upload = _CMD.commands["upload"]
     argv = [
         "--data-dir",
@@ -58,8 +69,8 @@ def test_stj_sync_argv_upload() -> None:
 
     assert ctx.params["data_dir"] == "data/stj"
     assert ctx.params["manifest_path"] == "data/stj/stj-manifest.csv"
-    assert ctx.params["ia_key"] == ""
-    assert ctx.params["ia_secret"] == ""
+    assert ctx.params["ia_key"] == "sentinel-ia-key"
+    assert ctx.params["ia_secret"] == "sentinel-ia-secret"  # noqa: S105 — test fixture, not a real credential
 
 
 def test_stj_sync_argv_status() -> None:

--- a/tests/tjro_juris/test_juris_cli_contract.py
+++ b/tests/tjro_juris/test_juris_cli_contract.py
@@ -24,8 +24,11 @@ def test_subcommands_presentes() -> None:
 
 
 def test_tjro_sync_argv_crawl_incremental() -> None:
-    """Reproduz `tjro-sync.yml` no modo incremental (`--mes` informado, sem
-    `--ano`/`--desde-ano` — o caso comum de cron, execução diária).
+    """Reproduz `tjro-sync.yml` no modo `--mes` — variante de execução manual via
+    `workflow_dispatch` (`tjro_mes`), não o caso comum de cron. O cron diário
+    roda sem inputs e força `--desde-ano 1988` (ver
+    `test_tjro_sync_argv_crawl_backfill_historico`), continuando o backfill
+    histórico em vez de crawlear só o mês corrente.
     """
     crawl = _CMD.commands["crawl"]
     argv = ["data/tjro-juris", "--mes", "2026-07"]


### PR DESCRIPTION
## Resumo

Endereça os dois bloqueios registrados na review da PR #848
(`rfc/0013-cyclopts-fastmcp-caracterizacao`), mais a correção menor
apontada na mesma review.

## O que mudou

- **`tests/stj_acordaos/test_stj_cli_contract.py`** — `test_stj_sync_argv_upload`
  assumia `ia_key`/`ia_secret` vazios só porque `IA_ACCESS_KEY`/`IA_SECRET_KEY`
  não estavam presentes no ambiente do job de CI. Como as opções usam
  `envvar=...`, `Command.make_context` lê essas variáveis do processo de
  verdade — o teste passava por acidente e quebraria em qualquer máquina com
  as credenciais exportadas, sem reproduzir a injeção real do workflow
  (`env:` do step). Passa a usar `monkeypatch.setenv` com valores sentinela e
  confirma que chegam a `ctx.params`.
- **`tests/tjro_juris/test_juris_cli_contract.py`** — corrige a descrição de
  `--mes` em `test_tjro_sync_argv_crawl_incremental`: não é o caso comum de
  cron (que roda sem inputs e força `--desde-ano 1988` para continuar o
  backfill histórico), é a variante de execução manual via
  `workflow_dispatch`.
- **`docs/rfc/0013-migracao-cyclopts-fastmcp.md`** — corrige a alegação de que
  a bateria desta Fase 1 serve de portão de aceitação da Fase 4. Ela usa
  introspecção Click (`Command.make_context`, `opts`/`secondary_opts`) que
  não sobrevive à troca para Cyclopts, e trava detalhes internos do Click sem
  relevância para os workflows (`tuple` vs. `list`, `Path` vs. `str`,
  representação de `secondary_opts`). Registra que o portão durável — no
  formato `argv → configuração semântica esperada`, exercitando a CLI com a
  camada de serviço mockada — é trabalho da Fase 2, com adaptadores finos por
  framework depois.

## Verificação

| Gate | Resultado |
| --- | --- |
| `pytest -q tests/stj_acordaos tests/tjro_juris tests/djen_backup tests/datajud` | 216 testes, 0 falhas |
| `ruff check src/ tests/` | limpo |
| `ruff format --check src/ tests/` | limpo |
| `test_stj_sync_argv_upload` com `IA_ACCESS_KEY`/`IA_SECRET_KEY` exportadas no shell | passa (antes falharia) |

Nenhuma mudança de código de produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_