### PR TITLE
refactor: extrai camada de serviço nos 4 pacotes CLI (RFC 0013 Fase 2)

### DIFF
--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -1,6 +1,6 @@
 # RFC 0013 — Migração das CLIs Typer para Cyclopts + FastMCP
 
-- **Status:** Proposto (Fase 1 implementada neste PR)
+- **Status:** Fase 1 e Fase 2 implementadas
 - **Data:** 2026-07-21
 - **Base:** comparação de arquitetura com o repo irmão `pink` (mesma stack alvo:
   Cyclopts + FastMCP, tools declaradas uma vez, CLI como despachante genérico
@@ -87,12 +87,45 @@ comparando a configuração entregue a ela. Typer e Cyclopts precisam então
 apenas de um adaptador fino para rodar os mesmos casos; a Fase 4 reexecuta
 essa bateria (não a desta Fase 1) contra a CLI já migrada.
 
-### Fase 2 — camada de serviço
+### Fase 2 — camada de serviço (implementada)
 
-Extrair, por pacote, funções de config→resultado sem Typer/Rich/`echo`
-(mesmo padrão do `service/` do pink). Matar os side effects de import.
-Resolver o bug de exit code descartado. Tirar `ia_key`/`ia_secret` de opção
-de CLI — só env/keyring.
+Cada pacote ganhou um `service.py` com funções config→resultado, sem
+Typer/Rich/`echo`; os `__main__.py` ficaram reduzidos a parsing de argv +
+tradução do resultado em echo/exit code:
+
+- **`djen_backup`**: `service.py` com `PipelineRunConfig`, `resolve_djen_url`,
+  `resolve_ia_auth` (levanta `MissingCredentialsError` em vez de
+  `typer.Exit`) e `run_pipeline` (chama `engine.run_sync`). Os side effects
+  de import (`structlog.configure(...)`, reconfiguração de
+  `stdout`/`stderr`) saíram do topo do módulo para `configure_runtime()`,
+  chamada uma vez no callback `main()` — Click sempre invoca o callback do
+  grupo antes de qualquer subcomando, então isso cobre `check`/`upload`/
+  `drain`/`probe`/`reset` também. O bug de exit code descartado — só
+  documentado no callback bare — na verdade existia igual em `check` e
+  `upload`; os três agora fazem `raise typer.Exit(code=_run_pipeline(...))`.
+- **`tjro_juris`**: `service.py` recebeu praticamente todo o corpo de
+  `crawl`/`upload`/`status`/`consolidate` (a lógica já era quase
+  config→resultado; só usava `typer.BadParameter`/`typer.echo` pontualmente).
+  `crawl_bounds` agora levanta `ValueError` — framework-neutro —, e o
+  `__main__.py` traduz para `typer.BadParameter` na borda da CLI.
+- **`stj_acordaos`**: `service.py` com `download_one` (retorna
+  `DownloadOutcome` em vez de `typer.echo` direto — o `__main__.py` traduz o
+  outcome em mensagens), `upload_all` (idem, via `UploadResult`) e
+  `manifest_summary`. `ia_key`/`ia_secret` deixaram de ser opção de CLI —
+  `upload` não os aceita mais como parâmetro; `service.ia_credentials()` lê
+  `IA_ACCESS_KEY`/`IA_SECRET_KEY` do ambiente diretamente.
+- **`datajud`**: mesmo padrão — `service.enrich`/`facetas`/`manifest_status`
+  sem Typer/echo, `ia_key`/`ia_secret` removidos da opção `enrich` (idem
+  `ia_credentials()`).
+
+**Não incluído nesta fase:** a bateria de testes framework-neutra (`argv →
+configuração semântica`, camada de serviço mockada) descrita na Fase 1 como
+o portão durável de Fase 4. Os testes de caracterização da Fase 1
+(introspecção Click) foram atualizados apenas onde o contrato de parâmetros
+mudou de propósito (remoção de `ia_key`/`ia_secret`) e continuam verdes para
+o resto — mas ainda são a única rede de segurança de argv hoje. Construir a
+bateria framework-neutra fica para o início da Fase 4, quando o formato dos
+casos pode ser desenhado já sabendo a API real do Cyclopts.
 
 ### Fase 3 — tools MCP
 
@@ -110,13 +143,29 @@ re-executar contra a CLI migrada antes de mudar qualquer workflow. O
 callback bare de `djen-backup` precisa de um `default_command` explícito
 equivalente a `invoke_without_command=True`.
 
-## 3. Critérios de aceitação (desta Fase 1)
+## 3. Critérios de aceitação
 
+**Fase 1:**
 - Este RFC mergeado.
 - Quatro arquivos de teste novos, um por pacote, cobrindo o argv literal dos
   5 workflows listados acima e o contrato de parâmetros correspondente.
 - `pytest`, `ruff check`, `ruff format --check` verdes.
 - Nenhuma mudança de código de produção.
+
+**Fase 2 (implementada):**
+- `service.py` por pacote, sem Typer/Rich/`echo`.
+- Side effects de import mortos em `djen_backup` (`configure_runtime()`
+  chamada do callback, não do topo do módulo).
+- Bug de exit code descartado corrigido em `djen_backup` (callback bare,
+  `check` e `upload`).
+- `ia_key`/`ia_secret` fora da opção de CLI em `stj_acordaos`/`datajud` —
+  só `IA_ACCESS_KEY`/`IA_SECRET_KEY` via ambiente.
+- Testes de caracterização da Fase 1 continuam verdes (exceto os dois que
+  documentavam o contrato antigo de credenciais, atualizados para afirmar a
+  ausência da opção). `pytest`, `ruff check`, `ruff format --check` verdes.
+- Nenhuma mudança de argv nos 5 workflows — `check`/`upload`/`drain`/
+  `probe`/`reset`/`crawl`/`status`/`consolidate`/`download`/`facetas`
+  mantêm nome, default e negação de flag idênticos ao que a Fase 1 travou.
 
 ## 4. Riscos
 
@@ -124,8 +173,12 @@ equivalente a `invoke_without_command=True`.
   default diferente para o par negável, `collect-zips` passa a rodar com
   `fail_fast=True` e aborta no primeiro 403 do CloudFront — regressão
   silenciosa, visível só na próxima execução (a cada 20 min).
-- **`ruff select=["ALL"]`** e **`vulture --min-confidence 100`** vão sinalizar
-  código novo/temporariamente órfão durante a extração da Fase 2 — orçar
-  tempo de whitelist, não tratar como bloqueio de escopo.
-- Testes de caracterização não cobrem execução (rede, I/O) — o bug de exit
-  code descartado só será corrigido/verificado na Fase 2, não antes.
+- **`ruff select=["ALL"]`** e **`vulture --min-confidence 100`** sinalizaram
+  código novo durante a extração da Fase 2 (complexidade, imports não
+  utilizados, docstrings) — resolvido com refino local (ex.: `enrich` do
+  `datajud` dividido em `_pending_cnjs`/`_upload_step` para ficar sob o
+  limite de complexidade) em vez de whitelist ampla.
+- A bateria framework-neutra de argv (ver Fase 2 acima) ainda não existe —
+  até que exista, a Fase 4 depende só da introspecção Click da Fase 1 mais
+  os testes unitários de `service.py`, nenhum dos quais sobrevive à troca de
+  framework sem edição.

--- a/ruff.toml
+++ b/ruff.toml
@@ -60,7 +60,21 @@ ignore = [
 # E501: long IA metadata strings; re-wrapping would harm readability.
 # BLE001: blind except around a single resource's download/extract in a batch
 # CLI loop — one bad ZIP shouldn't abort the whole run.
-"src/stj_acordaos/__main__.py" = ["B008", "PLC0415", "D101", "D102", "D103", "D107", "FBT001", "FBT003", "BLE001"]
+# TC003: Path used at runtime — Typer resolves bare `param: Path = ...`
+# annotations via get_type_hints(), so the import can't move into
+# TYPE_CHECKING (same rationale as tjro_juris/__main__.py below).
+"src/stj_acordaos/__main__.py" = [
+    "B008",
+    "PLC0415",
+    "D101",
+    "D102",
+    "D103",
+    "D107",
+    "FBT001",
+    "FBT003",
+    "BLE001",
+    "TC003",
+]
 "src/stj_acordaos/manifest.py" = ["D107", "D105", "PLW2901", "PERF401"]
 # S608: f-string SQL with DuckDB — path_list is internal (no user input).
 # E501: long log line; splitting would obscure the structured-logging pattern.
@@ -82,11 +96,15 @@ ignore = [
 "src/tjro_juris/archive.py" = ["D100", "D103", "PLC0415", "ASYNC240", "TC003"]
 
 # ── datajud ───────────────────────────────────────────────────────────────
-# PLC0415: lazy duckdb imports inside CLI helpers — standard pattern.
 # FBT001/FBT002: boolean CLI flags are idiomatic Typer.
+# TC003: Path used at runtime — Typer resolves `Annotated[Path, ...]`
+# annotations via get_type_hints(), so the import can't move into
+# TYPE_CHECKING (same rationale as tjro_juris/__main__.py above).
+"src/datajud/__main__.py" = ["FBT001", "FBT002", "TC003"]
+# PLC0415: lazy duckdb imports inside data-gathering helpers — standard pattern.
 # S608: f-string SQL over internal parquet paths only (no user input).
-# S310: urlopen against a fixed archive.org URL constant, not user input.
-"src/datajud/__main__.py" = ["PLC0415", "FBT001", "FBT002", "S608", "S310"]
+# S310: urlopen against a fixed archive.org URL constant, not user input (inline noqa).
+"src/datajud/service.py" = ["PLC0415", "S608"]
 
 # ── Lazy / conditional imports in library modules ─────────────────────────
 # These modules defer expensive imports to avoid slowing every process start.

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -73,7 +73,7 @@ from scripts.reconcile_processos import (
     _STJ_AGG_SQL,
     _UNIFICADOS_SQL,
 )
-from tjro_juris.__main__ import _PARQUET_SCHEMA as _TJRO_JURIS_SCHEMA
+from tjro_juris.service import _PARQUET_SCHEMA as _TJRO_JURIS_SCHEMA
 
 
 QUERIES_DIR = ROOT / "web" / "src" / "queries"

--- a/src/datajud/__main__.py
+++ b/src/datajud/__main__.py
@@ -19,8 +19,8 @@ Aggregate the acervo without downloading documents / show manifest state::
     uv run datajud status
 
 In CI, ``.github/workflows/datajud-enrich.yml`` runs the same commands with
-secrets injected. It is ``workflow_dispatch`` only (no cron) — trigger it
-manually from the Actions tab.
+secrets injected, daily (``--tribunal tjro --limit 500``) plus
+``workflow_dispatch`` for ad-hoc runs with different inputs.
 
 Business logic lives in ``datajud.service`` (RFC 0013 Fase 2); this module
 only parses argv and echoes results. ``IA_ACCESS_KEY``/``IA_SECRET_KEY`` are

--- a/src/datajud/__main__.py
+++ b/src/datajud/__main__.py
@@ -21,187 +21,31 @@ Aggregate the acervo without downloading documents / show manifest state::
 In CI, ``.github/workflows/datajud-enrich.yml`` runs the same commands with
 secrets injected. It is ``workflow_dispatch`` only (no cron) — trigger it
 manually from the Actions tab.
+
+Business logic lives in ``datajud.service`` (RFC 0013 Fase 2); this module
+only parses argv and echoes results. ``IA_ACCESS_KEY``/``IA_SECRET_KEY`` are
+read from the environment only — not CLI options — so they never appear in
+``--help`` or in a future MCP tool's schema.
 """
 
 from __future__ import annotations
 
 import asyncio
-import urllib.request
-from collections import Counter
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
 
 import httpx
-import structlog
 import typer
-from pydantic import ValidationError
 
-from datajud import archive
-from datajud.client import DEFAULT_TRIBUNAL, FACET_FIELDS, DataJudClient, DataJudError
-from datajud.dedup import capa_row_key, dedup_capas, merge_capa_rows, merge_movimento_rows
-from datajud.manifest import STATUS_OK, ManifestDataJud
-from datajud.models import ProcessoCapa, normalizar_cnj
+from datajud import service
+from datajud.client import DEFAULT_TRIBUNAL, FACET_FIELDS, DataJudError
 
-
-log = structlog.get_logger()
 
 app = typer.Typer(
     name="datajud",
     help="DataJud (CNJ) — enriquecimento de metadados processuais (capa + movimentos).",
     no_args_is_help=True,
 )
-
-_DEFAULT_DATA_DIR = Path("data/datajud")
-_DEFAULT_SOURCES_DIR = Path("data")
-_MANIFEST_NAME = "datajud-manifest.csv"
-
-_UNIFICADOS_IA_URL = (
-    "https://archive.org/download/causaganha-dashboard/processos_unificados.parquet"
-)
-
-
-def _manifest_path(data_dir: Path) -> Path:
-    return data_dir / _MANIFEST_NAME
-
-
-# ── CNJ sources ──────────────────────────────────────────────────────────
-
-
-def _read_cnj_file(path: Path) -> list[str]:
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-
-
-def _source_selects(sources_dir: Path) -> list[str]:
-    selects: list[str] = []
-    unificados = sources_dir / "processos_unificados.parquet"
-    if unificados.exists():
-        selects.append(f"SELECT nr_processo AS cnj FROM read_parquet('{unificados}')")
-    juris_files = sorted(sources_dir.glob("tjro-juris/*/tjro-juris-*.parquet"))
-    if juris_files:
-        juris_list = ", ".join(f"'{p}'" for p in juris_files)
-        selects.append(f"SELECT nr_processo AS cnj FROM read_parquet([{juris_list}])")
-    stj = sources_dir / "stj" / "stj-acordaos.parquet"
-    if stj.exists():
-        selects.append(f"SELECT \"numeroProcesso\" AS cnj FROM read_parquet('{stj}')")
-    return selects
-
-
-def _try_download_unificados(sources_dir: Path) -> None:
-    """Best-effort download of processos_unificados from IA (CI cold start)."""
-    dest = sources_dir / "processos_unificados.parquet"
-    typer.echo(f"No local sources — trying {_UNIFICADOS_IA_URL}")
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with urllib.request.urlopen(_UNIFICADOS_IA_URL, timeout=180) as resp:
-            dest.write_bytes(resp.read())
-    except OSError as exc:
-        typer.echo(f"  WARNING: could not download processos_unificados — {exc}", err=True)
-
-
-def _collect_source_cnjs(sources_dir: Path) -> list[str]:
-    """Distinct valid CNJs from the local source parquets (RFC 0010 §2)."""
-    import duckdb
-
-    selects = _source_selects(sources_dir)
-    if not selects:
-        _try_download_unificados(sources_dir)
-        selects = _source_selects(sources_dir)
-    if not selects:
-        return []
-    union = " UNION ALL ".join(selects)
-    sql = (
-        "SELECT DISTINCT regexp_replace(cnj, '[^0-9]', '', 'g') AS cnj "
-        f"FROM ({union}) "
-        "WHERE length(regexp_replace(cnj, '[^0-9]', '', 'g')) = 20 ORDER BY cnj"
-    )
-    con = duckdb.connect()
-    try:
-        rows = con.execute(sql).fetchall()
-    finally:
-        con.close()
-    return [row[0] for row in rows]
-
-
-def _gather_cnjs(cnj: list[str] | None, cnj_file: Path | None, sources_dir: Path) -> list[str]:
-    explicit: list[str] = list(cnj or [])
-    if cnj_file is not None:
-        explicit.extend(_read_cnj_file(cnj_file))
-    if explicit:
-        return explicit
-    return _collect_source_cnjs(sources_dir)
-
-
-# ── Parquet round-trip ───────────────────────────────────────────────────
-
-
-def _read_parquet_rows(path: Path) -> list[dict]:
-    if not path.exists():
-        return []
-    import duckdb
-
-    con = duckdb.connect()
-    try:
-        cursor = con.execute(f"SELECT * FROM read_parquet('{path}')")
-        columns = [d[0] for d in cursor.description]
-        return [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]
-    finally:
-        con.close()
-
-
-# ── Fetch ────────────────────────────────────────────────────────────────
-
-
-async def _fetch_capas(cnjs: list[str], tribunal: str, batch_size: int) -> list[ProcessoCapa]:
-    async with DataJudClient(tribunal=tribunal, batch_size=batch_size) as client:
-        sources = await client.fetch_processos(cnjs)
-    capas: list[ProcessoCapa] = []
-    for source in sources:
-        try:
-            capas.append(ProcessoCapa.from_source(source))
-        except ValidationError as exc:
-            log.warning(
-                "datajud_malformed_document",
-                error=str(exc),
-                numero_processo=source.get("numeroProcesso"),
-            )
-    return capas
-
-
-def _persist(
-    capas: list[ProcessoCapa],
-    tribunal: str,
-    data_dir: Path,
-) -> tuple[Path, Path, int, int]:
-    """Merge fresh capas into the tribunal parquets. Returns paths + counts."""
-    consultado_em = datetime.now(UTC).isoformat(timespec="seconds")
-    new_capa_rows = [c.capa_row(tribunal=tribunal, consultado_em=consultado_em) for c in capas]
-    new_mov_rows = [row for c in capas for row in c.movimento_rows(tribunal=tribunal)]
-    refreshed_keys = {capa_row_key(row) for row in new_capa_rows}
-
-    capa_path = data_dir / archive.capa_parquet_name(tribunal)
-    mov_path = data_dir / archive.movimentos_parquet_name(tribunal)
-    capa_rows = merge_capa_rows(_read_parquet_rows(capa_path), new_capa_rows)
-    mov_rows = merge_movimento_rows(_read_parquet_rows(mov_path), new_mov_rows, refreshed_keys)
-
-    n_capa = archive.write_capa_parquet(capa_rows, capa_path)
-    n_mov = archive.write_movimentos_parquet(mov_rows, mov_path)
-    return capa_path, mov_path, n_capa, n_mov
-
-
-def _upload(paths: list[Path], tribunal: str, ia_key: str, ia_secret: str) -> None:
-    if not ia_key or not ia_secret:
-        typer.echo("ERROR: IA_ACCESS_KEY and IA_SECRET_KEY must be set.", err=True)
-        raise typer.Exit(1)
-    for path in paths:
-        typer.echo(f"Uploading {path.name} to IA item {archive.item_id(tribunal)} …")
-        if not archive.upload_parquet(path, tribunal, ia_key, ia_secret):
-            typer.echo(f"Upload FAILED: {path.name}", err=True)
-            raise typer.Exit(1)
-    typer.echo("Upload complete.")
-
-
-# ── Commands ─────────────────────────────────────────────────────────────
 
 
 @app.command()
@@ -210,11 +54,11 @@ def enrich(
         DEFAULT_TRIBUNAL
     ),
     data_dir: Annotated[Path, typer.Option(help="Diretório dos parquets/manifest DataJud.")] = (
-        _DEFAULT_DATA_DIR
+        service.DEFAULT_DATA_DIR
     ),
     sources_dir: Annotated[
         Path, typer.Option(help="Diretório com os parquets-fonte de CNJs (data/).")
-    ] = _DEFAULT_SOURCES_DIR,
+    ] = service.DEFAULT_SOURCES_DIR,
     cnj: Annotated[
         list[str] | None, typer.Option("--cnj", help="CNJ explícito (repetível).")
     ] = None,
@@ -227,57 +71,49 @@ def enrich(
     skip_upload: Annotated[
         bool, typer.Option("--skip-upload", help="Não envia os parquets ao IA.")
     ] = False,
-    ia_key: Annotated[str, typer.Option(envvar="IA_ACCESS_KEY", help="IA S3 access key.")] = "",
-    ia_secret: Annotated[str, typer.Option(envvar="IA_SECRET_KEY", help="IA S3 secret key.")] = "",
 ) -> None:
     """Consulta capa + movimentos dos CNJs conhecidos e arquiva parquets no IA."""
-    candidates = _gather_cnjs(cnj, cnj_file, sources_dir)
-    if not candidates:
+    ia_key, ia_secret = service.ia_credentials()
+    result = service.enrich(
+        tribunal,
+        data_dir,
+        sources_dir,
+        cnj,
+        cnj_file,
+        limit,
+        max_age_days,
+        batch_size,
+        skip_upload=skip_upload,
+        ia_key=ia_key,
+        ia_secret=ia_secret,
+    )
+
+    if result.status == "no_cnjs":
         typer.echo("No CNJs found (no local source parquets and no --cnj/--cnj-file).", err=True)
         raise typer.Exit(1)
-
-    manifest = ManifestDataJud.load_local(_manifest_path(data_dir))
-    pending: list[str] = []
-    seen: set[str] = set()
-    for raw in candidates:
-        norm = normalizar_cnj(raw)
-        if not norm or norm in seen:
-            continue
-        seen.add(norm)
-        if manifest.needs_refresh(norm, tribunal, max_age_days=max_age_days):
-            pending.append(norm)
-    if limit > 0:
-        pending = pending[:limit]
-
-    if not pending:
+    if result.status == "nothing_to_do":
         typer.echo("Nothing to do — all CNJs are fresh in the manifest.")
         return
+    if result.status == "fetch_error":
+        typer.echo(f"ERROR: {result.error}", err=True)
+        raise typer.Exit(1)
 
-    typer.echo(f"Consulting {len(pending)} CNJ(s) on {tribunal.upper()} …")
-    try:
-        capas = dedup_capas(asyncio.run(_fetch_capas(pending, tribunal, batch_size)))
-    except (DataJudError, httpx.HTTPError) as exc:
-        typer.echo(f"ERROR: {exc}", err=True)
-        raise typer.Exit(1) from exc
+    typer.echo(f"  {result.n_capa:,} capa rows → {result.capa_path}")
+    typer.echo(f"  {result.n_mov:,} movimento rows → {result.mov_path}")
 
-    capa_path, mov_path, n_capa, n_mov = _persist(capas, tribunal, data_dir)
-    typer.echo(f"  {n_capa:,} capa rows → {capa_path}")
-    typer.echo(f"  {n_mov:,} movimento rows → {mov_path}")
+    if result.status == "missing_credentials":
+        typer.echo("ERROR: IA_ACCESS_KEY and IA_SECRET_KEY must be set.", err=True)
+        raise typer.Exit(1)
+    if result.status == "upload_error":
+        typer.echo(f"Upload FAILED: {result.error}", err=True)
+        raise typer.Exit(1)
 
-    # Mark the manifest fresh only after a successful upload (or an explicit
-    # --skip-upload) — otherwise a failed IA push would be indistinguishable
-    # from a completed one, and needs_refresh() would skip these CNJs for up
-    # to max_age_days before the upload is ever retried.
     if skip_upload:
         typer.echo("Skipping IA upload (--skip-upload).")
     else:
-        _upload([capa_path, mov_path], tribunal, ia_key, ia_secret)
+        typer.echo("Upload complete.")
 
-    found = Counter(capa.cnj for capa in capas)
-    for consulted in pending:
-        manifest.upsert(consulted, tribunal, docs=found.get(consulted, 0), status=STATUS_OK)
-    manifest.save_local(_manifest_path(data_dir))
-    typer.echo(f"Manifest saved ({len(manifest)} entries).")
+    typer.echo(f"Manifest saved ({result.manifest_entries} entries).")
 
 
 @app.command()
@@ -293,12 +129,8 @@ def facetas(
         typer.echo(f"ERROR: --por must be one of: {', '.join(FACET_FIELDS)}.", err=True)
         raise typer.Exit(2)
 
-    async def _run() -> tuple[int, list[dict]]:
-        async with DataJudClient(tribunal=tribunal) as client:
-            return await client.facetas(por, limite=limite)
-
     try:
-        total, buckets = asyncio.run(_run())
+        total, buckets = asyncio.run(service.facetas(tribunal, por, limite))
     except (DataJudError, httpx.HTTPError) as exc:
         typer.echo(f"ERROR: {exc}", err=True)
         raise typer.Exit(1) from exc
@@ -313,23 +145,20 @@ def facetas(
 @app.command()
 def status(
     data_dir: Annotated[Path, typer.Option(help="Diretório dos parquets/manifest DataJud.")] = (
-        _DEFAULT_DATA_DIR
+        service.DEFAULT_DATA_DIR
     ),
 ) -> None:
     """Mostra o estado do manifest DataJud."""
-    manifest = ManifestDataJud.load_local(_manifest_path(data_dir))
-    entries = manifest.all_entries()
-    if not entries:
+    result = service.manifest_status(data_dir)
+    if result is None:
         typer.echo("Manifest is empty or not found.")
         return
-    ok = sum(1 for e in entries if e.status == STATUS_OK)
-    com_docs = sum(1 for e in entries if e.status == STATUS_OK and e.docs > 0)
-    typer.echo(f"DataJud manifest: {_manifest_path(data_dir)}")
-    typer.echo(f"  CNJs consultados : {len(entries)}")
-    typer.echo(f"  Status ok        : {ok}")
-    typer.echo(f"  Com documentos   : {com_docs}")
-    typer.echo(f"  Sem documentos   : {ok - com_docs}")
-    typer.echo(f"  Com erro         : {len(entries) - ok}")
+    typer.echo(f"DataJud manifest: {service.manifest_path(data_dir)}")
+    typer.echo(f"  CNJs consultados : {result.total}")
+    typer.echo(f"  Status ok        : {result.ok}")
+    typer.echo(f"  Com documentos   : {result.com_docs}")
+    typer.echo(f"  Sem documentos   : {result.sem_docs}")
+    typer.echo(f"  Com erro         : {result.com_erro}")
 
 
 if __name__ == "__main__":

--- a/src/datajud/service.py
+++ b/src/datajud/service.py
@@ -1,0 +1,352 @@
+"""Config→result service layer for ``datajud``, free of Typer/echo (RFC 0013 Fase 2).
+
+``__main__.py`` owns argv parsing and echoing results; this module owns the
+actual work — gathering CNJs, fetching/persisting capa+movimentos, uploading
+— so it can be called from a future MCP tool or a different CLI framework
+without dragging Typer along. Also drops ``ia_key``/``ia_secret`` as CLI
+options: Internet Archive credentials are read from the environment only
+(``ia_credentials``), never exposed as a parameter a schema (CLI or future
+MCP tool) could carry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import httpx
+import structlog
+from pydantic import ValidationError
+
+from datajud import archive
+from datajud.client import DataJudClient, DataJudError
+from datajud.dedup import capa_row_key, dedup_capas, merge_capa_rows, merge_movimento_rows
+from datajud.manifest import STATUS_OK, ManifestDataJud
+from datajud.models import ProcessoCapa, normalizar_cnj
+
+
+log = structlog.get_logger()
+
+DEFAULT_DATA_DIR = Path("data/datajud")
+DEFAULT_SOURCES_DIR = Path("data")
+MANIFEST_NAME = "datajud-manifest.csv"
+
+UNIFICADOS_IA_URL = "https://archive.org/download/causaganha-dashboard/processos_unificados.parquet"
+
+
+def manifest_path(data_dir: Path) -> Path:
+    """Path to the local manifest CSV under *data_dir*."""
+    return data_dir / MANIFEST_NAME
+
+
+def ia_credentials() -> tuple[str, str]:
+    """Read Internet Archive S3 credentials from the environment."""
+    return os.environ.get("IA_ACCESS_KEY", ""), os.environ.get("IA_SECRET_KEY", "")
+
+
+# ── CNJ sources ──────────────────────────────────────────────────────────
+
+
+def _read_cnj_file(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _source_selects(sources_dir: Path) -> list[str]:
+    selects: list[str] = []
+    unificados = sources_dir / "processos_unificados.parquet"
+    if unificados.exists():
+        selects.append(f"SELECT nr_processo AS cnj FROM read_parquet('{unificados}')")
+    juris_files = sorted(sources_dir.glob("tjro-juris/*/tjro-juris-*.parquet"))
+    if juris_files:
+        juris_list = ", ".join(f"'{p}'" for p in juris_files)
+        selects.append(f"SELECT nr_processo AS cnj FROM read_parquet([{juris_list}])")
+    stj = sources_dir / "stj" / "stj-acordaos.parquet"
+    if stj.exists():
+        selects.append(f"SELECT \"numeroProcesso\" AS cnj FROM read_parquet('{stj}')")
+    return selects
+
+
+def _try_download_unificados(sources_dir: Path) -> None:
+    """Best-effort download of processos_unificados from IA (CI cold start)."""
+    dest = sources_dir / "processos_unificados.parquet"
+    log.info("datajud_downloading_unificados", url=UNIFICADOS_IA_URL)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(UNIFICADOS_IA_URL, timeout=180) as resp:  # noqa: S310
+            dest.write_bytes(resp.read())
+    except OSError as exc:
+        log.warning("datajud_unificados_download_failed", error=str(exc))
+
+
+def _collect_source_cnjs(sources_dir: Path) -> list[str]:
+    """Distinct valid CNJs from the local source parquets (RFC 0010 §2)."""
+    import duckdb
+
+    selects = _source_selects(sources_dir)
+    if not selects:
+        _try_download_unificados(sources_dir)
+        selects = _source_selects(sources_dir)
+    if not selects:
+        return []
+    union = " UNION ALL ".join(selects)
+    sql = (
+        "SELECT DISTINCT regexp_replace(cnj, '[^0-9]', '', 'g') AS cnj "
+        f"FROM ({union}) "
+        "WHERE length(regexp_replace(cnj, '[^0-9]', '', 'g')) = 20 ORDER BY cnj"
+    )
+    con = duckdb.connect()
+    try:
+        rows = con.execute(sql).fetchall()
+    finally:
+        con.close()
+    return [row[0] for row in rows]
+
+
+def gather_cnjs(cnj: list[str] | None, cnj_file: Path | None, sources_dir: Path) -> list[str]:
+    """Resolve the CNJs to consult: explicit --cnj/--cnj-file, else local source parquets."""
+    explicit: list[str] = list(cnj or [])
+    if cnj_file is not None:
+        explicit.extend(_read_cnj_file(cnj_file))
+    if explicit:
+        return explicit
+    return _collect_source_cnjs(sources_dir)
+
+
+# ── Parquet round-trip ───────────────────────────────────────────────────
+
+
+def _read_parquet_rows(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    import duckdb
+
+    con = duckdb.connect()
+    try:
+        cursor = con.execute(f"SELECT * FROM read_parquet('{path}')")
+        columns = [d[0] for d in cursor.description]
+        return [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]
+    finally:
+        con.close()
+
+
+# ── Fetch ────────────────────────────────────────────────────────────────
+
+
+async def fetch_capas(cnjs: list[str], tribunal: str, batch_size: int) -> list[ProcessoCapa]:
+    """Fetch capa+movimentos for *cnjs* from the DataJud API."""
+    async with DataJudClient(tribunal=tribunal, batch_size=batch_size) as client:
+        sources = await client.fetch_processos(cnjs)
+    capas: list[ProcessoCapa] = []
+    for source in sources:
+        try:
+            capas.append(ProcessoCapa.from_source(source))
+        except ValidationError as exc:
+            log.warning(
+                "datajud_malformed_document",
+                error=str(exc),
+                numero_processo=source.get("numeroProcesso"),
+            )
+    return capas
+
+
+def persist(
+    capas: list[ProcessoCapa],
+    tribunal: str,
+    data_dir: Path,
+) -> tuple[Path, Path, int, int]:
+    """Merge fresh capas into the tribunal parquets. Returns paths + counts."""
+    consultado_em = datetime.now(UTC).isoformat(timespec="seconds")
+    new_capa_rows = [c.capa_row(tribunal=tribunal, consultado_em=consultado_em) for c in capas]
+    new_mov_rows = [row for c in capas for row in c.movimento_rows(tribunal=tribunal)]
+    refreshed_keys = {capa_row_key(row) for row in new_capa_rows}
+
+    capa_path = data_dir / archive.capa_parquet_name(tribunal)
+    mov_path = data_dir / archive.movimentos_parquet_name(tribunal)
+    capa_rows = merge_capa_rows(_read_parquet_rows(capa_path), new_capa_rows)
+    mov_rows = merge_movimento_rows(_read_parquet_rows(mov_path), new_mov_rows, refreshed_keys)
+
+    n_capa = archive.write_capa_parquet(capa_rows, capa_path)
+    n_mov = archive.write_movimentos_parquet(mov_rows, mov_path)
+    return capa_path, mov_path, n_capa, n_mov
+
+
+@dataclass
+class UploadResult:
+    """Result of ``upload_parquets``."""
+
+    ok: bool
+    failed_file: str | None = None
+
+
+def upload_parquets(paths: list[Path], tribunal: str, ia_key: str, ia_secret: str) -> UploadResult:
+    """Upload *paths* to the ``datajud-{tribunal}`` IA item, stopping at the first failure."""
+    for path in paths:
+        log.info("datajud_uploading", file=path.name, item=archive.item_id(tribunal))
+        if not archive.upload_parquet(path, tribunal, ia_key, ia_secret):
+            return UploadResult(ok=False, failed_file=path.name)
+    return UploadResult(ok=True)
+
+
+@dataclass
+class EnrichResult:
+    """Result of ``enrich``."""
+
+    status: Literal[
+        "no_cnjs",
+        "nothing_to_do",
+        "fetch_error",
+        "missing_credentials",
+        "upload_error",
+        "done",
+    ]
+    error: str = ""
+    pending: list[str] = field(default_factory=list)
+    capa_path: Path | None = None
+    mov_path: Path | None = None
+    n_capa: int = 0
+    n_mov: int = 0
+    manifest_entries: int = 0
+
+
+def _upload_step(
+    capa_path: Path,
+    mov_path: Path,
+    tribunal: str,
+    ia_key: str,
+    ia_secret: str,
+) -> tuple[Literal["missing_credentials", "upload_error"], str] | None:
+    """Attempt the IA upload for ``enrich``; returns ``(status, error)`` on failure, else None."""
+    if not ia_key or not ia_secret:
+        return "missing_credentials", ""
+    result = upload_parquets([capa_path, mov_path], tribunal, ia_key, ia_secret)
+    if not result.ok:
+        return "upload_error", result.failed_file or ""
+    return None
+
+
+def _pending_cnjs(
+    candidates: list[str],
+    manifest: ManifestDataJud,
+    tribunal: str,
+    max_age_days: int,
+    limit: int,
+) -> list[str]:
+    """Dedup *candidates* and keep only those stale per the manifest, capped at *limit*."""
+    pending: list[str] = []
+    seen: set[str] = set()
+    for raw in candidates:
+        norm = normalizar_cnj(raw)
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        if manifest.needs_refresh(norm, tribunal, max_age_days=max_age_days):
+            pending.append(norm)
+    return pending[:limit] if limit > 0 else pending
+
+
+def enrich(
+    tribunal: str,
+    data_dir: Path,
+    sources_dir: Path,
+    cnj: list[str] | None,
+    cnj_file: Path | None,
+    limit: int,
+    max_age_days: int,
+    batch_size: int,
+    *,
+    skip_upload: bool,
+    ia_key: str,
+    ia_secret: str,
+) -> EnrichResult:
+    """Consulta capa + movimentos dos CNJs pendentes e arquiva parquets no IA."""
+    candidates = gather_cnjs(cnj, cnj_file, sources_dir)
+    if not candidates:
+        return EnrichResult(status="no_cnjs")
+
+    manifest = ManifestDataJud.load_local(manifest_path(data_dir))
+    pending = _pending_cnjs(candidates, manifest, tribunal, max_age_days, limit)
+
+    if not pending:
+        return EnrichResult(status="nothing_to_do")
+
+    log.info("datajud_consulting", count=len(pending), tribunal=tribunal.upper())
+    try:
+        capas = dedup_capas(asyncio.run(fetch_capas(pending, tribunal, batch_size)))
+    except (DataJudError, httpx.HTTPError) as exc:
+        return EnrichResult(status="fetch_error", error=str(exc))
+
+    capa_path, mov_path, n_capa, n_mov = persist(capas, tribunal, data_dir)
+
+    # Mark the manifest fresh only after a successful upload (or an explicit
+    # --skip-upload) — otherwise a failed IA push would be indistinguishable
+    # from a completed one, and needs_refresh() would skip these CNJs for up
+    # to max_age_days before the upload is ever retried.
+    if not skip_upload:
+        failure = _upload_step(capa_path, mov_path, tribunal, ia_key, ia_secret)
+        if failure is not None:
+            status, error = failure
+            return EnrichResult(
+                status=status,
+                error=error,
+                capa_path=capa_path,
+                mov_path=mov_path,
+                n_capa=n_capa,
+                n_mov=n_mov,
+            )
+
+    found = Counter(capa.cnj for capa in capas)
+    for consulted in pending:
+        manifest.upsert(consulted, tribunal, docs=found.get(consulted, 0), status=STATUS_OK)
+    manifest.save_local(manifest_path(data_dir))
+
+    return EnrichResult(
+        status="done",
+        pending=pending,
+        capa_path=capa_path,
+        mov_path=mov_path,
+        n_capa=n_capa,
+        n_mov=n_mov,
+        manifest_entries=len(manifest),
+    )
+
+
+async def facetas(tribunal: str, por: str, limite: int) -> tuple[int, list[dict]]:
+    """Aggregate the acervo by *por* (classe/assunto/orgao/...) without downloading docs."""
+    async with DataJudClient(tribunal=tribunal) as client:
+        return await client.facetas(por, limite=limite)
+
+
+@dataclass
+class ManifestStatus:
+    """Summary of the DataJud manifest for the ``status`` command."""
+
+    total: int
+    ok: int
+    com_docs: int
+
+    @property
+    def sem_docs(self) -> int:
+        """CNJs consulted successfully but with no documents found."""
+        return self.ok - self.com_docs
+
+    @property
+    def com_erro(self) -> int:
+        """CNJs whose last consult failed."""
+        return self.total - self.ok
+
+
+def manifest_status(data_dir: Path) -> ManifestStatus | None:
+    """Summarize the local manifest, or None when it's empty/missing."""
+    manifest = ManifestDataJud.load_local(manifest_path(data_dir))
+    entries = manifest.all_entries()
+    if not entries:
+        return None
+    ok = sum(1 for e in entries if e.status == STATUS_OK)
+    com_docs = sum(1 for e in entries if e.status == STATUS_OK and e.docs > 0)
+    return ManifestStatus(total=len(entries), ok=ok, com_docs=com_docs)

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -27,11 +27,9 @@ from rich.table import Table
 
 from djen_backup import service
 from djen_backup.drain import PARQUET_URL
-from djen_backup.drain import drain as _drain
 from djen_backup.engine import SyncSummary, load_djen_safe_concurrency
-from djen_backup.manifest import ManifestCounts, SyncManifest
+from djen_backup.manifest import ManifestCounts
 from djen_backup.probe import PARQUET_URL as _PROBE_PARQUET_URL
-from djen_backup.probe import probe as _probe
 from djen_backup.service import MissingCredentialsError, PipelineRunConfig
 
 
@@ -353,7 +351,6 @@ def main(
     raise typer.Exit(
         code=_run_pipeline(
             PipelineRunConfig(
-                start_date=date(2020, 1, 1),
                 end_date=_parse_date(end_date),
                 lower_bound=_parse_date(start_date),
                 tribunal=tribunal,
@@ -385,7 +382,6 @@ def check(
     raise typer.Exit(
         code=_run_pipeline(
             PipelineRunConfig(
-                start_date=date(2020, 1, 1),
                 end_date=_parse_date(end_date),
                 lower_bound=_parse_date(start_date),
                 tribunal=tribunal,
@@ -416,7 +412,6 @@ def upload(
     raise typer.Exit(
         code=_run_pipeline(
             PipelineRunConfig(
-                start_date=date(2020, 1, 1),
                 end_date=datetime.now(UTC).date(),
                 lower_bound=None,
                 tribunal=tribunal,
@@ -469,11 +464,11 @@ def drain(
     )
 
     uploads = asyncio.run(
-        _drain(
+        service.run_drain(
             workers=workers,
             batch_size=batch_size,
-            deadline_seconds=deadline_minutes * 60,
-            djen_proxy_url=djen_url,
+            deadline_minutes=deadline_minutes,
+            djen_url=djen_url,
             ia_auth=auth,
         )
     )
@@ -523,11 +518,11 @@ def probe(
     )
 
     confirmed, absent = asyncio.run(
-        _probe(
+        service.run_probe(
             workers=workers,
             batch_size=batch_size,
-            deadline_seconds=deadline_minutes * 60,
-            djen_proxy_url=djen_url,
+            deadline_minutes=deadline_minutes,
+            djen_url=djen_url,
             ia_auth=auth,
         )
     )
@@ -554,25 +549,14 @@ def reset(
         console.print("[bold red]Error:[/bold red] provide --tribunal CODE or --all")
         raise typer.Exit(code=1)
 
-    manifest = SyncManifest()
-    manifest.load_from_disk(manifest_file)
-
-    if not manifest:
+    try:
+        result = service.reset_manifest(manifest_file, tribunal=tribunal, reset_all=reset_all)
+    except service.ManifestNotFoundError:
         console.print("[bold red]Error:[/bold red] manifest file not found or empty.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
-    # Reset entries by rebuilding without the targeted entries
-    count = 0
-    for _k, entry in list(manifest._entries.items()):  # noqa: SLF001
-        if reset_all or (tribunal and entry.tribunal == tribunal.upper()):
-            entry.ia_status = ""
-            entry.djen_status = ""
-            entry.updated_at = ""
-            count += 1
-
-    if count > 0:
-        manifest.save_to_disk(manifest_file)
-        console.print(f"[green]Reset {count} entries.[/green]")
+    if result.count > 0:
+        console.print(f"[green]Reset {result.count} entries.[/green]")
     else:
         console.print("[yellow]Nothing to reset.[/yellow]")
 

--- a/src/djen_backup/__main__.py
+++ b/src/djen_backup/__main__.py
@@ -2,20 +2,10 @@
 
 from __future__ import annotations
 
-import contextlib
-
-# Safely reconfigure standard output and standard error encoding error handling on Windows
-import sys
-
-
-for stream in (sys.stdout, sys.stderr):
-    if stream and stream.encoding and stream.encoding.lower() != "utf-8":
-        with contextlib.suppress(AttributeError):
-            stream.reconfigure(errors="replace")
-
 import asyncio
+import contextlib
 import os
-from dataclasses import dataclass
+import sys
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import NamedTuple
@@ -35,20 +25,50 @@ from rich.progress import (
 )
 from rich.table import Table
 
-from djen_backup.credentials import get_ia_s3_auth
+from djen_backup import service
 from djen_backup.drain import PARQUET_URL
 from djen_backup.drain import drain as _drain
-from djen_backup.engine import SyncConfig, SyncSummary, load_djen_safe_concurrency, run_sync
+from djen_backup.engine import SyncSummary, load_djen_safe_concurrency
 from djen_backup.manifest import ManifestCounts, SyncManifest
 from djen_backup.probe import PARQUET_URL as _PROBE_PARQUET_URL
 from djen_backup.probe import probe as _probe
+from djen_backup.service import MissingCredentialsError, PipelineRunConfig
 
-
-DJEN_DIRECT_URL = "https://comunicaapi.pje.jus.br"
-DJEN_PROXY_FALLBACK_URL = "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
 
 # Default worker count — discovered via scripts/stress_test_djen.py
 DEFAULT_WORKERS = load_djen_safe_concurrency()
+
+
+def configure_runtime() -> None:
+    """Reconfigure stdio encoding and structlog for CLI use.
+
+    Called once, from the Typer callback below, before any command body
+    runs — Click always invokes the group callback first, so this covers
+    every subcommand too. Previously ran at import time, which meant
+    anything importing this module (a test, a future MCP server process)
+    silently reconfigured the whole process's stdout/stderr and global
+    structlog state.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if stream and stream.encoding and stream.encoding.lower() != "utf-8":
+            with contextlib.suppress(AttributeError):
+                stream.reconfigure(errors="replace")
+
+    # Configure structlog to use Rich for pretty logging
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.dev.ConsoleRenderer(colors=True),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(0),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
 
 
 class EnvLoadResult(NamedTuple):
@@ -63,22 +83,6 @@ app = typer.Typer(
     no_args_is_help=False,
 )
 console = Console()
-
-# Configure structlog to use Rich for pretty logging
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.dev.set_exc_info,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.dev.ConsoleRenderer(colors=True),
-    ],
-    wrapper_class=structlog.make_filtering_bound_logger(0),
-    context_class=dict,
-    logger_factory=structlog.PrintLoggerFactory(),
-    cache_logger_on_first_use=True,
-)
 
 # ── Rich Observer ───────────────────────────────────────────────────
 
@@ -193,18 +197,10 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _resolve_djen_url(*, use_proxy: bool) -> str:
-    if use_proxy:
-        return os.environ.get("DJEN_PROXY_URL", "").strip() or DJEN_PROXY_FALLBACK_URL
-    return os.environ.get("DJEN_DIRECT_URL", "").strip() or DJEN_DIRECT_URL
-
-
-def _resolve_ia_auth(*, dry_run: bool) -> str:
+def _resolve_ia_auth() -> str:
     try:
-        return get_ia_s3_auth()
-    except RuntimeError as exc:
-        if dry_run:
-            return "LOW dry-run:dry-run"
+        return service.resolve_ia_auth()
+    except MissingCredentialsError as exc:
         console.print(f"[bold red]Error:[/bold red] {exc}")
         raise typer.Exit(code=1) from exc
 
@@ -275,31 +271,13 @@ def _show_run_summary(
     )
 
 
-@dataclass
-class PipelineRunConfig:
-    start_date: date
-    end_date: date
-    lower_bound: date | None
-    tribunal: str | None
-    deadline_minutes: int
-    max_items: int
-    workers: int
-    fail_fast: bool
-    publish_live_status: bool
-    skip_if_mostly_complete: bool
-    use_proxy: bool
-    upload_only: bool = False
-    check_only: bool = False
-    mode_label: str = "Full Sync"
-
-
 def _run_pipeline(c: PipelineRunConfig) -> int:
     env_result = _load_local_env()
     show_banner()
     _show_env_hint(env_result)
 
-    djen_url = _resolve_djen_url(use_proxy=c.use_proxy)
-    auth = _resolve_ia_auth(dry_run=False)
+    djen_url = service.resolve_djen_url(use_proxy=c.use_proxy)
+    auth = _resolve_ia_auth()
 
     config_table = Table.grid(padding=(0, 2))
     config_table.add_column(style="bold cyan")
@@ -330,30 +308,13 @@ def _run_pipeline(c: PipelineRunConfig) -> int:
     )
     observer = RichManifestObserver(progress)
 
-    sync_config = SyncConfig(
-        start_date=c.end_date,
-        lower_bound=c.lower_bound,
-        tribunal=c.tribunal,
-        deadline_minutes=c.deadline_minutes,
-        max_items=c.max_items,
-        workers=c.workers,
-        manifest_file=Path("data/sync-manifest.csv"),
-        djen_proxy_url=djen_url,
-        ia_auth=auth,
-        dry_run=False,
-        fail_fast=c.fail_fast,
-        publish_live_status=c.publish_live_status,
-        skip_if_mostly_complete=c.skip_if_mostly_complete,
-        check_only=c.check_only,
-        upload_only=c.upload_only,
-        observer=observer,
-    )
-
     exit_code = 0
     interrupted = False
     try:
         with Live(Group(progress), console=console, refresh_per_second=4):
-            exit_code, summary = asyncio.run(run_sync(sync_config))
+            exit_code, summary = asyncio.run(
+                service.run_pipeline(c, djen_url=djen_url, ia_auth=auth, observer=observer)
+            )
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted — manifest saved to disk.[/yellow]")
         return 130
@@ -386,21 +347,24 @@ def main(
     use_proxy: bool = typer.Option(False, help="Use DJEN proxy."),
 ) -> None:
     """Main backup and sync command (check + download + upload)."""
+    configure_runtime()
     if ctx.invoked_subcommand:
         return
-    _run_pipeline(
-        PipelineRunConfig(
-            start_date=date(2020, 1, 1),
-            end_date=_parse_date(end_date),
-            lower_bound=_parse_date(start_date),
-            tribunal=tribunal,
-            deadline_minutes=deadline_minutes,
-            max_items=max_items,
-            workers=workers,
-            fail_fast=fail_fast,
-            publish_live_status=False,
-            skip_if_mostly_complete=False,
-            use_proxy=use_proxy,
+    raise typer.Exit(
+        code=_run_pipeline(
+            PipelineRunConfig(
+                start_date=date(2020, 1, 1),
+                end_date=_parse_date(end_date),
+                lower_bound=_parse_date(start_date),
+                tribunal=tribunal,
+                deadline_minutes=deadline_minutes,
+                max_items=max_items,
+                workers=workers,
+                fail_fast=fail_fast,
+                publish_live_status=False,
+                skip_if_mostly_complete=False,
+                use_proxy=use_proxy,
+            )
         )
     )
 
@@ -418,21 +382,23 @@ def check(
     use_proxy: bool = typer.Option(False, help="Use DJEN proxy."),
 ) -> None:
     """Check DJEN availability without downloading/uploading."""
-    _run_pipeline(
-        PipelineRunConfig(
-            start_date=date(2020, 1, 1),
-            end_date=_parse_date(end_date),
-            lower_bound=_parse_date(start_date),
-            tribunal=tribunal,
-            deadline_minutes=deadline_minutes,
-            max_items=0,
-            workers=workers,
-            fail_fast=fail_fast,
-            publish_live_status=False,
-            skip_if_mostly_complete=False,
-            use_proxy=use_proxy,
-            check_only=True,
-            mode_label="Check Only",
+    raise typer.Exit(
+        code=_run_pipeline(
+            PipelineRunConfig(
+                start_date=date(2020, 1, 1),
+                end_date=_parse_date(end_date),
+                lower_bound=_parse_date(start_date),
+                tribunal=tribunal,
+                deadline_minutes=deadline_minutes,
+                max_items=0,
+                workers=workers,
+                fail_fast=fail_fast,
+                publish_live_status=False,
+                skip_if_mostly_complete=False,
+                use_proxy=use_proxy,
+                check_only=True,
+                mode_label="Check Only",
+            )
         )
     )
 
@@ -447,21 +413,23 @@ def upload(
     use_proxy: bool = typer.Option(False, help="Use DJEN proxy."),
 ) -> None:
     """Upload already-discovered available entries (backlog drain)."""
-    _run_pipeline(
-        PipelineRunConfig(
-            start_date=date(2020, 1, 1),
-            end_date=datetime.now(UTC).date(),
-            lower_bound=None,
-            tribunal=tribunal,
-            deadline_minutes=deadline_minutes,
-            max_items=max_items,
-            workers=workers,
-            fail_fast=fail_fast,
-            publish_live_status=False,
-            skip_if_mostly_complete=False,
-            use_proxy=use_proxy,
-            upload_only=True,
-            mode_label="Upload Only",
+    raise typer.Exit(
+        code=_run_pipeline(
+            PipelineRunConfig(
+                start_date=date(2020, 1, 1),
+                end_date=datetime.now(UTC).date(),
+                lower_bound=None,
+                tribunal=tribunal,
+                deadline_minutes=deadline_minutes,
+                max_items=max_items,
+                workers=workers,
+                fail_fast=fail_fast,
+                publish_live_status=False,
+                skip_if_mostly_complete=False,
+                use_proxy=use_proxy,
+                upload_only=True,
+                mode_label="Upload Only",
+            )
         )
     )
 
@@ -482,8 +450,8 @@ def drain(
     _show_env_hint(env_result)
 
     resolved_use_proxy = use_proxy or _env_truthy("DJEN_USE_PROXY")
-    djen_url = _resolve_djen_url(use_proxy=resolved_use_proxy)
-    auth = _resolve_ia_auth(dry_run=False)
+    djen_url = service.resolve_djen_url(use_proxy=resolved_use_proxy)
+    auth = _resolve_ia_auth()
 
     config_table = Table.grid(padding=(0, 2))
     config_table.add_column(style="bold cyan")
@@ -534,8 +502,8 @@ def probe(
     _show_env_hint(env_result)
 
     resolved_use_proxy = use_proxy or _env_truthy("DJEN_USE_PROXY")
-    djen_url = _resolve_djen_url(use_proxy=resolved_use_proxy)
-    auth = _resolve_ia_auth(dry_run=False)
+    djen_url = service.resolve_djen_url(use_proxy=resolved_use_proxy)
+    auth = _resolve_ia_auth()
 
     config_table = Table.grid(padding=(0, 2))
     config_table.add_column(style="bold cyan")

--- a/src/djen_backup/service.py
+++ b/src/djen_backup/service.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from djen_backup.credentials import get_ia_s3_auth
+from djen_backup.drain import drain as _run_drain
 from djen_backup.engine import ManifestObserver, SyncConfig, SyncSummary, run_sync
+from djen_backup.manifest import SyncManifest
+from djen_backup.probe import probe as _run_probe
 
 
 if TYPE_CHECKING:
@@ -33,7 +36,6 @@ class MissingCredentialsError(RuntimeError):
 class PipelineRunConfig:
     """Config for a single ``run_pipeline`` invocation."""
 
-    start_date: date
     end_date: date
     lower_bound: date | None
     tribunal: str | None
@@ -91,3 +93,75 @@ async def run_pipeline(
         observer=observer,
     )
     return await run_sync(sync_config)
+
+
+async def run_drain(
+    *,
+    workers: int,
+    batch_size: int,
+    deadline_minutes: int,
+    djen_url: str,
+    ia_auth: str,
+) -> int:
+    """Run the batched upload-only drain. Returns the number of uploads completed."""
+    return await _run_drain(
+        workers=workers,
+        batch_size=batch_size,
+        deadline_seconds=deadline_minutes * 60,
+        djen_proxy_url=djen_url,
+        ia_auth=ia_auth,
+    )
+
+
+async def run_probe(
+    *,
+    workers: int,
+    batch_size: int,
+    deadline_minutes: int,
+    djen_url: str,
+    ia_auth: str,
+) -> tuple[int, int]:
+    """Run the probe-only DJEN availability check. Returns ``(confirmed, absent)``."""
+    return await _run_probe(
+        workers=workers,
+        batch_size=batch_size,
+        deadline_seconds=deadline_minutes * 60,
+        djen_proxy_url=djen_url,
+        ia_auth=ia_auth,
+    )
+
+
+class ManifestNotFoundError(RuntimeError):
+    """The manifest file doesn't exist or is empty."""
+
+
+@dataclass
+class ResetResult:
+    """Result of ``reset_manifest``."""
+
+    count: int
+
+
+def reset_manifest(manifest_file: Path, *, tribunal: str | None, reset_all: bool) -> ResetResult:
+    """Clear ``ia_status``/``djen_status`` for entries matching *tribunal* (or all).
+
+    Raises ``ManifestNotFoundError`` when *manifest_file* doesn't exist or is empty.
+    """
+    manifest = SyncManifest()
+    manifest.load_from_disk(manifest_file)
+
+    if not manifest:
+        raise ManifestNotFoundError
+
+    count = 0
+    for _k, entry in list(manifest._entries.items()):  # noqa: SLF001
+        if reset_all or (tribunal and entry.tribunal == tribunal.upper()):
+            entry.ia_status = ""
+            entry.djen_status = ""
+            entry.updated_at = ""
+            count += 1
+
+    if count > 0:
+        manifest.save_to_disk(manifest_file)
+
+    return ResetResult(count=count)

--- a/src/djen_backup/service.py
+++ b/src/djen_backup/service.py
@@ -1,0 +1,93 @@
+"""Config→result service layer for ``djen-backup``, free of Typer/Rich (RFC 0013 Fase 2).
+
+``__main__.py`` owns argv parsing and Rich rendering; this module owns the
+actual work — resolving runtime config from the environment and driving the
+sync engine — so it can be called from a future MCP tool or a different CLI
+framework without dragging Typer/Rich along.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from djen_backup.credentials import get_ia_s3_auth
+from djen_backup.engine import ManifestObserver, SyncConfig, SyncSummary, run_sync
+
+
+if TYPE_CHECKING:
+    from datetime import date
+
+
+DJEN_DIRECT_URL = "https://comunicaapi.pje.jus.br"
+DJEN_PROXY_FALLBACK_URL = "https://djen-proxy-mhgmawcn3a-rj.a.run.app"
+
+
+class MissingCredentialsError(RuntimeError):
+    """Internet Archive S3 credentials could not be resolved."""
+
+
+@dataclass
+class PipelineRunConfig:
+    """Config for a single ``run_pipeline`` invocation."""
+
+    start_date: date
+    end_date: date
+    lower_bound: date | None
+    tribunal: str | None
+    deadline_minutes: int
+    max_items: int
+    workers: int
+    fail_fast: bool
+    publish_live_status: bool
+    skip_if_mostly_complete: bool
+    use_proxy: bool
+    upload_only: bool = False
+    check_only: bool = False
+    mode_label: str = "Full Sync"
+
+
+def resolve_djen_url(*, use_proxy: bool) -> str:
+    """Resolve the DJEN base URL to use, direct or proxied."""
+    if use_proxy:
+        return os.environ.get("DJEN_PROXY_URL", "").strip() or DJEN_PROXY_FALLBACK_URL
+    return os.environ.get("DJEN_DIRECT_URL", "").strip() or DJEN_DIRECT_URL
+
+
+def resolve_ia_auth() -> str:
+    """Resolve the Internet Archive S3 auth header, or raise ``MissingCredentialsError``."""
+    try:
+        return get_ia_s3_auth()
+    except RuntimeError as exc:
+        raise MissingCredentialsError(str(exc)) from exc
+
+
+async def run_pipeline(
+    config: PipelineRunConfig,
+    *,
+    djen_url: str,
+    ia_auth: str,
+    observer: ManifestObserver | None = None,
+) -> tuple[int, SyncSummary]:
+    """Run the sync engine for *config* and return ``(exit_code, summary)``."""
+    sync_config = SyncConfig(
+        start_date=config.end_date,
+        lower_bound=config.lower_bound,
+        tribunal=config.tribunal,
+        deadline_minutes=config.deadline_minutes,
+        max_items=config.max_items,
+        workers=config.workers,
+        manifest_file=Path("data/sync-manifest.csv"),
+        djen_proxy_url=djen_url,
+        ia_auth=ia_auth,
+        dry_run=False,
+        fail_fast=config.fail_fast,
+        publish_live_status=config.publish_live_status,
+        skip_if_mostly_complete=config.skip_if_mostly_complete,
+        check_only=config.check_only,
+        upload_only=config.upload_only,
+        observer=observer,
+    )
+    return await run_sync(sync_config)

--- a/src/stj_acordaos/__main__.py
+++ b/src/stj_acordaos/__main__.py
@@ -21,23 +21,21 @@ the public IA item so already-uploaded, unchanged resources are skipped;
 
 In CI, ``.github/workflows/stj-sync.yml`` runs the same commands with
 secrets injected, daily plus ``workflow_dispatch``.
+
+Business logic lives in ``stj_acordaos.service`` (RFC 0013 Fase 2); this
+module only parses argv and echoes results. ``IA_ACCESS_KEY``/
+``IA_SECRET_KEY`` are read from the environment only — not CLI options —
+so they never appear in ``--help`` or in a future MCP tool's schema.
 """
 
 from __future__ import annotations
 
-import zipfile
 from pathlib import Path
 
-import httpx
 import typer
 
-from stj_acordaos.archive import fetch_manifest
-from stj_acordaos.client import (
-    STJWAFBlockedError,
-    download_resource,
-    extract_zip,
-    get_resource_list,
-)
+from stj_acordaos import service
+from stj_acordaos.client import get_resource_list
 from stj_acordaos.manifest import ManifestSTJ
 
 
@@ -47,123 +45,31 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Default paths relative to project root (can be overridden via options)
-_DEFAULT_DATA_DIR = Path("data/stj")
-_DEFAULT_MANIFEST = _DEFAULT_DATA_DIR / "stj-manifest.csv"
-_DEFAULT_EXTRACT_DIR = _DEFAULT_DATA_DIR / "extracted"
-_DEFAULT_PARQUET = _DEFAULT_DATA_DIR / "stj-acordaos.parquet"
 
-
-def _classify_resource(fmt: str, url: str) -> str | None:
-    """Classify a CKAN resource as "zip" or "json"; None when neither.
-
-    The STJ dataset carries auxiliary resources (e.g. a "dicionário de
-    dados" CSV) that are not acórdãos data — downloading those as if they
-    were JSON produces a file DuckDB's ``read_json`` chokes on later. Only
-    resources explicitly declared zip/json (by CKAN ``format`` or URL
-    suffix) are downloaded; anything else is skipped.
-    """
-    fmt = fmt.lower()
-    url_lower = url.lower()
-    if fmt == "zip" or url_lower.endswith(".zip"):
-        return "zip"
-    if fmt == "json" or url_lower.endswith(".json"):
-        return "json"
-    return None
-
-
-def _already_uploaded(manifest: ManifestSTJ, dest_name: str, last_modified: str) -> bool:
-    """True when *dest_name* is already on IA, unchanged since *last_modified*."""
-    existing = manifest.get(dest_name)
-    return (
-        existing is not None
-        and existing.ia_status == "uploaded"
-        and existing.data_extracao == last_modified
-    )
-
-
-def _download_one(
-    resource: dict,
-    manifest: ManifestSTJ,
-    zip_dir: Path,
-    extract_dir: Path,
-) -> None:
-    """Download, extract and record a single CKAN resource.
-
-    Raises ``STJWAFBlockedError`` upward unchanged (fail-fast: once the WAF
-    has blocked this runner, every further request will fail too — the
-    caller must not keep grinding through the remaining resources).
-    """
-    url: str = resource.get("url", "")
-    name: str = resource.get("name", "") or resource.get("id", "unknown")
-    fmt: str = (resource.get("format") or "").lower()
-    last_modified: str = resource.get("last_modified") or resource.get("created") or ""
-
-    if not url:
-        typer.echo(f"  SKIP {name}: no URL", err=True)
-        return
-
-    tipo = _classify_resource(fmt, url)
-    if tipo is None:
-        typer.echo(f"  SKIP {name}: unrecognized format {fmt!r} (not zip/json)", err=True)
-        return
-    dest = zip_dir / f"{name}.{tipo}"
-
-    if _already_uploaded(manifest, dest.name, last_modified):
-        typer.echo(f"  SKIP {name}: already uploaded to IA (unchanged since {last_modified})")
-        return
-
-    typer.echo(f"→ Downloading {name} ({tipo}) …")
-    try:
-        download_resource(url, dest)
-    except STJWAFBlockedError:
-        typer.echo("  FATAL: STJ WAF blocked this runner — aborting.", err=True)
-        raise
-    except (httpx.HTTPError, OSError) as exc:
-        typer.echo(f"  ERROR: {exc}", err=True)
-        return
-
-    n_extracted = 0
-    if tipo == "zip":
-        typer.echo(f"  Extracting {dest.name} …")
-        try:
-            extracted = extract_zip(dest, extract_dir)
-            n_extracted = len(extracted)
-        except (zipfile.BadZipFile, OSError) as exc:
-            typer.echo(f"  Extract ERROR: {exc}", err=True)
-
-    manifest.upsert(
-        arquivo=dest.name,
-        tipo=tipo,
-        data_extracao=last_modified,
-        ia_status="",
-        n_registros=n_extracted,
-    )
-    manifest.save()
-    typer.echo(f"  Done ({n_extracted} files extracted).")
-
-
-def _restore_manifest_best_effort(manifest_path: Path) -> None:
-    """Restore the manifest from IA when absent; never abort the run on failure.
-
-    IA can return a transient error (observed: 503, not 404, for an item
-    that has simply never been created yet) for reasons unrelated to whether
-    a manifest actually exists. Failing to restore only costs redundant
-    re-downloads of already-uploaded resources — no data is lost — so it
-    must never abort the run.
-    """
-    if manifest_path.exists():
-        return
-    try:
-        fetch_manifest(manifest_path)
-    except httpx.HTTPError as exc:
-        typer.echo(f"WARNING: manifest restore failed ({exc}); starting fresh.", err=True)
+def _echo_download_outcome(outcome: service.DownloadOutcome) -> None:
+    if outcome.action == "skip_no_url":
+        typer.echo(f"  SKIP {outcome.dest_name}: no URL", err=True)
+    elif outcome.action == "skip_unrecognized_format":
+        typer.echo(
+            f"  SKIP {outcome.dest_name}: unrecognized format {outcome.detail!r} (not zip/json)",
+            err=True,
+        )
+    elif outcome.action == "skip_already_uploaded":
+        typer.echo(
+            f"  SKIP {outcome.dest_name}: already uploaded to IA (unchanged since {outcome.detail})"
+        )
+    elif outcome.action == "download_error":
+        typer.echo(f"  ERROR: {outcome.detail}", err=True)
+    else:
+        if outcome.action == "extract_error":
+            typer.echo(f"  Extract ERROR: {outcome.detail}", err=True)
+        typer.echo(f"  Done ({outcome.n_extracted} files extracted).")
 
 
 @app.command()
 def download(
-    data_dir: Path = typer.Option(_DEFAULT_DATA_DIR, help="Directory to store downloads."),
-    manifest_path: Path = typer.Option(_DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
+    data_dir: Path = typer.Option(service.DEFAULT_DATA_DIR, help="Directory to store downloads."),
+    manifest_path: Path = typer.Option(service.DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
 ) -> None:
     """Discover resources, download ZIPs + JSONs, and extract safely.
 
@@ -171,7 +77,7 @@ def download(
     (per the manifest, restored from IA when no local copy exists) are
     skipped, keeping scheduled runs on blank runners incremental.
     """
-    _restore_manifest_best_effort(manifest_path)
+    service.restore_manifest_best_effort(manifest_path)
     manifest = ManifestSTJ(manifest_path)
     manifest.load()
 
@@ -186,90 +92,36 @@ def download(
     extract_dir.mkdir(parents=True, exist_ok=True)
 
     for resource in resources:
-        _download_one(resource, manifest, zip_dir, extract_dir)
+        outcome = service.download_one(resource, manifest, zip_dir, extract_dir)
+        _echo_download_outcome(outcome)
 
     typer.echo(f"\nManifest saved to {manifest_path} ({len(manifest)} entries).")
 
 
 @app.command()
 def upload(
-    data_dir: Path = typer.Option(_DEFAULT_DATA_DIR, help="Directory containing the parquet file."),
-    parquet_path: Path = typer.Option(_DEFAULT_PARQUET, help="Parquet file to upload."),
-    manifest_path: Path = typer.Option(_DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
-    ia_key: str = typer.Option("", envvar="IA_ACCESS_KEY", help="IA S3 access key."),
-    ia_secret: str = typer.Option("", envvar="IA_SECRET_KEY", help="IA S3 secret key."),
+    data_dir: Path = typer.Option(
+        service.DEFAULT_DATA_DIR, help="Directory containing the parquet file."
+    ),
+    parquet_path: Path = typer.Option(service.DEFAULT_PARQUET, help="Parquet file to upload."),
+    manifest_path: Path = typer.Option(service.DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
 ) -> None:
     """Upload the deduplicated parquet file to Internet Archive."""
-    from stj_acordaos.archive import upload_parquet
-    from stj_acordaos.dedup import dedup_acordaos
-
+    ia_key, ia_secret = service.ia_credentials()
     if not ia_key or not ia_secret:
         typer.echo("ERROR: IA_ACCESS_KEY and IA_SECRET_KEY must be set.", err=True)
         raise typer.Exit(1)
 
-    manifest = ManifestSTJ(manifest_path)
-    manifest.load()
+    result = service.upload_all(data_dir, parquet_path, manifest_path, ia_key, ia_secret)
 
-    # Collect all JSON sources: extracted from ZIP + monthly downloads
-    extract_dir = data_dir / "extracted"
-    zip_dir = data_dir / "zips"
-    json_files = sorted(
-        list(extract_dir.glob("*.json") if extract_dir.exists() else [])
-        + list(zip_dir.glob("*.json") if zip_dir.exists() else [])
-    )
-    if json_files:
-        typer.echo(f"Deduplicating {len(json_files)} JSON files → {parquet_path} …")
-        count = dedup_acordaos(json_files, parquet_path)
-        typer.echo(f"  {count:,} records after dedup.")
-    elif not parquet_path.exists():
-        # No local JSONs (every resource was already uploaded+unchanged and
-        # `download` skipped it) and no local parquet (a blank runner never
-        # restores it). If the manifest agrees nothing is pending, IA already
-        # has the correct parquet from a prior run — there is genuinely
-        # nothing to do, not an error.
-        if manifest.get_pending_uploads():
-            typer.echo("ERROR: No JSON files and no existing parquet to upload.", err=True)
-            raise typer.Exit(1)
+    if result.status == "nothing_to_do":
         typer.echo("Nothing new to upload — all resources already on IA.")
         return
+    if result.status == "no_data":
+        typer.echo("ERROR: No JSON files and no existing parquet to upload.", err=True)
+        raise typer.Exit(1)
 
-    # Upload original source files (ZIPs + monthly JSONs). Preserve the
-    # entry's data_extracao/n_registros stamped by `download` — the download
-    # skip compares data_extracao against CKAN's last_modified.
-    all_sources = sorted(zip_dir.glob("*") if zip_dir.exists() else [])
-    for src in all_sources:
-        typer.echo(f"Uploading source {src.name} …")
-        ok = upload_parquet(src, ia_key, ia_secret)
-        tipo_src = "zip" if src.suffix == ".zip" else "json"
-        existing = manifest.get(src.name)
-        manifest.upsert(
-            arquivo=src.name,
-            tipo=tipo_src,
-            data_extracao=existing.data_extracao if existing else "",
-            ia_status="uploaded" if ok else "",
-            n_registros=existing.n_registros if existing else 0,
-        )
-
-    # Upload consolidated parquet
-    typer.echo(f"Uploading {parquet_path.name} to IA item stj-acordaos-primeira-secao …")
-    ok = upload_parquet(parquet_path, ia_key, ia_secret)
-
-    manifest.upsert(
-        arquivo=parquet_path.name,
-        tipo="parquet",
-        data_extracao="",
-        ia_status="uploaded" if ok else "",
-        n_registros=0,
-    )
-    manifest.save()
-
-    # Push the manifest itself so a blank runner can restore it next run.
-    typer.echo(f"Uploading {manifest_path.name} to IA …")
-    manifest_ok = upload_parquet(manifest_path, ia_key, ia_secret)
-    if not manifest_ok:
-        typer.echo("WARNING: manifest upload failed (next run re-downloads).", err=True)
-
-    if ok:
+    if result.ok:
         typer.echo("Upload complete.")
     else:
         typer.echo("Upload FAILED.", err=True)
@@ -278,26 +130,21 @@ def upload(
 
 @app.command()
 def status(
-    manifest_path: Path = typer.Option(_DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
+    manifest_path: Path = typer.Option(service.DEFAULT_MANIFEST, help="Path to stj-manifest.csv."),
 ) -> None:
     """Show a summary of the STJ manifest."""
-    manifest = ManifestSTJ(manifest_path)
-    count = manifest.load()
+    summary = service.manifest_summary(manifest_path)
 
-    if count == 0:
+    if summary.count == 0:
         typer.echo("Manifest is empty or not found.")
         return
 
-    rows = manifest.to_df()
-    uploaded = sum(1 for r in rows if r["ia_status"] == "uploaded")
-    pending = count - uploaded
-
     typer.echo(f"STJ Manifest: {manifest_path}")
-    typer.echo(f"  Total entries : {count}")
-    typer.echo(f"  Uploaded to IA: {uploaded}")
-    typer.echo(f"  Pending upload: {pending}")
+    typer.echo(f"  Total entries : {summary.count}")
+    typer.echo(f"  Uploaded to IA: {summary.uploaded}")
+    typer.echo(f"  Pending upload: {summary.pending}")
     typer.echo("")
-    for row in rows:
+    for row in summary.rows:
         typer.echo(
             f"  {row['arquivo']:40s}  {row['tipo']:6s}  {row['ia_status'] or 'pending':8s}"
             f"  {row['n_registros']:>8,} records"

--- a/src/stj_acordaos/__main__.py
+++ b/src/stj_acordaos/__main__.py
@@ -35,8 +35,6 @@ from pathlib import Path
 import typer
 
 from stj_acordaos import service
-from stj_acordaos.client import get_resource_list
-from stj_acordaos.manifest import ManifestSTJ
 
 
 app = typer.Typer(
@@ -77,25 +75,15 @@ def download(
     (per the manifest, restored from IA when no local copy exists) are
     skipped, keeping scheduled runs on blank runners incremental.
     """
-    service.restore_manifest_best_effort(manifest_path)
-    manifest = ManifestSTJ(manifest_path)
-    manifest.load()
-
-    resources = get_resource_list()
-    if not resources:
+    summary = service.download_all(data_dir, manifest_path)
+    if summary is None:
         typer.echo("No resources found.", err=True)
         raise typer.Exit(1)
 
-    zip_dir = data_dir / "zips"
-    extract_dir = data_dir / "extracted"
-    zip_dir.mkdir(parents=True, exist_ok=True)
-    extract_dir.mkdir(parents=True, exist_ok=True)
-
-    for resource in resources:
-        outcome = service.download_one(resource, manifest, zip_dir, extract_dir)
+    for outcome in summary.outcomes:
         _echo_download_outcome(outcome)
 
-    typer.echo(f"\nManifest saved to {manifest_path} ({len(manifest)} entries).")
+    typer.echo(f"\nManifest saved to {manifest_path} ({summary.manifest_entries} entries).")
 
 
 @app.command()

--- a/src/stj_acordaos/service.py
+++ b/src/stj_acordaos/service.py
@@ -1,0 +1,268 @@
+"""Config→result service layer for ``stj-acordaos``, free of Typer/echo (RFC 0013 Fase 2).
+
+``__main__.py`` owns argv parsing and echoing results; this module owns the
+actual work — discovering, downloading, deduping, uploading — so it can be
+called from a future MCP tool or a different CLI framework without dragging
+Typer along. Also drops ``ia_key``/``ia_secret`` as CLI options: Internet
+Archive credentials are read from the environment only (``ia_credentials``),
+never exposed as a parameter a schema (CLI or future MCP tool) could carry.
+"""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+import structlog
+
+from stj_acordaos import archive as stj_archive
+from stj_acordaos import client as stj_client
+from stj_acordaos.client import STJWAFBlockedError
+from stj_acordaos.dedup import dedup_acordaos
+from stj_acordaos.manifest import ManifestSTJ
+
+
+log = structlog.get_logger()
+
+DEFAULT_DATA_DIR = Path("data/stj")
+DEFAULT_MANIFEST = DEFAULT_DATA_DIR / "stj-manifest.csv"
+DEFAULT_EXTRACT_DIR = DEFAULT_DATA_DIR / "extracted"
+DEFAULT_PARQUET = DEFAULT_DATA_DIR / "stj-acordaos.parquet"
+
+
+def ia_credentials() -> tuple[str, str]:
+    """Read Internet Archive S3 credentials from the environment."""
+    return os.environ.get("IA_ACCESS_KEY", ""), os.environ.get("IA_SECRET_KEY", "")
+
+
+def _classify_resource(fmt: str, url: str) -> str | None:
+    """Classify a CKAN resource as "zip" or "json"; None when neither.
+
+    The STJ dataset carries auxiliary resources (e.g. a "dicionário de
+    dados" CSV) that are not acórdãos data — downloading those as if they
+    were JSON produces a file DuckDB's ``read_json`` chokes on later. Only
+    resources explicitly declared zip/json (by CKAN ``format`` or URL
+    suffix) are downloaded; anything else is skipped.
+    """
+    fmt = fmt.lower()
+    url_lower = url.lower()
+    if fmt == "zip" or url_lower.endswith(".zip"):
+        return "zip"
+    if fmt == "json" or url_lower.endswith(".json"):
+        return "json"
+    return None
+
+
+def _already_uploaded(manifest: ManifestSTJ, dest_name: str, last_modified: str) -> bool:
+    """True when *dest_name* is already on IA, unchanged since *last_modified*."""
+    existing = manifest.get(dest_name)
+    return (
+        existing is not None
+        and existing.ia_status == "uploaded"
+        and existing.data_extracao == last_modified
+    )
+
+
+@dataclass
+class DownloadOutcome:
+    """Result of attempting to download+extract a single CKAN resource."""
+
+    dest_name: str
+    action: Literal[
+        "skip_no_url",
+        "skip_unrecognized_format",
+        "skip_already_uploaded",
+        "downloaded",
+        "download_error",
+        "extract_error",
+    ]
+    detail: str = ""
+    n_extracted: int = 0
+
+
+def download_one(
+    resource: dict,
+    manifest: ManifestSTJ,
+    zip_dir: Path,
+    extract_dir: Path,
+) -> DownloadOutcome:
+    """Download, extract and record a single CKAN resource.
+
+    Raises ``STJWAFBlockedError`` upward unchanged (fail-fast: once the WAF
+    has blocked this runner, every further request will fail too — the
+    caller must not keep grinding through the remaining resources).
+    """
+    url: str = resource.get("url", "")
+    name: str = resource.get("name", "") or resource.get("id", "unknown")
+    fmt: str = (resource.get("format") or "").lower()
+    last_modified: str = resource.get("last_modified") or resource.get("created") or ""
+
+    if not url:
+        return DownloadOutcome(dest_name=name, action="skip_no_url")
+
+    tipo = _classify_resource(fmt, url)
+    if tipo is None:
+        return DownloadOutcome(dest_name=name, action="skip_unrecognized_format", detail=fmt)
+    dest = zip_dir / f"{name}.{tipo}"
+
+    if _already_uploaded(manifest, dest.name, last_modified):
+        return DownloadOutcome(dest_name=name, action="skip_already_uploaded", detail=last_modified)
+
+    log.info("stj_downloading", name=name, tipo=tipo)
+    try:
+        stj_client.download_resource(url, dest)
+    except STJWAFBlockedError:
+        raise
+    except (httpx.HTTPError, OSError) as exc:
+        return DownloadOutcome(dest_name=name, action="download_error", detail=str(exc))
+
+    n_extracted = 0
+    extract_error = ""
+    if tipo == "zip":
+        log.info("stj_extracting", file=dest.name)
+        try:
+            extracted = stj_client.extract_zip(dest, extract_dir)
+            n_extracted = len(extracted)
+        except (zipfile.BadZipFile, OSError) as exc:
+            extract_error = str(exc)
+
+    manifest.upsert(
+        arquivo=dest.name,
+        tipo=tipo,
+        data_extracao=last_modified,
+        ia_status="",
+        n_registros=n_extracted,
+    )
+    manifest.save()
+
+    if extract_error:
+        return DownloadOutcome(
+            dest_name=name, action="extract_error", detail=extract_error, n_extracted=n_extracted
+        )
+    return DownloadOutcome(dest_name=name, action="downloaded", n_extracted=n_extracted)
+
+
+def restore_manifest_best_effort(manifest_path: Path) -> None:
+    """Restore the manifest from IA when absent; never abort the run on failure.
+
+    IA can return a transient error (observed: 503, not 404, for an item
+    that has simply never been created yet) for reasons unrelated to whether
+    a manifest actually exists. Failing to restore only costs redundant
+    re-downloads of already-uploaded resources — no data is lost — so it
+    must never abort the run.
+    """
+    if manifest_path.exists():
+        return
+    try:
+        stj_archive.fetch_manifest(manifest_path)
+    except httpx.HTTPError as exc:
+        log.warning("stj_manifest_restore_failed", error=str(exc))
+
+
+@dataclass
+class UploadResult:
+    """Result of ``upload_all``."""
+
+    status: Literal["nothing_to_do", "no_data", "done"]
+    ok: bool = True
+    dedup_count: int | None = None
+
+
+def upload_all(
+    data_dir: Path,
+    parquet_path: Path,
+    manifest_path: Path,
+    ia_key: str,
+    ia_secret: str,
+) -> UploadResult:
+    """Dedup local JSONs into *parquet_path* and upload sources + parquet + manifest to IA."""
+    manifest = ManifestSTJ(manifest_path)
+    manifest.load()
+
+    # Collect all JSON sources: extracted from ZIP + monthly downloads
+    extract_dir = data_dir / "extracted"
+    zip_dir = data_dir / "zips"
+    json_files = sorted(
+        list(extract_dir.glob("*.json") if extract_dir.exists() else [])
+        + list(zip_dir.glob("*.json") if zip_dir.exists() else [])
+    )
+    dedup_count: int | None = None
+    if json_files:
+        log.info("stj_dedup_starting", count=len(json_files), parquet=str(parquet_path))
+        dedup_count = dedup_acordaos(json_files, parquet_path)
+        log.info("stj_dedup_done", records=dedup_count)
+    elif not parquet_path.exists():
+        # No local JSONs (every resource was already uploaded+unchanged and
+        # `download` skipped it) and no local parquet (a blank runner never
+        # restores it). If the manifest agrees nothing is pending, IA already
+        # has the correct parquet from a prior run — there is genuinely
+        # nothing to do, not an error.
+        if manifest.get_pending_uploads():
+            return UploadResult(status="no_data", ok=False)
+        return UploadResult(status="nothing_to_do")
+
+    # Upload original source files (ZIPs + monthly JSONs). Preserve the
+    # entry's data_extracao/n_registros stamped by `download` — the download
+    # skip compares data_extracao against CKAN's last_modified.
+    all_sources = sorted(zip_dir.glob("*") if zip_dir.exists() else [])
+    for src in all_sources:
+        log.info("stj_uploading_source", file=src.name)
+        ok = stj_archive.upload_parquet(src, ia_key, ia_secret)
+        tipo_src = "zip" if src.suffix == ".zip" else "json"
+        existing = manifest.get(src.name)
+        manifest.upsert(
+            arquivo=src.name,
+            tipo=tipo_src,
+            data_extracao=existing.data_extracao if existing else "",
+            ia_status="uploaded" if ok else "",
+            n_registros=existing.n_registros if existing else 0,
+        )
+
+    # Upload consolidated parquet
+    log.info("stj_uploading_parquet", file=parquet_path.name)
+    ok = stj_archive.upload_parquet(parquet_path, ia_key, ia_secret)
+
+    manifest.upsert(
+        arquivo=parquet_path.name,
+        tipo="parquet",
+        data_extracao="",
+        ia_status="uploaded" if ok else "",
+        n_registros=0,
+    )
+    manifest.save()
+
+    # Push the manifest itself so a blank runner can restore it next run.
+    log.info("stj_uploading_manifest", file=manifest_path.name)
+    manifest_ok = stj_archive.upload_parquet(manifest_path, ia_key, ia_secret)
+    if not manifest_ok:
+        # Non-fatal: parquets are already on IA; the next run just re-uploads.
+        log.warning("stj_manifest_upload_failed")
+
+    return UploadResult(status="done", ok=ok, dedup_count=dedup_count)
+
+
+@dataclass
+class ManifestSummary:
+    """Summary of the STJ manifest for the ``status`` command."""
+
+    count: int
+    uploaded: int
+    rows: list[dict]
+
+    @property
+    def pending(self) -> int:
+        """Entries not yet uploaded."""
+        return self.count - self.uploaded
+
+
+def manifest_summary(manifest_path: Path) -> ManifestSummary:
+    """Load the manifest and summarize upload progress."""
+    manifest = ManifestSTJ(manifest_path)
+    count = manifest.load()
+    rows = manifest.to_df() if count else []
+    uploaded = sum(1 for r in rows if r["ia_status"] == "uploaded")
+    return ManifestSummary(count=count, uploaded=uploaded, rows=rows)

--- a/src/stj_acordaos/service.py
+++ b/src/stj_acordaos/service.py
@@ -164,6 +164,43 @@ def restore_manifest_best_effort(manifest_path: Path) -> None:
 
 
 @dataclass
+class DownloadSummary:
+    """Result of ``download_all``."""
+
+    outcomes: list[DownloadOutcome]
+    manifest_entries: int
+
+
+def download_all(data_dir: Path, manifest_path: Path) -> DownloadSummary | None:
+    """Discover resources, download ZIPs + JSONs, and extract safely.
+
+    Restores the manifest from IA first when no local copy exists, so
+    resources already uploaded to IA with an unchanged ``last_modified`` are
+    skipped — keeps scheduled runs on blank runners incremental. Returns
+    None when CKAN reports no resources at all.
+
+    Propagates ``STJWAFBlockedError`` from ``download_one`` unchanged
+    (fail-fast: once the WAF has blocked this runner, every further request
+    will fail too).
+    """
+    restore_manifest_best_effort(manifest_path)
+    manifest = ManifestSTJ(manifest_path)
+    manifest.load()
+
+    resources = stj_client.get_resource_list()
+    if not resources:
+        return None
+
+    zip_dir = data_dir / "zips"
+    extract_dir = data_dir / "extracted"
+    zip_dir.mkdir(parents=True, exist_ok=True)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+
+    outcomes = [download_one(resource, manifest, zip_dir, extract_dir) for resource in resources]
+    return DownloadSummary(outcomes=outcomes, manifest_entries=len(manifest))
+
+
+@dataclass
 class UploadResult:
     """Result of ``upload_all``."""
 
@@ -209,9 +246,11 @@ def upload_all(
     # entry's data_extracao/n_registros stamped by `download` — the download
     # skip compares data_extracao against CKAN's last_modified.
     all_sources = sorted(zip_dir.glob("*") if zip_dir.exists() else [])
+    sources_ok = True
     for src in all_sources:
         log.info("stj_uploading_source", file=src.name)
         ok = stj_archive.upload_parquet(src, ia_key, ia_secret)
+        sources_ok = sources_ok and ok
         tipo_src = "zip" if src.suffix == ".zip" else "json"
         existing = manifest.get(src.name)
         manifest.upsert(
@@ -224,13 +263,13 @@ def upload_all(
 
     # Upload consolidated parquet
     log.info("stj_uploading_parquet", file=parquet_path.name)
-    ok = stj_archive.upload_parquet(parquet_path, ia_key, ia_secret)
+    parquet_ok = stj_archive.upload_parquet(parquet_path, ia_key, ia_secret)
 
     manifest.upsert(
         arquivo=parquet_path.name,
         tipo="parquet",
         data_extracao="",
-        ia_status="uploaded" if ok else "",
+        ia_status="uploaded" if parquet_ok else "",
         n_registros=0,
     )
     manifest.save()
@@ -242,7 +281,10 @@ def upload_all(
         # Non-fatal: parquets are already on IA; the next run just re-uploads.
         log.warning("stj_manifest_upload_failed")
 
-    return UploadResult(status="done", ok=ok, dedup_count=dedup_count)
+    # ok must reflect every required artifact (sources + parquet) — a
+    # failed source upload must not be masked by a successful parquet
+    # upload (manifest upload is non-fatal by design, excluded here).
+    return UploadResult(status="done", ok=sources_ok and parquet_ok, dedup_count=dedup_count)
 
 
 @dataclass

--- a/src/tjro_juris/__main__.py
+++ b/src/tjro_juris/__main__.py
@@ -23,210 +23,23 @@ scheduled runs on blank runners stay incremental.
 
 In CI, ``.github/workflows/tjro-sync.yml`` runs the same commands hourly
 (scheduled runs crawl only the current month) plus ``workflow_dispatch``.
+
+Business logic lives in ``tjro_juris.service`` (RFC 0013 Fase 2); this
+module only parses argv and echoes results.
 """
 
 from __future__ import annotations
 
 import asyncio
-import datetime as _dt
-import re
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
 
-import anyio
-import httpx
-import pyarrow as pa
-import pyarrow.parquet as pq
-import structlog
 import typer
 
-from tjro_juris import archive as ia_archive
-from tjro_juris.client import TIPOS, clean_html
-from tjro_juris.crawler import crawl_all
-from tjro_juris.dedup import consolidate_year
-from tjro_juris.manifest import ManifestJuris, ManifestJurisEntry
+from tjro_juris import service
 
 
-log = structlog.get_logger()
 app = typer.Typer(name="tjro-juris", help="TJRO JURIS scraping and archival.")
-
-_MANIFEST_NAME = "tjro-juris-manifest.csv"
-_PARTIAL_CACHE_DIRNAME = ".partial-cache"
-_MIN_DATE_LEN = 10
-
-_PARQUET_SCHEMA = pa.schema(
-    [
-        pa.field("id_documento", pa.int64()),
-        pa.field("nr_processo", pa.string()),
-        pa.field("tipo", pa.string()),
-        pa.field("classe_judicial", pa.string()),
-        pa.field("orgao", pa.string()),
-        pa.field("relator", pa.string()),
-        pa.field("sistema_origem", pa.string()),
-        pa.field("data_julgamento", pa.date32()),
-        pa.field("texto_limpo", pa.string()),
-        pa.field("url_portal", pa.string()),
-        pa.field("extraido_em", pa.string()),
-    ]
-)
-
-
-_MES_RE = re.compile(r"\d{4}-(0[1-9]|1[0-2])")
-
-
-def _manifest_path(data_dir: Path) -> Path:
-    return data_dir / _MANIFEST_NAME
-
-
-def _partial_cache_dir(data_dir: Path) -> Path:
-    """Staging area for in-progress pagination (see crawler._fetch_pages).
-
-    Lives under data_dir so it survives between crawl invocations of the
-    same --ano; never uploaded to IA, never read by anything except a
-    resumed crawl of the same window.
-    """
-    return data_dir / _PARTIAL_CACHE_DIRNAME
-
-
-def _load_manifest(data_dir: Path) -> ManifestJuris:
-    """Load the local manifest, restoring it from IA when absent.
-
-    A blank runner (CI) starts with no local state; without the restore every
-    scheduled run would re-crawl and re-upload everything. The restore is
-    best-effort: IA can return a transient error (observed: 503, not 404, for
-    an item that has simply never been created yet) for reasons that have
-    nothing to do with whether a manifest actually exists. Failing to
-    restore only costs a redundant re-crawl of already-uploaded windows —
-    no data is lost — so it must never abort the whole run.
-    """
-    path = _manifest_path(data_dir)
-    if not path.exists():
-        try:
-            ia_archive.download_manifest(path)
-        except httpx.HTTPError as exc:
-            log.warning("manifest_restore_failed", error=str(exc))
-    return ManifestJuris.load_local(path)
-
-
-def _should_skip_window(
-    manifest: ManifestJuris, current_ym: str, tipo_name: str, year_month: str
-) -> bool:
-    """Skip a (tipo, year_month) window the manifest already records as uploaded.
-
-    The current month is never skipped: JURIS keeps publishing into it, so it
-    must always be re-crawled even if a previous run already uploaded it.
-    """
-    if year_month >= current_ym:
-        return False
-    entry = manifest.get(tipo_name, year_month)
-    return entry is not None and entry.ia_status == "uploaded"
-
-
-_DEFAULT_START_YEAR = 2010
-
-# JURIS's own data goes further back than the crawler's original hardcoded
-# default: live probes (2026-07-14) found DECISÃO from 1989, ACÓRDÃO from
-# 1991, and SENTENÇA from 2007 — years before the old start_year=2010 default
-# silently never crawled. --desde-ano lets a full backfill start earlier
-# without changing the default (incremental/scheduled runs stay cheap).
-
-
-def _crawl_bounds(
-    ano: int | None, mes: str | None, desde_ano: int | None, now: datetime
-) -> tuple[int, str | None, str | None]:
-    """Resolve (start_year, end_year_month, start_year_month) for the crawl."""
-    exclusive = [v is not None for v in (ano, mes, desde_ano)]
-    if sum(exclusive) > 1:
-        msg = "--ano, --mes and --desde-ano are mutually exclusive"
-        raise typer.BadParameter(msg)
-    if mes is not None:
-        if not _MES_RE.fullmatch(mes):
-            msg = f"--mes must be AAAA-MM, got {mes!r}"
-            raise typer.BadParameter(msg)
-        return int(mes[:4]), mes, mes
-    if ano is not None:
-        end = f"{ano:04d}-12" if ano < now.year else now.strftime("%Y-%m")
-        return ano, end, None
-    if desde_ano is not None:
-        return desde_ano, None, None
-    return _DEFAULT_START_YEAR, None, None
-
-
-def _parquet_path(data_dir: Path, tipo: str, year_month: str) -> Path:
-    year = year_month[:4]
-    safe_tipo = tipo.replace(" ", "_").replace("/", "_")
-    return data_dir / year / safe_tipo / f"{year_month}.parquet"
-
-
-def _normalize_date(dt_raw: str) -> str | None:
-    """Normalize date string to YYYY-MM-DD."""
-    if not dt_raw:
-        return None
-    m = re.match(r"(\d{2})/(\d{2})/(\d{4})", dt_raw)
-    if m:
-        return f"{m.group(3)}-{m.group(2)}-{m.group(1)}"
-    return dt_raw[:_MIN_DATE_LEN] if len(dt_raw) >= _MIN_DATE_LEN else dt_raw
-
-
-def _to_row(src: dict) -> dict:
-    """Map a crawler-normalized doc to canonical parquet schema.
-
-    Accepts the dict produced by crawler._extract_doc() which already uses
-    canonical field names (id_documento, classe_judicial, orgao, etc.).
-    """
-    dt_raw = src.get("data_julgamento") or ""
-    return {
-        "id_documento": src.get("id_documento"),
-        "nr_processo": src.get("nr_processo") or "",
-        "tipo": src.get("tipo") or "",
-        "classe_judicial": src.get("classe_judicial") or "",
-        "orgao": src.get("orgao") or "",
-        "relator": src.get("relator") or "",
-        "sistema_origem": src.get("sistema_origem") or "",
-        "data_julgamento": _normalize_date(dt_raw),
-        "texto_limpo": src.get("texto_limpo") or clean_html(src.get("ds_modelo_documento") or ""),
-        "url_portal": src.get("url_portal") or "",
-        "extraido_em": src.get("extraido_em") or datetime.now(UTC).isoformat(),
-    }
-
-
-def _parse_date(v: str | None) -> _dt.date | None:
-    """Parse ISO date string to date object."""
-    if not v:
-        return None
-    try:
-        return _dt.date.fromisoformat(v)
-    except ValueError:
-        return None
-
-
-def _rows_to_parquet(rows: list[dict], out: Path) -> None:
-    """Write list of row dicts to a parquet file using pyarrow."""
-    arrays: dict[str, list] = {f.name: [] for f in _PARQUET_SCHEMA}
-    for row in rows:
-        for field in _PARQUET_SCHEMA:
-            val = row.get(field.name)
-            if field.name == "id_documento":
-                arrays[field.name].append(int(val) if val is not None else None)
-            elif field.name == "data_julgamento":
-                arrays[field.name].append(val)
-            else:
-                arrays[field.name].append(str(val) if val is not None else None)
-
-    arrow_cols = []
-    for field in _PARQUET_SCHEMA:
-        raw = arrays[field.name]
-        if field.type == pa.date32():
-            arrow_cols.append(pa.array([_parse_date(v) for v in raw], type=pa.date32()))
-        else:
-            arrow_cols.append(pa.array(raw, type=field.type))
-
-    table = pa.table(
-        dict(zip(_PARQUET_SCHEMA.names, arrow_cols, strict=True)), schema=_PARQUET_SCHEMA
-    )
-    out.parent.mkdir(parents=True, exist_ok=True)
-    pq.write_table(table, out)
 
 
 @app.command()
@@ -250,80 +63,16 @@ def crawl(
             "--desde-ano",
             help=(
                 f"Full backfill starting from this year instead of the default "
-                f"({_DEFAULT_START_YEAR}). Mutually exclusive with --ano/--mes."
+                f"({service.DEFAULT_START_YEAR}). Mutually exclusive with --ano/--mes."
             ),
         ),
     ] = None,
 ) -> None:
-    """Crawl JURIS and save as parquet files per (tipo, mes_ano).
-
-    Windows already uploaded to IA (per the manifest, restored from IA when
-    no local copy exists) are skipped, except the current month, which is
-    always re-crawled to pick up newly published documents. Windows whose
-    parquet is already on local disk (e.g. a prior attempt this same year
-    got partway through before failing) are also skipped — see
-    ``_already_crawled_locally``.
-
-    The manifest is saved after EVERY window, not just once at the end: a
-    long --ano/--desde-ano crawl that dies partway through (observed live —
-    TJRO's STIC anti-abuse system can block a sustained crawl mid-year)
-    previously lost all of that year's progress from the manifest even
-    though the parquet files were already safely on disk, forcing a full
-    re-fetch of every tipo on the next attempt. Saving incrementally means
-    a retry only has to redo whatever wasn't finished yet.
-    """
-    manifest = _load_manifest(data_dir)
-    tipos_to_crawl = tipo or TIPOS
-
-    now = datetime.now(UTC)
-    current_ym = now.strftime("%Y-%m")
-    start_year, end_year_month, start_year_month = _crawl_bounds(ano, mes, desde_ano, now)
-
-    def _already_crawled_locally(tipo_name: str, year_month: str) -> bool:
-        return _parquet_path(data_dir, tipo_name, year_month).exists()
-
-    def _skip(tipo_name: str, year_month: str) -> bool:
-        if _already_crawled_locally(tipo_name, year_month):
-            return True
-        return _should_skip_window(manifest, current_ym, tipo_name, year_month)
-
-    for tipo_name, year_month, docs in crawl_all(
-        start_year=start_year,
-        end_year_month=end_year_month,
-        tipos=tipos_to_crawl,
-        start_year_month=start_year_month,
-        skip=_skip,
-        cache_dir=_partial_cache_dir(data_dir),
-        shuffle=True,
-    ):
-        if not docs:
-            continue
-
-        rows = [_to_row(d) for d in docs]
-        out = _parquet_path(data_dir, tipo_name, year_month)
-        _rows_to_parquet(rows, out)
-        log.info("parquet_saved", path=str(out), rows=len(rows))
-
-        entry = ManifestJurisEntry(
-            tipo=tipo_name,
-            mes_ano=year_month,
-            ia_status="",
-            n_docs=len(docs),
-        )
-        manifest.upsert(entry)
-        manifest.save_local(_manifest_path(data_dir))
-
-    log.info("crawl_done")
-
-
-_UPLOAD_INTERVAL_S = 1.0
-# IA's S3-compatible endpoint 503s ("Slow Down") under sustained upload
-# volume even WITH per-file retry/backoff (see tjro_juris.archive) — observed
-# live during the historical backfill, where a whole year's worth of
-# monthly parquets landed back-to-back with zero delay between PUTs. A
-# small self-imposed pause between uploads mirrors the crawler's own
-# _REQUEST_INTERVAL rate-limiting and cuts how often the retry path is
-# needed at all, instead of just reacting to it after the fact.
+    """Crawl JURIS and save as parquet files per (tipo, mes_ano). See ``service.crawl_juris``."""
+    try:
+        service.crawl_juris(data_dir, tipo, ano, mes, desde_ano)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 @app.command()
@@ -331,39 +80,7 @@ def upload(
     data_dir: Annotated[Path, typer.Argument(help="Directory with parquet files")],
 ) -> None:
     """Upload parquets (and the manifest) to Internet Archive."""
-    manifest = _load_manifest(data_dir)
-    pending = manifest.pending_upload()
-
-    async def _upload_all() -> None:
-        for i, entry in enumerate(pending):
-            if i > 0:
-                await asyncio.sleep(_UPLOAD_INTERVAL_S)
-            pq_path = _parquet_path(data_dir, entry.tipo, entry.mes_ano)
-            if not await anyio.Path(pq_path).exists():
-                log.warning("parquet_not_found", path=str(pq_path))
-                continue
-            year = int(entry.mes_ano[:4])
-            safe_tipo = entry.tipo.replace(" ", "_").replace("/", "_")
-            remote_name = f"{entry.mes_ano}-{safe_tipo}.parquet"
-            try:
-                await ia_archive.upload_file(pq_path, year, remote_name)
-                entry.ia_status = "uploaded"
-                manifest.upsert(entry)
-            except (httpx.HTTPError, httpx.RequestError, RuntimeError) as exc:
-                log.warning(
-                    "upload_failed",
-                    entry=f"{entry.tipo}/{entry.mes_ano}",
-                    error=str(exc),
-                )
-
-    asyncio.run(_upload_all())
-    manifest.save_local(_manifest_path(data_dir))
-    try:
-        asyncio.run(ia_archive.upload_manifest(_manifest_path(data_dir)))
-    except (httpx.HTTPError, RuntimeError) as exc:
-        # Non-fatal: parquets are already on IA; the next run just re-uploads.
-        log.warning("manifest_upload_failed", error=str(exc))
-    log.info("upload_done", pending=len(pending))
+    asyncio.run(service.upload_pending(data_dir))
 
 
 @app.command()
@@ -371,13 +88,10 @@ def status(
     data_dir: Annotated[Path, typer.Argument(help="Directory with manifest")],
 ) -> None:
     """Show manifest status."""
-    manifest = ManifestJuris.load_local(_manifest_path(data_dir))
-    entries = manifest.all_entries()
-    uploaded = sum(1 for e in entries if e.ia_status == "uploaded")
-    total = len(entries)
-    typer.echo(f"Total entries: {total}")
-    typer.echo(f"Uploaded:      {uploaded}")
-    typer.echo(f"Pending:       {total - uploaded}")
+    result = service.manifest_status(data_dir)
+    typer.echo(f"Total entries: {result.total}")
+    typer.echo(f"Uploaded:      {result.uploaded}")
+    typer.echo(f"Pending:       {result.pending}")
 
 
 @app.command()
@@ -386,15 +100,7 @@ def consolidate(
     year: Annotated[int, typer.Argument(help="Year to consolidate")],
 ) -> None:
     """Consolidate monthly parquets for a year into a single deduplicated file."""
-    parquet_files: list[Path] = []
-    for tipo_name in TIPOS:
-        safe_tipo = tipo_name.replace(" ", "_").replace("/", "_")
-        tipo_dir = data_dir / str(year) / safe_tipo
-        if tipo_dir.exists():
-            parquet_files.extend(sorted(tipo_dir.glob("*.parquet")))
-
-    output = data_dir / str(year) / f"tjro-juris-{year}.parquet"
-    count = consolidate_year(parquet_files, output)
+    output, count = service.consolidate_parquets(data_dir, year)
     typer.echo(f"Consolidated {count} documents to {output}")
 
 

--- a/src/tjro_juris/__main__.py
+++ b/src/tjro_juris/__main__.py
@@ -21,8 +21,10 @@ When no local manifest exists, ``crawl``/``upload`` first try to restore it
 from the public IA item (``tjro-juris``); ``upload`` pushes it back so
 scheduled runs on blank runners stay incremental.
 
-In CI, ``.github/workflows/tjro-sync.yml`` runs the same commands hourly
-(scheduled runs crawl only the current month) plus ``workflow_dispatch``.
+In CI, ``.github/workflows/tjro-sync.yml`` runs the same commands daily
+(scheduled runs continue the historical backfill via ``--desde-ano 1988``,
+not just the current month) plus ``workflow_dispatch`` for ad-hoc
+``--ano``/``--mes``/``--desde-ano`` runs.
 
 Business logic lives in ``tjro_juris.service`` (RFC 0013 Fase 2); this
 module only parses argv and echoes results.

--- a/src/tjro_juris/service.py
+++ b/src/tjro_juris/service.py
@@ -1,0 +1,363 @@
+"""Config→result service layer for ``tjro-juris``, free of Typer (RFC 0013 Fase 2).
+
+``__main__.py`` owns argv parsing and echoing results; this module owns the
+actual work — crawling, uploading, consolidating — so it can be called from
+a future MCP tool or a different CLI framework without dragging Typer along.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import anyio
+import httpx
+import pyarrow as pa
+import pyarrow.parquet as pq
+import structlog
+
+from tjro_juris import archive as ia_archive
+from tjro_juris.client import TIPOS, clean_html
+from tjro_juris.crawler import crawl_all
+from tjro_juris.dedup import consolidate_year
+from tjro_juris.manifest import ManifestJuris, ManifestJurisEntry
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+log = structlog.get_logger()
+
+_MANIFEST_NAME = "tjro-juris-manifest.csv"
+_PARTIAL_CACHE_DIRNAME = ".partial-cache"
+_MIN_DATE_LEN = 10
+
+_PARQUET_SCHEMA = pa.schema(
+    [
+        pa.field("id_documento", pa.int64()),
+        pa.field("nr_processo", pa.string()),
+        pa.field("tipo", pa.string()),
+        pa.field("classe_judicial", pa.string()),
+        pa.field("orgao", pa.string()),
+        pa.field("relator", pa.string()),
+        pa.field("sistema_origem", pa.string()),
+        pa.field("data_julgamento", pa.date32()),
+        pa.field("texto_limpo", pa.string()),
+        pa.field("url_portal", pa.string()),
+        pa.field("extraido_em", pa.string()),
+    ]
+)
+
+
+_MES_RE = re.compile(r"\d{4}-(0[1-9]|1[0-2])")
+
+DEFAULT_START_YEAR = 2010
+
+# JURIS's own data goes further back than the crawler's original hardcoded
+# default: live probes (2026-07-14) found DECISÃO from 1989, ACÓRDÃO from
+# 1991, and SENTENÇA from 2007 — years before the old start_year=2010 default
+# silently never crawled. --desde-ano lets a full backfill start earlier
+# without changing the default (incremental/scheduled runs stay cheap).
+
+_UPLOAD_INTERVAL_S = 1.0
+# IA's S3-compatible endpoint 503s ("Slow Down") under sustained upload
+# volume even WITH per-file retry/backoff (see tjro_juris.archive) — observed
+# live during the historical backfill, where a whole year's worth of
+# monthly parquets landed back-to-back with zero delay between PUTs. A
+# small self-imposed pause between uploads mirrors the crawler's own
+# _REQUEST_INTERVAL rate-limiting and cuts how often the retry path is
+# needed at all, instead of just reacting to it after the fact.
+
+
+def manifest_path(data_dir: Path) -> Path:
+    """Path to the local manifest CSV under *data_dir*."""
+    return data_dir / _MANIFEST_NAME
+
+
+def _partial_cache_dir(data_dir: Path) -> Path:
+    """Staging area for in-progress pagination (see crawler._fetch_pages).
+
+    Lives under data_dir so it survives between crawl invocations of the
+    same --ano; never uploaded to IA, never read by anything except a
+    resumed crawl of the same window.
+    """
+    return data_dir / _PARTIAL_CACHE_DIRNAME
+
+
+def load_manifest(data_dir: Path) -> ManifestJuris:
+    """Load the local manifest, restoring it from IA when absent.
+
+    A blank runner (CI) starts with no local state; without the restore every
+    scheduled run would re-crawl and re-upload everything. The restore is
+    best-effort: IA can return a transient error (observed: 503, not 404, for
+    an item that has simply never been created yet) for reasons that have
+    nothing to do with whether a manifest actually exists. Failing to
+    restore only costs a redundant re-crawl of already-uploaded windows —
+    no data is lost — so it must never abort the whole run.
+    """
+    path = manifest_path(data_dir)
+    if not path.exists():
+        try:
+            ia_archive.download_manifest(path)
+        except httpx.HTTPError as exc:
+            log.warning("manifest_restore_failed", error=str(exc))
+    return ManifestJuris.load_local(path)
+
+
+def _should_skip_window(
+    manifest: ManifestJuris, current_ym: str, tipo_name: str, year_month: str
+) -> bool:
+    """Skip a (tipo, year_month) window the manifest already records as uploaded.
+
+    The current month is never skipped: JURIS keeps publishing into it, so it
+    must always be re-crawled even if a previous run already uploaded it.
+    """
+    if year_month >= current_ym:
+        return False
+    entry = manifest.get(tipo_name, year_month)
+    return entry is not None and entry.ia_status == "uploaded"
+
+
+def crawl_bounds(
+    ano: int | None, mes: str | None, desde_ano: int | None, now: datetime
+) -> tuple[int, str | None, str | None]:
+    """Resolve (start_year, end_year_month, start_year_month) for the crawl."""
+    exclusive = [v is not None for v in (ano, mes, desde_ano)]
+    if sum(exclusive) > 1:
+        msg = "--ano, --mes and --desde-ano are mutually exclusive"
+        raise ValueError(msg)
+    if mes is not None:
+        if not _MES_RE.fullmatch(mes):
+            msg = f"--mes must be AAAA-MM, got {mes!r}"
+            raise ValueError(msg)
+        return int(mes[:4]), mes, mes
+    if ano is not None:
+        end = f"{ano:04d}-12" if ano < now.year else now.strftime("%Y-%m")
+        return ano, end, None
+    if desde_ano is not None:
+        return desde_ano, None, None
+    return DEFAULT_START_YEAR, None, None
+
+
+def parquet_path(data_dir: Path, tipo: str, year_month: str) -> Path:
+    """Path to the monthly parquet for a (tipo, year_month) window."""
+    year = year_month[:4]
+    safe_tipo = tipo.replace(" ", "_").replace("/", "_")
+    return data_dir / year / safe_tipo / f"{year_month}.parquet"
+
+
+def _normalize_date(dt_raw: str) -> str | None:
+    """Normalize date string to YYYY-MM-DD."""
+    if not dt_raw:
+        return None
+    m = re.match(r"(\d{2})/(\d{2})/(\d{4})", dt_raw)
+    if m:
+        return f"{m.group(3)}-{m.group(2)}-{m.group(1)}"
+    return dt_raw[:_MIN_DATE_LEN] if len(dt_raw) >= _MIN_DATE_LEN else dt_raw
+
+
+def _to_row(src: dict) -> dict:
+    """Map a crawler-normalized doc to canonical parquet schema.
+
+    Accepts the dict produced by crawler._extract_doc() which already uses
+    canonical field names (id_documento, classe_judicial, orgao, etc.).
+    """
+    dt_raw = src.get("data_julgamento") or ""
+    return {
+        "id_documento": src.get("id_documento"),
+        "nr_processo": src.get("nr_processo") or "",
+        "tipo": src.get("tipo") or "",
+        "classe_judicial": src.get("classe_judicial") or "",
+        "orgao": src.get("orgao") or "",
+        "relator": src.get("relator") or "",
+        "sistema_origem": src.get("sistema_origem") or "",
+        "data_julgamento": _normalize_date(dt_raw),
+        "texto_limpo": src.get("texto_limpo") or clean_html(src.get("ds_modelo_documento") or ""),
+        "url_portal": src.get("url_portal") or "",
+        "extraido_em": src.get("extraido_em") or datetime.now(UTC).isoformat(),
+    }
+
+
+def _parse_date(v: str | None) -> _dt.date | None:
+    """Parse ISO date string to date object."""
+    if not v:
+        return None
+    try:
+        return _dt.date.fromisoformat(v)
+    except ValueError:
+        return None
+
+
+def _rows_to_parquet(rows: list[dict], out: Path) -> None:
+    """Write list of row dicts to a parquet file using pyarrow."""
+    arrays: dict[str, list] = {f.name: [] for f in _PARQUET_SCHEMA}
+    for row in rows:
+        for field in _PARQUET_SCHEMA:
+            val = row.get(field.name)
+            if field.name == "id_documento":
+                arrays[field.name].append(int(val) if val is not None else None)
+            elif field.name == "data_julgamento":
+                arrays[field.name].append(val)
+            else:
+                arrays[field.name].append(str(val) if val is not None else None)
+
+    arrow_cols = []
+    for field in _PARQUET_SCHEMA:
+        raw = arrays[field.name]
+        if field.type == pa.date32():
+            arrow_cols.append(pa.array([_parse_date(v) for v in raw], type=pa.date32()))
+        else:
+            arrow_cols.append(pa.array(raw, type=field.type))
+
+    table = pa.table(
+        dict(zip(_PARQUET_SCHEMA.names, arrow_cols, strict=True)), schema=_PARQUET_SCHEMA
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, out)
+
+
+def crawl_juris(
+    data_dir: Path,
+    tipo: list[str] | None,
+    ano: int | None,
+    mes: str | None,
+    desde_ano: int | None,
+) -> None:
+    """Crawl JURIS and save as parquet files per (tipo, mes_ano).
+
+    Windows already uploaded to IA (per the manifest, restored from IA when
+    no local copy exists) are skipped, except the current month, which is
+    always re-crawled to pick up newly published documents. Windows whose
+    parquet is already on local disk (e.g. a prior attempt this same year
+    got partway through before failing) are also skipped — see
+    ``_already_crawled_locally``.
+
+    The manifest is saved after EVERY window, not just once at the end: a
+    long --ano/--desde-ano crawl that dies partway through (observed live —
+    TJRO's STIC anti-abuse system can block a sustained crawl mid-year)
+    previously lost all of that year's progress from the manifest even
+    though the parquet files were already safely on disk, forcing a full
+    re-fetch of every tipo on the next attempt. Saving incrementally means
+    a retry only has to redo whatever wasn't finished yet.
+
+    Raises ``ValueError`` when --ano/--mes/--desde-ano are combined, or
+    --mes isn't AAAA-MM (see ``crawl_bounds``).
+    """
+    manifest = load_manifest(data_dir)
+    tipos_to_crawl = tipo or TIPOS
+
+    now = datetime.now(UTC)
+    current_ym = now.strftime("%Y-%m")
+    start_year, end_year_month, start_year_month = crawl_bounds(ano, mes, desde_ano, now)
+
+    def _already_crawled_locally(tipo_name: str, year_month: str) -> bool:
+        return parquet_path(data_dir, tipo_name, year_month).exists()
+
+    def _skip(tipo_name: str, year_month: str) -> bool:
+        if _already_crawled_locally(tipo_name, year_month):
+            return True
+        return _should_skip_window(manifest, current_ym, tipo_name, year_month)
+
+    for tipo_name, year_month, docs in crawl_all(
+        start_year=start_year,
+        end_year_month=end_year_month,
+        tipos=tipos_to_crawl,
+        start_year_month=start_year_month,
+        skip=_skip,
+        cache_dir=_partial_cache_dir(data_dir),
+        shuffle=True,
+    ):
+        if not docs:
+            continue
+
+        rows = [_to_row(d) for d in docs]
+        out = parquet_path(data_dir, tipo_name, year_month)
+        _rows_to_parquet(rows, out)
+        log.info("parquet_saved", path=str(out), rows=len(rows))
+
+        entry = ManifestJurisEntry(
+            tipo=tipo_name,
+            mes_ano=year_month,
+            ia_status="",
+            n_docs=len(docs),
+        )
+        manifest.upsert(entry)
+        manifest.save_local(manifest_path(data_dir))
+
+    log.info("crawl_done")
+
+
+async def upload_pending(data_dir: Path) -> int:
+    """Upload parquets (and the manifest) to Internet Archive. Returns the pending count."""
+    manifest = load_manifest(data_dir)
+    pending = manifest.pending_upload()
+
+    for i, entry in enumerate(pending):
+        if i > 0:
+            await asyncio.sleep(_UPLOAD_INTERVAL_S)
+        pq_path = parquet_path(data_dir, entry.tipo, entry.mes_ano)
+        if not await anyio.Path(pq_path).exists():
+            log.warning("parquet_not_found", path=str(pq_path))
+            continue
+        year = int(entry.mes_ano[:4])
+        safe_tipo = entry.tipo.replace(" ", "_").replace("/", "_")
+        remote_name = f"{entry.mes_ano}-{safe_tipo}.parquet"
+        try:
+            await ia_archive.upload_file(pq_path, year, remote_name)
+            entry.ia_status = "uploaded"
+            manifest.upsert(entry)
+        except (httpx.HTTPError, httpx.RequestError, RuntimeError) as exc:
+            log.warning(
+                "upload_failed",
+                entry=f"{entry.tipo}/{entry.mes_ano}",
+                error=str(exc),
+            )
+
+    manifest.save_local(manifest_path(data_dir))
+    try:
+        await ia_archive.upload_manifest(manifest_path(data_dir))
+    except (httpx.HTTPError, RuntimeError) as exc:
+        # Non-fatal: parquets are already on IA; the next run just re-uploads.
+        log.warning("manifest_upload_failed", error=str(exc))
+    log.info("upload_done", pending=len(pending))
+    return len(pending)
+
+
+@dataclass
+class ManifestStatus:
+    """Summary counts for the local manifest."""
+
+    total: int
+    uploaded: int
+
+    @property
+    def pending(self) -> int:
+        """Entries not yet uploaded."""
+        return self.total - self.uploaded
+
+
+def manifest_status(data_dir: Path) -> ManifestStatus:
+    """Summarize the local manifest: total entries and how many are uploaded."""
+    manifest = ManifestJuris.load_local(manifest_path(data_dir))
+    entries = manifest.all_entries()
+    uploaded = sum(1 for e in entries if e.ia_status == "uploaded")
+    return ManifestStatus(total=len(entries), uploaded=uploaded)
+
+
+def consolidate_parquets(data_dir: Path, year: int) -> tuple[Path, int]:
+    """Consolidate monthly parquets for a year into a single deduplicated file."""
+    parquet_files: list[Path] = []
+    for tipo_name in TIPOS:
+        safe_tipo = tipo_name.replace(" ", "_").replace("/", "_")
+        tipo_dir = data_dir / str(year) / safe_tipo
+        if tipo_dir.exists():
+            parquet_files.extend(sorted(tipo_dir.glob("*.parquet")))
+
+    output = data_dir / str(year) / f"tjro-juris-{year}.parquet"
+    count = consolidate_year(parquet_files, output)
+    return output, count

--- a/tests/datajud/test_datajud_cli_contract.py
+++ b/tests/datajud/test_datajud_cli_contract.py
@@ -78,12 +78,15 @@ def test_datajud_status_argv() -> None:
     assert ctx.params == {"data_dir": "data/datajud"}
 
 
-def test_enrich_credenciais_ia_sao_opcao_de_cli_com_envvar() -> None:
-    """`ia_key`/`ia_secret` são `typer.Option(envvar=...)` — mesmo padrão de
-    `stj_acordaos`. A Fase 2 do RFC 0013 precisa eliminar isso antes de
-    `enrich` (mesmo em variante restrita, sem upload) virar tool MCP.
+def test_enrich_nao_tem_mais_credenciais_ia_como_opcao_de_cli() -> None:
+    """Fase 2 do RFC 0013: `ia_key`/`ia_secret` deixaram de ser opção de CLI.
+
+    Antes eram `typer.Option(envvar=...)`, mesmo padrão de `stj_acordaos`.
+    Agora `enrich` só lê `IA_ACCESS_KEY`/`IA_SECRET_KEY` do ambiente via
+    `datajud.service.ia_credentials()` — nada aparece em `--help` nem em
+    `ctx.params`, então nada disso vira campo de schema numa tool MCP.
     """
     enrich = _CMD.commands["enrich"]
     by_name = {p.name: p for p in enrich.params}
-    assert by_name["ia_key"].envvar == "IA_ACCESS_KEY"
-    assert by_name["ia_secret"].envvar == "IA_SECRET_KEY"
+    assert "ia_key" not in by_name
+    assert "ia_secret" not in by_name

--- a/tests/datajud/test_datajud_enrich.py
+++ b/tests/datajud/test_datajud_enrich.py
@@ -154,10 +154,10 @@ def test_enrich_cnj_file_and_limit(tmp_path: Path):
 
 
 def test_enrich_no_cnjs_and_no_sources_fails_nominally(tmp_path: Path, monkeypatch):
-    import datajud.__main__ as cli
+    from datajud import service
 
     # IA fallback download is a urllib call — stub it out (zero real network)
-    monkeypatch.setattr(cli, "_try_download_unificados", lambda _dir: None)
+    monkeypatch.setattr(service, "_try_download_unificados", lambda _dir: None)
     result = runner.invoke(
         app,
         [
@@ -239,11 +239,11 @@ def test_enrich_reads_cnjs_from_tjro_juris_source_parquet(tmp_path: Path):
 
 
 def test_enrich_rate_limit_exhaustion_is_a_nominal_error(tmp_path: Path, monkeypatch):
-    import datajud.__main__ as cli
+    from datajud import service
 
-    original = cli.DataJudClient
+    original = service.DataJudClient
     monkeypatch.setattr(
-        cli,
+        service,
         "DataJudClient",
         lambda **kw: original(**{**kw, "backoff_base": 0.0, "max_retries": 1}),
     )

--- a/tests/djen_backup/test_cli_exit_code.py
+++ b/tests/djen_backup/test_cli_exit_code.py
@@ -1,0 +1,44 @@
+"""Regression tests for the exit-code propagation fix (RFC 0013 Fase 2).
+
+Before the fix, the bare callback, `check` and `upload` all called
+`_run_pipeline(...)` without doing anything with its return value — the
+process exit code was always 0 regardless of whether the sync actually
+succeeded. `_run_pipeline` itself is monkeypatched here (never invokes the
+real sync engine — no network, no I/O) so these tests isolate exactly the
+propagation logic: does the CLI's exit code match what `_run_pipeline`
+returned?
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from djen_backup.__main__ import app
+
+
+runner = CliRunner()
+
+
+def test_bare_callback_propagates_nonzero_exit_code(monkeypatch) -> None:
+    monkeypatch.setattr("djen_backup.__main__._run_pipeline", lambda _config: 7)
+    result = runner.invoke(app, [])
+    assert result.exit_code == 7
+
+
+def test_check_propagates_nonzero_exit_code(monkeypatch) -> None:
+    monkeypatch.setattr("djen_backup.__main__._run_pipeline", lambda _config: 5)
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 5
+
+
+def test_upload_propagates_nonzero_exit_code(monkeypatch) -> None:
+    monkeypatch.setattr("djen_backup.__main__._run_pipeline", lambda _config: 3)
+    result = runner.invoke(app, ["upload"])
+    assert result.exit_code == 3
+
+
+def test_bare_callback_propagates_zero_exit_code(monkeypatch) -> None:
+    """Sanity check: the success path (0) isn't accidentally turned into a failure."""
+    monkeypatch.setattr("djen_backup.__main__._run_pipeline", lambda _config: 0)
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0

--- a/tests/djen_backup/test_cli_helpers.py
+++ b/tests/djen_backup/test_cli_helpers.py
@@ -2,13 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from djen_backup.__main__ import (
-    DJEN_DIRECT_URL,
-    DJEN_PROXY_FALLBACK_URL,
-    _env_truthy,
-    _load_local_env,
-    _resolve_djen_url,
-)
+from djen_backup.__main__ import _env_truthy, _load_local_env
+from djen_backup.service import DJEN_DIRECT_URL, DJEN_PROXY_FALLBACK_URL, resolve_djen_url
 
 
 if TYPE_CHECKING:
@@ -36,13 +31,13 @@ def test_resolve_djen_url_defaults_to_direct(monkeypatch) -> None:
     monkeypatch.delenv("DJEN_DIRECT_URL", raising=False)
     monkeypatch.delenv("DJEN_PROXY_URL", raising=False)
 
-    assert _resolve_djen_url(use_proxy=False) == DJEN_DIRECT_URL
+    assert resolve_djen_url(use_proxy=False) == DJEN_DIRECT_URL
 
 
 def test_resolve_djen_url_uses_proxy_when_requested(monkeypatch) -> None:
     monkeypatch.delenv("DJEN_PROXY_URL", raising=False)
 
-    assert _resolve_djen_url(use_proxy=True) == DJEN_PROXY_FALLBACK_URL
+    assert resolve_djen_url(use_proxy=True) == DJEN_PROXY_FALLBACK_URL
 
 
 def test_env_truthy_recognizes_proxy_flag(monkeypatch) -> None:

--- a/tests/stj_acordaos/test_stj_cli_contract.py
+++ b/tests/stj_acordaos/test_stj_cli_contract.py
@@ -38,26 +38,18 @@ def test_stj_sync_argv_download() -> None:
     }
 
 
-def test_stj_sync_argv_upload(monkeypatch) -> None:
+def test_stj_sync_argv_upload() -> None:
     """Reproduz `stj-sync.yml`: `stj-acordaos upload --data-dir ... --manifest-path ...`.
 
-    O workflow não passa `--parquet-path`/`--ia-key`/`--ia-secret` no argv —
-    `parquet_path` fica no default computado a partir de `data_dir` default
-    (não do `--data-dir` informado: são opções independentes, não há
-    recomputação), e as credenciais vêm só de env (`IA_ACCESS_KEY`/
-    `IA_SECRET_KEY`, injetadas pelo workflow via `env:` do step).
-
-    `ia_key`/`ia_secret` usam `envvar=...`, e `Command.make_context` lê essas
-    variáveis do processo de verdade — `monkeypatch.setenv` com valores
-    sentinela reproduz a injeção do workflow e confirma que elas chegam a
-    `ctx.params`, em vez de assumir que ficam vazias (isso só valia por
-    acidente, porque o job de CI não tinha essas variáveis no ambiente; numa
-    máquina com `IA_ACCESS_KEY`/`IA_SECRET_KEY` exportadas, o teste antigo
-    quebrava).
+    O workflow não passa `--parquet-path` no argv — `parquet_path` fica no
+    default computado a partir de `data_dir` default (não do `--data-dir`
+    informado: são opções independentes, não há recomputação). Desde a Fase
+    2 do RFC 0013, `ia_key`/`ia_secret` não são mais parâmetros de CLI (ver
+    `test_upload_nao_tem_mais_credenciais_ia_como_opcao_de_cli`) — as
+    credenciais vêm só de `IA_ACCESS_KEY`/`IA_SECRET_KEY` no ambiente,
+    lidas dentro de `stj_acordaos.service.ia_credentials()`, injetadas pelo
+    workflow via `env:` do step.
     """
-    monkeypatch.setenv("IA_ACCESS_KEY", "sentinel-ia-key")
-    monkeypatch.setenv("IA_SECRET_KEY", "sentinel-ia-secret")
-
     upload = _CMD.commands["upload"]
     argv = [
         "--data-dir",
@@ -67,10 +59,11 @@ def test_stj_sync_argv_upload(monkeypatch) -> None:
     ]
     ctx = upload.make_context("upload", list(argv))
 
-    assert ctx.params["data_dir"] == "data/stj"
-    assert ctx.params["manifest_path"] == "data/stj/stj-manifest.csv"
-    assert ctx.params["ia_key"] == "sentinel-ia-key"
-    assert ctx.params["ia_secret"] == "sentinel-ia-secret"  # noqa: S105 — test fixture, not a real credential
+    assert ctx.params == {
+        "data_dir": "data/stj",
+        "manifest_path": "data/stj/stj-manifest.csv",
+        "parquet_path": Path("data/stj/stj-acordaos.parquet"),
+    }
 
 
 def test_stj_sync_argv_status() -> None:
@@ -81,16 +74,19 @@ def test_stj_sync_argv_status() -> None:
     assert ctx.params == {"manifest_path": "data/stj/stj-manifest.csv"}
 
 
-def test_upload_credenciais_ia_sao_opcao_de_cli_com_envvar() -> None:
-    """`ia_key`/`ia_secret` são `typer.Option(envvar=...)` — a credencial do
-    Internet Archive é literalmente um parâmetro de CLI. Isso é o que a Fase
-    2 do RFC 0013 precisa eliminar antes de qualquer coisa virar tool MCP:
-    um schema de tool não pode ter campo de credencial.
+def test_upload_nao_tem_mais_credenciais_ia_como_opcao_de_cli() -> None:
+    """Fase 2 do RFC 0013: `ia_key`/`ia_secret` deixaram de ser opção de CLI.
+
+    Antes eram `typer.Option(envvar=...)` — a credencial do Internet Archive
+    era literalmente um parâmetro de CLI, o que teria virado campo de schema
+    numa tool MCP. Agora `upload` só lê `IA_ACCESS_KEY`/`IA_SECRET_KEY` do
+    ambiente via `stj_acordaos.service.ia_credentials()` — nada aparece em
+    `--help` nem em `ctx.params`.
     """
     upload = _CMD.commands["upload"]
     by_name = {p.name: p for p in upload.params}
-    assert by_name["ia_key"].envvar == "IA_ACCESS_KEY"
-    assert by_name["ia_secret"].envvar == "IA_SECRET_KEY"
+    assert "ia_key" not in by_name
+    assert "ia_secret" not in by_name
 
 
 def test_download_e_status_tem_defaults_de_path_fixos() -> None:

--- a/tests/stj_acordaos/test_stj_main.py
+++ b/tests/stj_acordaos/test_stj_main.py
@@ -1,4 +1,4 @@
-"""Tests for stj_acordaos.__main__ — CKAN resource classification, skip/fail-fast.
+"""Tests for stj_acordaos.service — CKAN resource classification, skip/fail-fast.
 
 Regression: the STJ dataset carries a non-JSON "dicionário de dados"
 resource (format=CSV) that used to be blindly downloaded as ``.json`` and
@@ -13,15 +13,12 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
-from stj_acordaos.__main__ import (
-    _already_uploaded,
-    _classify_resource,
-    _download_one,
-    _restore_manifest_best_effort,
-    app,
-)
+from stj_acordaos.__main__ import app
 from stj_acordaos.client import STJWAFBlockedError
 from stj_acordaos.manifest import ManifestSTJ
+from stj_acordaos.service import _already_uploaded, _classify_resource
+from stj_acordaos.service import download_one as _download_one
+from stj_acordaos.service import restore_manifest_best_effort as _restore_manifest_best_effort
 
 
 if TYPE_CHECKING:
@@ -116,7 +113,7 @@ def test_download_one_skips_already_uploaded_unchanged(
         msg = "download_resource must not be called for an unchanged, uploaded entry"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("stj_acordaos.__main__.download_resource", _boom)
+    monkeypatch.setattr("stj_acordaos.client.download_resource", _boom)
     _download_one(_resource(), manifest, tmp_path, tmp_path)
     # entry untouched — still the pre-existing uploaded state
     assert manifest.get("acordaos-2024.zip").n_registros == 5
@@ -129,9 +126,9 @@ def test_download_one_re_downloads_when_last_modified_changed(
     manifest.upsert("acordaos-2024.zip", "zip", "2024-01-31", "uploaded", 5)
     calls: list[str] = []
     monkeypatch.setattr(
-        "stj_acordaos.__main__.download_resource", lambda url, _dest: calls.append(url)
+        "stj_acordaos.client.download_resource", lambda url, _dest: calls.append(url)
     )
-    monkeypatch.setattr("stj_acordaos.__main__.extract_zip", lambda *_a, **_k: [])
+    monkeypatch.setattr("stj_acordaos.client.extract_zip", lambda *_a, **_k: [])
 
     _download_one(_resource(last_modified="2024-02-15"), manifest, tmp_path, tmp_path)
 
@@ -154,7 +151,7 @@ def test_download_one_stj_waf_blocked_error_propagates_fail_fast(
         msg = "blocked"
         raise STJWAFBlockedError(msg, request=request, response=response)
 
-    monkeypatch.setattr("stj_acordaos.__main__.download_resource", _blocked)
+    monkeypatch.setattr("stj_acordaos.client.download_resource", _blocked)
     with pytest.raises(STJWAFBlockedError):
         _download_one(_resource(), manifest, tmp_path, tmp_path)
 
@@ -172,7 +169,7 @@ def test_restore_manifest_skips_when_local_copy_exists(
         msg = "fetch_manifest must not be called when a local manifest already exists"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("stj_acordaos.__main__.fetch_manifest", _boom)
+    monkeypatch.setattr("stj_acordaos.archive.fetch_manifest", _boom)
     _restore_manifest_best_effort(manifest_path)  # must not raise
 
 
@@ -193,7 +190,7 @@ def test_restore_manifest_survives_transient_ia_error(
         msg = "503"
         raise httpx.HTTPStatusError(msg, request=request, response=response)
 
-    monkeypatch.setattr("stj_acordaos.__main__.fetch_manifest", _flaky)
+    monkeypatch.setattr("stj_acordaos.archive.fetch_manifest", _flaky)
 
     _restore_manifest_best_effort(manifest_path)  # must not raise
     assert not manifest_path.exists()
@@ -229,6 +226,8 @@ def test_upload_with_everything_already_uploaded_is_a_clean_noop(
         raise AssertionError(msg)
 
     monkeypatch.setattr("stj_acordaos.archive.upload_parquet", _boom)
+    monkeypatch.setenv("IA_ACCESS_KEY", "k")
+    monkeypatch.setenv("IA_SECRET_KEY", "s")
 
     result = runner.invoke(
         app,
@@ -240,10 +239,6 @@ def test_upload_with_everything_already_uploaded_is_a_clean_noop(
             str(data_dir / "stj-acordaos.parquet"),
             "--manifest-path",
             str(manifest_path),
-            "--ia-key",
-            "k",
-            "--ia-secret",
-            "s",
         ],
     )
 
@@ -271,6 +266,8 @@ def test_upload_with_pending_entries_but_no_local_data_is_an_error(
             AssertionError("must not upload with nothing to send")
         ),
     )
+    monkeypatch.setenv("IA_ACCESS_KEY", "k")
+    monkeypatch.setenv("IA_SECRET_KEY", "s")
 
     result = runner.invoke(
         app,
@@ -282,10 +279,6 @@ def test_upload_with_pending_entries_but_no_local_data_is_an_error(
             str(data_dir / "stj-acordaos.parquet"),
             "--manifest-path",
             str(manifest_path),
-            "--ia-key",
-            "k",
-            "--ia-secret",
-            "s",
         ],
     )
 

--- a/tests/stj_acordaos/test_stj_main.py
+++ b/tests/stj_acordaos/test_stj_main.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
+from stj_acordaos import service
 from stj_acordaos.__main__ import app
 from stj_acordaos.client import STJWAFBlockedError
 from stj_acordaos.manifest import ManifestSTJ
@@ -194,6 +195,38 @@ def test_restore_manifest_survives_transient_ia_error(
 
     _restore_manifest_best_effort(manifest_path)  # must not raise
     assert not manifest_path.exists()
+
+
+# ── upload_all: ok must reflect every required artifact ──────────────────
+
+
+def test_upload_all_ok_is_false_when_a_source_fails_even_if_parquet_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: a failed source upload must not be masked by a later, successful one.
+
+    `ok` used to be reassigned by each source's upload and then overwritten
+    by the parquet upload's own `ok` — so a failed ZIP/JSON upload silently
+    disappeared as long as the parquet itself made it to IA.
+    """
+    data_dir = tmp_path / "data"
+    zip_dir = data_dir / "zips"
+    zip_dir.mkdir(parents=True)
+    (zip_dir / "a.zip").write_bytes(b"fake")
+
+    parquet_path = data_dir / "stj-acordaos.parquet"
+    parquet_path.write_bytes(b"fake-parquet")  # pre-existing — dedup step is skipped
+    manifest_path = data_dir / "stj-manifest.csv"
+
+    def _fake_upload(path: Path, _ia_key: str, _ia_secret: str) -> bool:
+        return path.name != "a.zip"  # the source fails; parquet + manifest succeed
+
+    monkeypatch.setattr("stj_acordaos.archive.upload_parquet", _fake_upload)
+
+    result = service.upload_all(data_dir, parquet_path, manifest_path, "k", "s")
+
+    assert result.status == "done"
+    assert result.ok is False
 
 
 # ── upload: nothing-new-to-do must not be an error ───────────────────────

--- a/tests/tjro_juris/test_juris_main.py
+++ b/tests/tjro_juris/test_juris_main.py
@@ -1,4 +1,4 @@
-"""Tests for tjro_juris.__main__ — incremental crawl bounds, manifest restore, skip logic."""
+"""Tests for tjro_juris.service — incremental crawl bounds, manifest restore, skip logic."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
-import typer
 
-from tjro_juris.__main__ import _crawl_bounds, _load_manifest, _should_skip_window
 from tjro_juris.manifest import ManifestJuris, ManifestJurisEntry
+from tjro_juris.service import _should_skip_window
+from tjro_juris.service import crawl_bounds as _crawl_bounds
+from tjro_juris.service import load_manifest as _load_manifest
 
 
 if TYPE_CHECKING:
@@ -32,15 +33,15 @@ def test_crawl_bounds_mes_narrows_to_a_single_month() -> None:
 
 def test_crawl_bounds_mes_rejects_bad_format() -> None:
     now = datetime(2026, 7, 12, tzinfo=UTC)
-    with pytest.raises(typer.BadParameter, match="AAAA-MM"):
+    with pytest.raises(ValueError, match="AAAA-MM"):
         _crawl_bounds(None, "2026-13", None, now)
-    with pytest.raises(typer.BadParameter, match="AAAA-MM"):
+    with pytest.raises(ValueError, match="AAAA-MM"):
         _crawl_bounds(None, "not-a-month", None, now)
 
 
 def test_crawl_bounds_mes_and_ano_are_mutually_exclusive() -> None:
     now = datetime(2026, 7, 12, tzinfo=UTC)
-    with pytest.raises(typer.BadParameter, match="mutually exclusive"):
+    with pytest.raises(ValueError, match="mutually exclusive"):
         _crawl_bounds(2026, "2026-07", None, now)
 
 
@@ -61,13 +62,13 @@ def test_crawl_bounds_desde_ano_overrides_default_start() -> None:
 
 def test_crawl_bounds_desde_ano_mutually_exclusive_with_ano() -> None:
     now = datetime(2026, 7, 12, tzinfo=UTC)
-    with pytest.raises(typer.BadParameter, match="mutually exclusive"):
+    with pytest.raises(ValueError, match="mutually exclusive"):
         _crawl_bounds(2020, None, 1988, now)
 
 
 def test_crawl_bounds_desde_ano_mutually_exclusive_with_mes() -> None:
     now = datetime(2026, 7, 12, tzinfo=UTC)
-    with pytest.raises(typer.BadParameter, match="mutually exclusive"):
+    with pytest.raises(ValueError, match="mutually exclusive"):
         _crawl_bounds(None, "2026-07", 1988, now)
 
 
@@ -120,7 +121,7 @@ def test_load_manifest_restores_from_ia_when_local_copy_absent(
         dest.write_text("tipo,mes_ano,ia_status,n_docs,updated_at\nVOTO,2026-01,uploaded,3,\n")
         return True
 
-    monkeypatch.setattr("tjro_juris.__main__.ia_archive.download_manifest", _fake_download)
+    monkeypatch.setattr("tjro_juris.service.ia_archive.download_manifest", _fake_download)
 
     manifest = _load_manifest(tmp_path)
 
@@ -141,7 +142,7 @@ def test_load_manifest_skips_restore_when_local_copy_exists(
         msg = "download_manifest must not be called when a local manifest already exists"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("tjro_juris.__main__.ia_archive.download_manifest", _boom)
+    monkeypatch.setattr("tjro_juris.service.ia_archive.download_manifest", _boom)
 
     manifest = _load_manifest(tmp_path)
     assert manifest.get("EMENTA", "2026-02") is not None
@@ -150,7 +151,7 @@ def test_load_manifest_skips_restore_when_local_copy_exists(
 def test_load_manifest_starts_empty_when_ia_has_no_manifest_either(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("tjro_juris.__main__.ia_archive.download_manifest", lambda _dest: False)
+    monkeypatch.setattr("tjro_juris.service.ia_archive.download_manifest", lambda _dest: False)
     manifest = _load_manifest(tmp_path)
     assert manifest.all_entries() == []
 
@@ -171,7 +172,7 @@ def test_load_manifest_survives_transient_ia_error_starts_empty(
         msg = "503"
         raise httpx.HTTPStatusError(msg, request=request, response=response)
 
-    monkeypatch.setattr("tjro_juris.__main__.ia_archive.download_manifest", _flaky)
+    monkeypatch.setattr("tjro_juris.service.ia_archive.download_manifest", _flaky)
 
     manifest = _load_manifest(tmp_path)  # must not raise
 


### PR DESCRIPTION
## Resumo

Fase 2 de 4 da migração Typer→Cyclopts+FastMCP (RFC 0013, Fase 1 já mergeada em #848). Cada pacote (`djen_backup`, `tjro_juris`, `stj_acordaos`, `datajud`) ganha um `service.py` com funções config→resultado, sem Typer/Rich/`echo` — os `__main__.py` ficam reduzidos a parsing de argv e tradução do resultado em echo/exit code.

## O que mudou

- **`djen_backup`**: side effects de import (`structlog.configure(...)`, reconfiguração de `stdout`/`stderr`) saem do topo do módulo para `configure_runtime()`, chamada uma vez no callback `main()` — Click sempre invoca o callback do grupo antes de qualquer subcomando, cobrindo `check`/`upload`/`drain`/`probe`/`reset` também. O bug de exit code descartado — documentado no RFC só para o callback bare — na verdade existia igual em `check` e `upload`; os três agora fazem `raise typer.Exit(code=_run_pipeline(...))`.
- **`tjro_juris`**: `crawl`/`upload`/`status`/`consolidate` movidos quase inteiros para `service.py`. `crawl_bounds` passa a levantar `ValueError` (framework-neutro) em vez de `typer.BadParameter`; o `__main__.py` traduz na borda da CLI.
- **`stj_acordaos`**: `download_one`/`upload_all` retornam outcomes estruturados em vez de chamar `typer.echo` diretamente — o `__main__.py` traduz o outcome em mensagens. `ia_key`/`ia_secret` deixam de ser opção de CLI: `upload` só lê `IA_ACCESS_KEY`/`IA_SECRET_KEY` do ambiente via `service.ia_credentials()`.
- **`datajud`**: mesmo padrão para `enrich`/`facetas`/`status`; `ia_key`/`ia_secret` removidos da opção `enrich` pelo mesmo motivo.
- **`docs/rfc/0013-migracao-cyclopts-fastmcp.md`**: Fase 2 marcada como implementada, com o que foi (e não foi) entregue.

## Testes

Os testes de caracterização da Fase 1 continuam verdes, exceto os dois que documentavam `ia_key`/`ia_secret` como opção de CLI — atualizados para afirmar a ausência da opção, já que essa mudança de contrato é o objetivo desta fase. Testes unitários que monkeypatchavam símbolos de `__main__.py` (ex.: `download_resource`, `DataJudClient`, `fetch_manifest`) foram atualizados para os novos módulos de destino (`service.py` ou o módulo de origem, conforme o padrão já usado em `tjro_juris`).

| Gate | Resultado |
| --- | --- |
| Suíte completa (`--junitxml`) | 751 testes, 0 falhas, 0 erros, 1 skipped |
| `ruff check src/ tests/ scripts/` | limpo |
| `ruff format --check src/ tests/ scripts/` | limpo |
| `--help` das 4 CLIs | OK |

## Fora de escopo desta fase

A bateria de testes framework-neutra (`argv → configuração semântica`, camada de serviço mockada) cotada no RFC como portão durável de Fase 4 **não foi construída aqui** — fica para o início da Fase 4, quando a API real do Cyclopts for conhecida e o formato dos casos puder ser desenhado contra ela.

## Próximas fases

Fase 3: tools MCP de leitura sobre a camada de serviço agora extraída. Fase 4: Typer→Cyclopts, com a bateria framework-neutra (a construir) como portão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_