### PR TITLE
test: adiciona gate framework-neutral para contratos das CLIs

### DIFF
--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -155,12 +155,17 @@ migração para Cyclopts só precisa trocar `CliRunner.invoke` por um
 adaptador equivalente; todo caso e todo `check()` são reaproveitados
 verbatim.
 
-Cobre as 5 famílias de workflow do RFC mais os casos que a review de Fase 2
-marcou como perigosos:
+Cobre todo passo literal dos 5 workflows do RFC — não só um comando
+representativo por família: `djen-backup` bare + `drain`; `tjro-juris
+crawl` + `upload` + `status`; `stj-acordaos download` + `upload` +
+`status`; `datajud enrich` + `status`. Reduzir cobertura em relação à Fase
+1 (que já caracterizava todos esses argv via introspecção Click) ao trocar
+de bateria não seria aceitável — uma migração Cyclopts poderia quebrar
+`tjro-juris upload`, por exemplo, com esta bateria inteira verde. Mais os
+casos que a review de Fase 2 marcou como perigosos:
 
-- `djen-backup` sem subcomando (`collect-zips.yml`), incluindo
-  `--no-fail-fast` — o caso mais frágil do RFC (§ Riscos).
-- `djen-backup drain` (`upload-backlog.yml`).
+- `--no-fail-fast` no callback bare do `djen-backup` — o caso mais frágil
+  do RFC (§ Riscos).
 - A assimetria do `--use-proxy`: negável no callback bare
   (`--no-use-proxy` aceito), não-negável em `drain` (`--no-use-proxy`
   rejeitado com exit code 2 — testado explicitamente, não só o caminho
@@ -169,9 +174,14 @@ marcou como perigosos:
   (`--desde-ano 1988`).
 - Defaults de path do `stj-acordaos upload` (`--parquet-path` nunca
   informado no workflow).
-- Ausência de credenciais nos parâmetros semânticos de `stj-acordaos` e
-  `datajud`: além de nunca aparecerem em `ctx.params` (Fase 1), `--ia-key`
-  não é mais uma opção reconhecida em nenhum dos dois (exit code 2).
+- Credenciais de `stj-acordaos` e `datajud`: `--ia-key`/`--ia-secret` não
+  são mais opção reconhecida em nenhum dos dois (exit code 2) — e, no
+  caminho feliz que reproduz o `env:` real de `stj-sync.yml`/
+  `datajud-enrich.yml`, chegam corretamente à camada de serviço a partir de
+  sentinelas em `IA_ACCESS_KEY`/`IA_SECRET_KEY`. A garantia não é
+  "credenciais vazias" (que uma migração poderia satisfazer por acidente
+  mesmo com a fiação ambiente→serviço quebrada) — é "fora do argv/schema,
+  vindas só do ambiente".
 
 ### Fase 3 — tools MCP
 
@@ -215,10 +225,11 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
   mantêm nome, default e negação de flag idênticos ao que a Fase 1 travou.
 
 **Fase 2.5 (implementada):**
-- `tests/cli_contract/` com a tabela `CliContractCase` cobrindo as 5
-  famílias de workflow e os casos perigosos listados acima (`--no-fail-fast`,
-  assimetria `--use-proxy`, `--tipo` repetido, defaults de path do STJ,
-  ausência de credenciais).
+- `tests/cli_contract/` com a tabela `CliContractCase` cobrindo todo passo
+  literal dos 5 workflows (não um comando por família) e os casos perigosos
+  listados acima (`--no-fail-fast`, assimetria `--use-proxy`, `--tipo`
+  repetido, defaults de path do STJ, credenciais vindas do ambiente real do
+  job, nunca do argv).
 - Cada caso mocka só a função de `service.py` alcançada, nunca introspecciona
   Click (`get_command`, `make_context`, `opts`, `secondary_opts`,
   `param.type` não aparecem neste módulo).
@@ -241,9 +252,14 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
   utilizados, docstrings) — resolvido com refino local (ex.: `enrich` do
   `datajud` dividido em `_pending_cnjs`/`_upload_step` para ficar sob o
   limite de complexidade) em vez de whitelist ampla.
-- A bateria framework-neutra de argv (Fase 2.5) cobre os casos que a review
-  de Fase 2 identificou como perigosos, não necessariamente todo parâmetro
-  de toda subcommand — `check`/`upload`/`probe`/`reset`/`status`/
-  `consolidate`/`facetas` (não exercidos por nenhum workflow) ainda dependem
-  só da introspecção Click da Fase 1. Ampliar a cobertura é trabalho
+- A bateria framework-neutra de argv (Fase 2.5) cobre todo passo literal
+  dos 5 workflows — incluindo `tjro-juris upload`/`status`, `stj-acordaos
+  download`/`status` e `datajud status`, que uma primeira versão da Fase 2.5
+  deixou de fora por engano (a review corrigiu: são passos de produção, não
+  hipotéticos, e já eram caracterizados pela Fase 1 — reduzir a cobertura ao
+  trocar de bateria não era aceitável). Não cobre todo parâmetro de toda
+  subcommand, só o que cada workflow de fato invoca: `djen-backup
+  check`/`probe`/`reset` (nenhum workflow os chama), `tjro-juris
+  consolidate` e `datajud facetas` (idem, confirmado no RFC §1) ainda
+  dependem só da introspecção Click da Fase 1. Ampliar isso é trabalho
   incremental, não bloqueio para começar a Fase 3.

--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -1,6 +1,6 @@
 # RFC 0013 — Migração das CLIs Typer para Cyclopts + FastMCP
 
-- **Status:** Fase 1 e Fase 2 implementadas
+- **Status:** Fase 1, Fase 2 e Fase 2.5 implementadas
 - **Data:** 2026-07-21
 - **Base:** comparação de arquitetura com o repo irmão `pink` (mesma stack alvo:
   Cyclopts + FastMCP, tools declaradas uma vez, CLI como despachante genérico
@@ -55,9 +55,10 @@ fora desta migração.
 
 ## 2. Proposta
 
-Quatro fases sequenciais, cada uma um PR, na ordem abaixo. Trocar o framework
-por último significa fazer a parte de maior risco depois que todo o resto já
-estiver provado.
+Quatro fases sequenciais, cada uma um PR, na ordem abaixo — mais uma Fase
+2.5 inserida depois que a Fase 2 expôs uma lacuna concreta (ver abaixo).
+Trocar o framework por último significa fazer a parte de maior risco depois
+que todo o resto já estiver provado.
 
 ### Fase 1 — este PR: rede de segurança
 
@@ -80,7 +81,7 @@ vs. `list`, `Path` vs. `str` cru, a representação interna de
 `secondary_opts`), o que os torna frágeis a mudanças que não afetam nenhum
 cron.
 
-O portão durável — a construir na Fase 2, depois que a camada de serviço
+O portão durável — construído na Fase 2.5, depois que a camada de serviço
 existir — é framework-neutro: casos no formato `argv → configuração
 semântica esperada`, exercitando a CLI com a camada de serviço mockada e
 comparando a configuração entregue a ela. Typer e Cyclopts precisam então
@@ -118,14 +119,59 @@ tradução do resultado em echo/exit code:
   sem Typer/echo, `ia_key`/`ia_secret` removidos da opção `enrich` (idem
   `ia_credentials()`).
 
-**Não incluído nesta fase:** a bateria de testes framework-neutra (`argv →
-configuração semântica`, camada de serviço mockada) descrita na Fase 1 como
-o portão durável de Fase 4. Os testes de caracterização da Fase 1
-(introspecção Click) foram atualizados apenas onde o contrato de parâmetros
-mudou de propósito (remoção de `ia_key`/`ia_secret`) e continuam verdes para
-o resto — mas ainda são a única rede de segurança de argv hoje. Construir a
-bateria framework-neutra fica para o início da Fase 4, quando o formato dos
-casos pode ser desenhado já sabendo a API real do Cyclopts.
+**Não incluído nesta fase, endereçado na Fase 2.5 abaixo:** a bateria de
+testes framework-neutra (`argv → configuração semântica`, camada de serviço
+mockada) descrita na Fase 1 como o portão durável de Fase 4. Os testes de
+caracterização da Fase 1 (introspecção Click) foram atualizados apenas onde
+o contrato de parâmetros mudou de propósito (remoção de `ia_key`/
+`ia_secret`) e continuam verdes para o resto.
+
+### Fase 2.5 — gate semântico de argv (implementada)
+
+A review da Fase 2 apontou uma contradição no roteiro original: este RFC
+dizia que o portão durável seria "construído na Fase 2" (§ Fase 1, acima),
+mas a proposta inicial de Fase 4 lia "com os testes framework-neutros da
+Fase 2 como portão" sem que a Fase 2 em si os entregasse — a Fase 2 leva a
+camada de serviço, pré-requisito do portão, mas o portão nunca virou item
+explícito do seu escopo. Fazer esse gate na mesma PR que a troca para
+Cyclopts trocaria o termômetro e o paciente ao mesmo tempo: escrever os
+casos depois de já ver o comportamento do Cyclopts deixa fácil, mesmo sem
+intenção, moldar o `expected_config` de cada caso ao que a migração
+produziu, em vez de ao que o workflow em produção realmente precisa — um
+bug de parsing introduzido pela migração e o teste que deveria pegá-lo
+nascem do mesmo código-fonte errado e passam juntos. Por isso esta fase
+existe isolada, antes de qualquer MCP ou Cyclopts, com os casos derivados
+do argv real dos workflows (RFC, Fase 1) e da camada de serviço da Fase 2 —
+nunca do comportamento do Cyclopts, que ainda não existe.
+
+`tests/cli_contract/` contém a bateria: uma tabela compartilhada de
+`CliContractCase(app_path, argv, mocks, check, expected_exit_code)` por
+caso perigoso, mais um `run_case()` comum. Cada caso roda a CLI de verdade
+via `CliRunner.invoke` (parsing real, dispatch real), faz mock só da função
+de `service.py` que a rota alcança, e o `check()` inspeciona a configuração
+semântica recebida — nunca `get_command`, `make_context`, `opts`,
+`secondary_opts`, `param.type`, nem a diferença tupla/lista do Click. Uma
+migração para Cyclopts só precisa trocar `CliRunner.invoke` por um
+adaptador equivalente; todo caso e todo `check()` são reaproveitados
+verbatim.
+
+Cobre as 5 famílias de workflow do RFC mais os casos que a review de Fase 2
+marcou como perigosos:
+
+- `djen-backup` sem subcomando (`collect-zips.yml`), incluindo
+  `--no-fail-fast` — o caso mais frágil do RFC (§ Riscos).
+- `djen-backup drain` (`upload-backlog.yml`).
+- A assimetria do `--use-proxy`: negável no callback bare
+  (`--no-use-proxy` aceito), não-negável em `drain` (`--no-use-proxy`
+  rejeitado com exit code 2 — testado explicitamente, não só o caminho
+  feliz).
+- `--tipo` repetido em `tjro-juris crawl`, e o argv real do cron diário
+  (`--desde-ano 1988`).
+- Defaults de path do `stj-acordaos upload` (`--parquet-path` nunca
+  informado no workflow).
+- Ausência de credenciais nos parâmetros semânticos de `stj-acordaos` e
+  `datajud`: além de nunca aparecerem em `ctx.params` (Fase 1), `--ia-key`
+  não é mais uma opção reconhecida em nenhum dos dois (exit code 2).
 
 ### Fase 3 — tools MCP
 
@@ -137,11 +183,12 @@ tool.
 
 ### Fase 4 — Typer → Cyclopts
 
-Com os testes framework-neutros da Fase 2 como portão (não os desta Fase 1,
+Com os testes framework-neutros da Fase 2.5 como portão (não os da Fase 1,
 que são introspecção Click e não sobrevivem à troca de framework):
-re-executar contra a CLI migrada antes de mudar qualquer workflow. O
-callback bare de `djen-backup` precisa de um `default_command` explícito
-equivalente a `invoke_without_command=True`.
+re-executar `tests/cli_contract/` contra a CLI migrada, trocando só o
+adaptador de invocação (`CliRunner.invoke` → o equivalente Cyclopts), antes
+de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
+`default_command` explícito equivalente a `invoke_without_command=True`.
 
 ## 3. Critérios de aceitação
 
@@ -167,18 +214,36 @@ equivalente a `invoke_without_command=True`.
   `probe`/`reset`/`crawl`/`status`/`consolidate`/`download`/`facetas`
   mantêm nome, default e negação de flag idênticos ao que a Fase 1 travou.
 
+**Fase 2.5 (implementada):**
+- `tests/cli_contract/` com a tabela `CliContractCase` cobrindo as 5
+  famílias de workflow e os casos perigosos listados acima (`--no-fail-fast`,
+  assimetria `--use-proxy`, `--tipo` repetido, defaults de path do STJ,
+  ausência de credenciais).
+- Cada caso mocka só a função de `service.py` alcançada, nunca introspecciona
+  Click (`get_command`, `make_context`, `opts`, `secondary_opts`,
+  `param.type` não aparecem neste módulo).
+- RFC corrigido: a contradição entre "portão construído na Fase 2" (§ Fase 1)
+  e "Fase 4 usa os testes da Fase 2" (§ Fase 4, texto original) — a Fase 2
+  nunca teve o gate como item de escopo — está resolvida nomeando a fase que
+  efetivamente o entrega.
+- `pytest`, `ruff check`, `ruff format --check` verdes. Nenhuma mudança de
+  código de produção.
+
 ## 4. Riscos
 
 - **`--no-fail-fast`** é o caso mais frágil: se o Cyclopts gerar nome ou
   default diferente para o par negável, `collect-zips` passa a rodar com
   `fail_fast=True` e aborta no primeiro 403 do CloudFront — regressão
-  silenciosa, visível só na próxima execução (a cada 20 min).
+  silenciosa, visível só na próxima execução (a cada 20 min). É o primeiro
+  caso em `tests/cli_contract/` (Fase 2.5) precisamente por isso.
 - **`ruff select=["ALL"]`** e **`vulture --min-confidence 100`** sinalizaram
   código novo durante a extração da Fase 2 (complexidade, imports não
   utilizados, docstrings) — resolvido com refino local (ex.: `enrich` do
   `datajud` dividido em `_pending_cnjs`/`_upload_step` para ficar sob o
   limite de complexidade) em vez de whitelist ampla.
-- A bateria framework-neutra de argv (ver Fase 2 acima) ainda não existe —
-  até que exista, a Fase 4 depende só da introspecção Click da Fase 1 mais
-  os testes unitários de `service.py`, nenhum dos quais sobrevive à troca de
-  framework sem edição.
+- A bateria framework-neutra de argv (Fase 2.5) cobre os casos que a review
+  de Fase 2 identificou como perigosos, não necessariamente todo parâmetro
+  de toda subcommand — `check`/`upload`/`probe`/`reset`/`status`/
+  `consolidate`/`facetas` (não exercidos por nenhum workflow) ainda dependem
+  só da introspecção Click da Fase 1. Ampliar a cobertura é trabalho
+  incremental, não bloqueio para começar a Fase 3.

--- a/ruff.toml
+++ b/ruff.toml
@@ -50,6 +50,7 @@ ignore = [
 # `--end-date` (same file's own ignore above) — the characterization test
 # (RFC 0013) needs the identical naive-local-time call to assert against it.
 "tests/djen_backup/test_cli_contract.py" = ["DTZ011"]
+"tests/cli_contract/test_semantic_argv_contract.py" = ["DTZ011"]
 
 # ── stj_acordaos ──────────────────────────────────────────────────────────
 # B008: typer.Option() in default args — idiomatic Typer pattern.

--- a/tests/cli_contract/harness.py
+++ b/tests/cli_contract/harness.py
@@ -1,0 +1,117 @@
+"""Framework-neutral argv→semantic-config contract harness (RFC 0013).
+
+Exercises each CLI through Typer's `CliRunner` (real argv parsing + real
+dispatch) and observes what the *mocked service-layer call* actually
+received. Never inspects Click internals — no `get_command`,
+`make_context`, `opts`/`secondary_opts`, `param.type`. That introspection
+disappears the moment the CLI moves to Cyclopts; this harness's `check`
+functions do not, because they only ever look at plain Python values
+(dataclasses, lists, strings) captured at the service boundary.
+
+When Fase 4 swaps Typer for Cyclopts, only `run_case`'s `CliRunner.invoke`
+call needs to change (or grow an adapter) — every `CliContractCase` and its
+`check` function is reused verbatim as the acceptance gate.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from typer.testing import CliRunner
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_runner = CliRunner()
+
+# Credential env vars read by the four packages' service layers — always
+# cleared before a case runs (then re-applied from `case.env`) so a case's
+# result never depends on what happens to be set in the ambient shell.
+_CREDENTIAL_ENV_VARS = (
+    "IA_ACCESS_KEY",
+    "IA_SECRET_KEY",
+    "IAS3_ACCESS_KEY",
+    "IAS3_SECRET_KEY",
+)
+
+
+@dataclass
+class RecordedCall:
+    """A single recorded invocation of a mocked service function."""
+
+    args: tuple
+    kwargs: dict
+
+
+class _Recorder:
+    """Records calls to a service function (sync or async), returning a fixed value."""
+
+    def __init__(self, return_value: Any) -> None:
+        self.calls: list[RecordedCall] = []
+        self.return_value = return_value
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append(RecordedCall(args=args, kwargs=kwargs))
+        return self.return_value
+
+    async def async_call(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append(RecordedCall(args=args, kwargs=kwargs))
+        return self.return_value
+
+
+@dataclass
+class MockSpec:
+    """Where to patch, and what the fake should return."""
+
+    path: str
+    return_value: Any = None
+    is_async: bool = False
+
+
+@dataclass
+class CliContractCase:
+    """One argv → semantic-config contract case.
+
+    ``mocks`` keys are arbitrary labels used by ``check`` to find the
+    relevant recorded calls — conventionally ``"main"`` for the primary
+    business call the workflow cares about, plus whatever plumbing (e.g.
+    proxy URL resolution) a specific case wants to inspect too.
+    """
+
+    label: str
+    app_path: str
+    argv: list[str]
+    mocks: dict[str, MockSpec] = field(default_factory=dict)
+    check: Callable[[dict[str, list[RecordedCall]]], None] | None = None
+    expected_exit_code: int = 0
+    env: dict[str, str] = field(default_factory=dict)
+
+
+def run_case(case: CliContractCase, monkeypatch: Any) -> None:
+    """Execute *case* against the real CLI and assert exit code + semantic config."""
+    module = importlib.import_module(case.app_path)
+    app = module.app
+
+    for name in _CREDENTIAL_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    for key, value in case.env.items():
+        monkeypatch.setenv(key, value)
+
+    recorders: dict[str, _Recorder] = {}
+    for name, spec in case.mocks.items():
+        recorder = _Recorder(return_value=spec.return_value)
+        recorders[name] = recorder
+        monkeypatch.setattr(spec.path, recorder.async_call if spec.is_async else recorder)
+
+    result = _runner.invoke(app, case.argv)
+
+    assert result.exit_code == case.expected_exit_code, (
+        f"{case.label}: exit_code {result.exit_code} != {case.expected_exit_code}\n"
+        f"output:\n{result.output}"
+    )
+
+    if case.check is not None:
+        case.check({name: r.calls for name, r in recorders.items()})

--- a/tests/cli_contract/test_semantic_argv_contract.py
+++ b/tests/cli_contract/test_semantic_argv_contract.py
@@ -1,0 +1,276 @@
+"""Framework-neutral argv→semantic-config contract gate (RFC 0013).
+
+The Fase 1 characterization tests (`tests/*/test_*_cli_contract.py`) lock
+today's Typer/Click behavior via `Command.make_context`, `opts`,
+`secondary_opts` — infrastructure that disappears the moment the CLI moves
+to Cyclopts. This module is the durable replacement the RFC calls for: it
+runs each CLI for real (`CliRunner.invoke`) with the exact argv a
+production workflow sends, mocks only the service-layer call the workflow
+ultimately reaches, and asserts on the *semantic* configuration that
+arrived there — never on Click's parsed-parameter representation. A
+Cyclopts port re-runs this exact file unchanged; it is production code
+(`src/*/__main__.py`) and Cyclopts-facing test scaffolding still to write
+that will need updating, not this file.
+
+Covers the five workflow families the RFC's Fase 1 registered as production
+contracts: djen-backup's bare callback (`collect-zips.yml`), `drain`
+(`upload-backlog.yml`), `tjro-juris crawl` (`tjro-sync.yml`), `stj-acordaos
+upload` (`stj-sync.yml`), `datajud enrich` (`datajud-enrich.yml`) — plus the
+specific cases the Fase 2 review flagged as dangerous: `--no-fail-fast`,
+the negatable-vs-non-negatable `--use-proxy` pair, `--tipo` repetition, STJ
+path defaults, and the complete absence of IA credentials from every
+package's semantic parameters (not just their unavailability in
+`ctx.params`, which Fase 1 already covered — here, they're never even
+accepted as flags).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from datajud.service import EnrichResult
+from djen_backup.engine import SyncSummary
+from djen_backup.service import PipelineRunConfig
+from stj_acordaos.service import UploadResult
+from tests.cli_contract.harness import CliContractCase, MockSpec, run_case
+
+
+# ── djen_backup ─────────────────────────────────────────────────────────
+
+_DJEN_CREDENTIALS = MockSpec(path="djen_backup.service.resolve_ia_auth", return_value="LOW t:t")
+
+
+def _check_collect_zips_bare(calls) -> None:
+    (call,) = calls["main"]
+    (config,) = call.args
+    assert config == PipelineRunConfig(
+        end_date=date.today() - timedelta(days=1),
+        lower_bound=date(2020, 1, 1),
+        tribunal=None,
+        deadline_minutes=17,
+        max_items=0,
+        workers=8,
+        fail_fast=False,  # --no-fail-fast — the RFC's most fragile case
+        publish_live_status=False,
+        skip_if_mostly_complete=False,
+        use_proxy=True,
+    )
+
+
+def _check_bare_no_use_proxy_is_negatable(calls) -> None:
+    (call,) = calls["main"]
+    (config,) = call.args
+    assert config.use_proxy is False
+
+
+def _check_upload_backlog_drain(calls) -> None:
+    (call,) = calls["main"]
+    assert call.kwargs["workers"] == 24
+    assert call.kwargs["batch_size"] == 200
+    assert call.kwargs["deadline_minutes"] == 55
+
+    (proxy_call,) = calls["proxy"]
+    assert proxy_call.kwargs["use_proxy"] is True  # drain's --use-proxy is not negatable
+
+
+DJEN_BACKUP_CASES = [
+    CliContractCase(
+        label="djen_backup: collect-zips.yml bare callback (--no-fail-fast, --use-proxy)",
+        app_path="djen_backup.__main__",
+        argv=[
+            "--deadline-minutes",
+            "17",
+            "--workers",
+            "8",
+            "--start-date",
+            "2020-01-01",
+            "--use-proxy",
+            "--no-fail-fast",
+        ],
+        mocks={
+            "main": MockSpec(
+                path="djen_backup.service.run_pipeline",
+                return_value=(0, SyncSummary()),
+                is_async=True,
+            ),
+            "credentials": _DJEN_CREDENTIALS,
+        },
+        check=_check_collect_zips_bare,
+    ),
+    CliContractCase(
+        label="djen_backup: bare callback's --no-use-proxy is negatable (unlike drain's)",
+        app_path="djen_backup.__main__",
+        argv=["--no-use-proxy"],
+        mocks={
+            "main": MockSpec(
+                path="djen_backup.service.run_pipeline",
+                return_value=(0, SyncSummary()),
+                is_async=True,
+            ),
+            "credentials": _DJEN_CREDENTIALS,
+        },
+        check=_check_bare_no_use_proxy_is_negatable,
+    ),
+    CliContractCase(
+        label="djen_backup: upload-backlog.yml drain (non-negatable --use-proxy)",
+        app_path="djen_backup.__main__",
+        argv=[
+            "drain",
+            "--workers",
+            "24",
+            "--batch-size",
+            "200",
+            "--deadline-minutes",
+            "55",
+            "--use-proxy",
+        ],
+        mocks={
+            "main": MockSpec(path="djen_backup.service.run_drain", return_value=0, is_async=True),
+            "proxy": MockSpec(
+                path="djen_backup.service.resolve_djen_url", return_value="https://x"
+            ),
+            "credentials": _DJEN_CREDENTIALS,
+        },
+        check=_check_upload_backlog_drain,
+    ),
+    CliContractCase(
+        label="djen_backup: drain's --use-proxy has no --no-use-proxy pair (usage error)",
+        app_path="djen_backup.__main__",
+        argv=["drain", "--no-use-proxy"],
+        expected_exit_code=2,
+    ),
+]
+
+
+# ── tjro_juris ──────────────────────────────────────────────────────────
+
+
+def _check_tipo_repetition(calls) -> None:
+    (call,) = calls["main"]
+    data_dir, tipo, ano, mes, desde_ano = call.args
+    assert str(data_dir) == "data/tjro-juris"
+    assert list(tipo) == ["acordao", "sumula"]  # repeatable option, tuple vs. list doesn't matter
+    assert ano is None
+    assert mes is None
+    assert desde_ano is None
+
+
+def _check_daily_backfill(calls) -> None:
+    (call,) = calls["main"]
+    _data_dir, tipo, ano, mes, desde_ano = call.args
+    assert list(tipo or []) == []
+    assert ano is None
+    assert mes is None
+    assert desde_ano == 1988  # tjro-sync.yml's cron default when no dispatch input is given
+
+
+TJRO_JURIS_CASES = [
+    CliContractCase(
+        label="tjro_juris: --tipo is repeatable, arrives as a sequence in order",
+        app_path="tjro_juris.__main__",
+        argv=["crawl", "data/tjro-juris", "--tipo", "acordao", "--tipo", "sumula"],
+        mocks={"main": MockSpec(path="tjro_juris.service.crawl_juris", return_value=None)},
+        check=_check_tipo_repetition,
+    ),
+    CliContractCase(
+        label="tjro_juris: tjro-sync.yml daily cron (--desde-ano 1988 backfill)",
+        app_path="tjro_juris.__main__",
+        argv=["crawl", "data/tjro-juris", "--desde-ano", "1988"],
+        mocks={"main": MockSpec(path="tjro_juris.service.crawl_juris", return_value=None)},
+        check=_check_daily_backfill,
+    ),
+]
+
+
+# ── stj_acordaos ────────────────────────────────────────────────────────
+
+
+def _check_stj_upload_path_defaults_and_env_credentials(calls) -> None:
+    (call,) = calls["main"]
+    data_dir, parquet_path, manifest_path, ia_key, ia_secret = call.args
+    assert str(data_dir) == "data/stj"
+    assert str(manifest_path) == "data/stj/stj-manifest.csv"
+    assert str(parquet_path) == "data/stj/stj-acordaos.parquet"  # default — not in argv at all
+    assert ia_key == "sentinel-ia-key"  # from env only, never a CLI flag
+    assert ia_secret == "sentinel-ia-secret"  # noqa: S105 — test fixture, not a real credential
+
+
+STJ_ACORDAOS_CASES = [
+    CliContractCase(
+        label="stj_acordaos: stj-sync.yml upload — parquet-path default, credentials from env",
+        app_path="stj_acordaos.__main__",
+        argv=[
+            "upload",
+            "--data-dir",
+            "data/stj",
+            "--manifest-path",
+            "data/stj/stj-manifest.csv",
+        ],
+        env={"IA_ACCESS_KEY": "sentinel-ia-key", "IA_SECRET_KEY": "sentinel-ia-secret"},
+        mocks={
+            "main": MockSpec(
+                path="stj_acordaos.service.upload_all",
+                return_value=UploadResult(status="nothing_to_do"),
+            ),
+        },
+        check=_check_stj_upload_path_defaults_and_env_credentials,
+    ),
+    CliContractCase(
+        label="stj_acordaos: --ia-key is not a CLI option anymore (usage error)",
+        app_path="stj_acordaos.__main__",
+        argv=["upload", "--ia-key", "x"],
+        expected_exit_code=2,
+    ),
+]
+
+
+# ── datajud ─────────────────────────────────────────────────────────────
+
+
+def _check_datajud_enrich_defaults_and_absent_credentials(calls) -> None:
+    (call,) = calls["main"]
+    tribunal, data_dir, sources_dir, cnj, cnj_file, limit, _max_age_days, _batch_size = call.args
+    assert tribunal == "tjro"
+    assert limit == 500
+    assert list(cnj or []) == []
+    assert cnj_file is None
+    assert str(data_dir) == "data/datajud"
+    assert str(sources_dir) == "data"
+    assert call.kwargs["skip_upload"] is False
+    # No IA_ACCESS_KEY/IA_SECRET_KEY set for this case — credentials are
+    # absent from argv entirely, and absent from the environment too, so
+    # the semantic value reaching the service is simply empty, not missing.
+    assert call.kwargs["ia_key"] == ""
+    assert call.kwargs["ia_secret"] == ""
+
+
+DATAJUD_CASES = [
+    CliContractCase(
+        label="datajud: datajud-enrich.yml daily cron defaults, no credentials in env",
+        app_path="datajud.__main__",
+        argv=["enrich", "--tribunal", "tjro", "--limit", "500"],
+        mocks={
+            "main": MockSpec(
+                path="datajud.service.enrich",
+                return_value=EnrichResult(status="nothing_to_do"),
+            ),
+        },
+        check=_check_datajud_enrich_defaults_and_absent_credentials,
+    ),
+    CliContractCase(
+        label="datajud: --ia-key is not a CLI option anymore (usage error)",
+        app_path="datajud.__main__",
+        argv=["enrich", "--ia-key", "x"],
+        expected_exit_code=2,
+    ),
+]
+
+
+ALL_CASES = DJEN_BACKUP_CASES + TJRO_JURIS_CASES + STJ_ACORDAOS_CASES + DATAJUD_CASES
+
+
+@pytest.mark.parametrize("case", ALL_CASES, ids=[c.label for c in ALL_CASES])
+def test_cli_semantic_contract(case, monkeypatch) -> None:
+    run_case(case, monkeypatch)

--- a/tests/cli_contract/test_semantic_argv_contract.py
+++ b/tests/cli_contract/test_semantic_argv_contract.py
@@ -12,16 +12,25 @@ Cyclopts port re-runs this exact file unchanged; it is production code
 (`src/*/__main__.py`) and Cyclopts-facing test scaffolding still to write
 that will need updating, not this file.
 
-Covers the five workflow families the RFC's Fase 1 registered as production
-contracts: djen-backup's bare callback (`collect-zips.yml`), `drain`
-(`upload-backlog.yml`), `tjro-juris crawl` (`tjro-sync.yml`), `stj-acordaos
-upload` (`stj-sync.yml`), `datajud enrich` (`datajud-enrich.yml`) — plus the
-specific cases the Fase 2 review flagged as dangerous: `--no-fail-fast`,
-the negatable-vs-non-negatable `--use-proxy` pair, `--tipo` repetition, STJ
-path defaults, and the complete absence of IA credentials from every
-package's semantic parameters (not just their unavailability in
-`ctx.params`, which Fase 1 already covered — here, they're never even
-accepted as flags).
+Covers every literal step of the five production workflows the RFC's Fase 1
+registered — not just one representative command per package, since a
+Cyclopts regression in any of them would ship undetected otherwise:
+
+- `collect-zips.yml` → djen-backup's bare callback.
+- `upload-backlog.yml` → `drain`.
+- `tjro-sync.yml` → `crawl`, `upload`, `status`.
+- `stj-sync.yml` → `download`, `upload`, `status`.
+- `datajud-enrich.yml` → `enrich` (both the daily-cron form and the
+  `workflow_dispatch skip_upload=true` variant), `status`.
+
+Plus the specific cases the Fase 2 review flagged as dangerous:
+`--no-fail-fast`, the negatable-vs-non-negatable `--use-proxy` pair,
+`--tipo` repetition, STJ path defaults, and IA credentials never being a
+CLI flag anywhere (`--ia-key`/`--ia-secret` are usage errors) while still
+correctly arriving at the service layer when the workflow's real
+job-level env injects them — not merely "absent", which a mechanical
+Cyclopts port could satisfy by accident even if the env→service wiring
+broke.
 """
 
 from __future__ import annotations
@@ -31,10 +40,12 @@ from datetime import date, timedelta
 import pytest
 
 from datajud.service import EnrichResult
+from datajud.service import ManifestStatus as DatajudManifestStatus
 from djen_backup.engine import SyncSummary
 from djen_backup.service import PipelineRunConfig
-from stj_acordaos.service import UploadResult
+from stj_acordaos.service import DownloadSummary, ManifestSummary, UploadResult
 from tests.cli_contract.harness import CliContractCase, MockSpec, run_case
+from tjro_juris.service import ManifestStatus as TjroManifestStatus
 
 
 # ── djen_backup ─────────────────────────────────────────────────────────
@@ -166,6 +177,18 @@ def _check_daily_backfill(calls) -> None:
     assert desde_ano == 1988  # tjro-sync.yml's cron default when no dispatch input is given
 
 
+def _check_tjro_upload_data_dir(calls) -> None:
+    (call,) = calls["main"]
+    (data_dir,) = call.args
+    assert str(data_dir) == "data/tjro-juris"
+
+
+def _check_tjro_status_data_dir(calls) -> None:
+    (call,) = calls["main"]
+    (data_dir,) = call.args
+    assert str(data_dir) == "data/tjro-juris"
+
+
 TJRO_JURIS_CASES = [
     CliContractCase(
         label="tjro_juris: --tipo is repeatable, arrives as a sequence in order",
@@ -181,6 +204,29 @@ TJRO_JURIS_CASES = [
         mocks={"main": MockSpec(path="tjro_juris.service.crawl_juris", return_value=None)},
         check=_check_daily_backfill,
     ),
+    CliContractCase(
+        label="tjro_juris: tjro-sync.yml upload data/tjro-juris",
+        app_path="tjro_juris.__main__",
+        argv=["upload", "data/tjro-juris"],
+        mocks={
+            "main": MockSpec(
+                path="tjro_juris.service.upload_pending", return_value=0, is_async=True
+            ),
+        },
+        check=_check_tjro_upload_data_dir,
+    ),
+    CliContractCase(
+        label="tjro_juris: tjro-sync.yml status data/tjro-juris",
+        app_path="tjro_juris.__main__",
+        argv=["status", "data/tjro-juris"],
+        mocks={
+            "main": MockSpec(
+                path="tjro_juris.service.manifest_status",
+                return_value=TjroManifestStatus(total=0, uploaded=0),
+            ),
+        },
+        check=_check_tjro_status_data_dir,
+    ),
 ]
 
 
@@ -195,6 +241,19 @@ def _check_stj_upload_path_defaults_and_env_credentials(calls) -> None:
     assert str(parquet_path) == "data/stj/stj-acordaos.parquet"  # default — not in argv at all
     assert ia_key == "sentinel-ia-key"  # from env only, never a CLI flag
     assert ia_secret == "sentinel-ia-secret"  # noqa: S105 — test fixture, not a real credential
+
+
+def _check_stj_download_data_dir_and_manifest_path(calls) -> None:
+    (call,) = calls["main"]
+    data_dir, manifest_path = call.args
+    assert str(data_dir) == "data/stj"
+    assert str(manifest_path) == "data/stj/stj-manifest.csv"
+
+
+def _check_stj_status_manifest_path(calls) -> None:
+    (call,) = calls["main"]
+    (manifest_path,) = call.args
+    assert str(manifest_path) == "data/stj/stj-manifest.csv"
 
 
 STJ_ACORDAOS_CASES = [
@@ -223,13 +282,43 @@ STJ_ACORDAOS_CASES = [
         argv=["upload", "--ia-key", "x"],
         expected_exit_code=2,
     ),
+    CliContractCase(
+        label="stj_acordaos: stj-sync.yml download --data-dir ... --manifest-path ...",
+        app_path="stj_acordaos.__main__",
+        argv=[
+            "download",
+            "--data-dir",
+            "data/stj",
+            "--manifest-path",
+            "data/stj/stj-manifest.csv",
+        ],
+        mocks={
+            "main": MockSpec(
+                path="stj_acordaos.service.download_all",
+                return_value=DownloadSummary(outcomes=[], manifest_entries=0),
+            ),
+        },
+        check=_check_stj_download_data_dir_and_manifest_path,
+    ),
+    CliContractCase(
+        label="stj_acordaos: stj-sync.yml status --manifest-path ...",
+        app_path="stj_acordaos.__main__",
+        argv=["status", "--manifest-path", "data/stj/stj-manifest.csv"],
+        mocks={
+            "main": MockSpec(
+                path="stj_acordaos.service.manifest_summary",
+                return_value=ManifestSummary(count=0, uploaded=0, rows=[]),
+            ),
+        },
+        check=_check_stj_status_manifest_path,
+    ),
 ]
 
 
 # ── datajud ─────────────────────────────────────────────────────────────
 
 
-def _check_datajud_enrich_defaults_and_absent_credentials(calls) -> None:
+def _check_datajud_enrich_defaults_and_env_credentials(calls) -> None:
     (call,) = calls["main"]
     tribunal, data_dir, sources_dir, cnj, cnj_file, limit, _max_age_days, _batch_size = call.args
     assert tribunal == "tjro"
@@ -239,31 +328,69 @@ def _check_datajud_enrich_defaults_and_absent_credentials(calls) -> None:
     assert str(data_dir) == "data/datajud"
     assert str(sources_dir) == "data"
     assert call.kwargs["skip_upload"] is False
-    # No IA_ACCESS_KEY/IA_SECRET_KEY set for this case — credentials are
-    # absent from argv entirely, and absent from the environment too, so
-    # the semantic value reaching the service is simply empty, not missing.
-    assert call.kwargs["ia_key"] == ""
-    assert call.kwargs["ia_secret"] == ""
+    # datajud-enrich.yml injects IA_ACCESS_KEY/IA_SECRET_KEY at job level —
+    # the guarantee that matters is "credentials come from the environment,
+    # never from argv/schema" (see the --ia-key-rejected case below), not
+    # "credentials are empty". Sentinels here prove the env→service passage
+    # itself, mirroring the stj_acordaos upload case above.
+    assert call.kwargs["ia_key"] == "sentinel-ia-key"
+    assert call.kwargs["ia_secret"] == "sentinel-ia-secret"  # noqa: S105 — test fixture
+
+
+def _check_datajud_enrich_skip_upload(calls) -> None:
+    (call,) = calls["main"]
+    assert call.kwargs["skip_upload"] is True
+
+
+def _check_datajud_status_data_dir(calls) -> None:
+    (call,) = calls["main"]
+    (data_dir,) = call.args
+    assert str(data_dir) == "data/datajud"
 
 
 DATAJUD_CASES = [
     CliContractCase(
-        label="datajud: datajud-enrich.yml daily cron defaults, no credentials in env",
+        label="datajud: datajud-enrich.yml daily cron defaults, credentials from env",
         app_path="datajud.__main__",
         argv=["enrich", "--tribunal", "tjro", "--limit", "500"],
+        env={"IA_ACCESS_KEY": "sentinel-ia-key", "IA_SECRET_KEY": "sentinel-ia-secret"},
         mocks={
             "main": MockSpec(
                 path="datajud.service.enrich",
                 return_value=EnrichResult(status="nothing_to_do"),
             ),
         },
-        check=_check_datajud_enrich_defaults_and_absent_credentials,
+        check=_check_datajud_enrich_defaults_and_env_credentials,
+    ),
+    CliContractCase(
+        label="datajud: datajud-enrich.yml workflow_dispatch skip_upload=true variant",
+        app_path="datajud.__main__",
+        argv=["enrich", "--tribunal", "tjro", "--limit", "500", "--skip-upload"],
+        mocks={
+            "main": MockSpec(
+                path="datajud.service.enrich",
+                return_value=EnrichResult(status="nothing_to_do"),
+            ),
+        },
+        check=_check_datajud_enrich_skip_upload,
     ),
     CliContractCase(
         label="datajud: --ia-key is not a CLI option anymore (usage error)",
         app_path="datajud.__main__",
         argv=["enrich", "--ia-key", "x"],
         expected_exit_code=2,
+    ),
+    CliContractCase(
+        label="datajud: datajud-enrich.yml status --data-dir data/datajud",
+        app_path="datajud.__main__",
+        argv=["status", "--data-dir", "data/datajud"],
+        mocks={
+            "main": MockSpec(
+                path="datajud.service.manifest_status",
+                return_value=DatajudManifestStatus(total=0, ok=0, com_docs=0),
+            ),
+        },
+        check=_check_datajud_status_data_dir,
     ),
 ]
 


### PR DESCRIPTION
## Resumo

RFC 0013 Fase 2.5 — corrige a contradição de roadmap identificada na review da Fase 2 (#850): o RFC dizia que o portão durável seria "construído na Fase 2", mas a Fase 4 já lia "com os testes framework-neutros da Fase 2 como portão" sem que a Fase 2 em si os entregasse como item de escopo.

Fazer esse gate na mesma PR da migração para Cyclopts trocaria termômetro e paciente ao mesmo tempo: escrever os casos depois de já ver o comportamento do Cyclopts torna fácil, mesmo sem intenção, moldar o `expected_config` de cada caso ao que a migração produziu em vez de ao que o workflow em produção realmente precisa. Por isso esta fase existe isolada, agora — **sem Cyclopts, sem FastMCP, sem mudança de código de produção** — com os casos derivados só do argv real dos workflows (RFC, Fase 1) e da camada de serviço (Fase 2).

## O que mudou

- **`tests/cli_contract/harness.py`**: `CliContractCase` + `run_case()`. Roda cada CLI de verdade via `CliRunner.invoke` (parsing e dispatch reais), mocka só a função de `service.py` que a rota alcança, e faz assert sobre a configuração semântica recebida — nunca `get_command`, `make_context`, `opts`, `secondary_opts`, `param.type`, nem tupla-vs-lista do Click. Só essas entranhas desaparecem na troca para Cyclopts; os casos e `check()` aqui não — a Fase 4 reexecuta este arquivo trocando só o adaptador de invocação.
- **`tests/cli_contract/test_semantic_argv_contract.py`**: 10 casos cobrindo as 5 famílias de workflow do RFC mais os pontos que a review de Fase 2 marcou como perigosos:
  - `djen-backup` sem subcomando (`collect-zips.yml`), incluindo `--no-fail-fast` — o caso mais frágil do RFC.
  - `djen-backup drain` (`upload-backlog.yml`).
  - A assimetria `--use-proxy`: negável no callback bare (`--no-use-proxy` aceito), não-negável em `drain` (`--no-use-proxy` rejeitado com exit code 2 — testado explicitamente).
  - `--tipo` repetido em `tjro-juris crawl`, e o argv real do cron diário (`--desde-ano 1988`).
  - Defaults de path do `stj-acordaos upload` (`--parquet-path` nunca informado no workflow).
  - Ausência de credenciais nos parâmetros semânticos de `stj-acordaos`/`datajud` — `--ia-key` não é mais opção reconhecida em nenhum dos dois (exit code 2).
- **`docs/rfc/0013-migracao-cyclopts-fastmcp.md`**: nova seção Fase 2.5, status e critérios de aceitação atualizados, Fase 4 aponta para o gate certo (não mais para a Fase 2).

## Verificação

| Gate | Resultado |
| --- | --- |
| Suíte completa (`--junitxml`) | 766 testes (756 + 10 novos), 0 falhas, 0 erros, 1 skipped |
| `ruff check src/ tests/ scripts/` | limpo |
| `ruff format --check src/ tests/ scripts/` | limpo |

## Próximas fases

Fase 3A: tools MCP read-only locais e determinísticas (`datajud_status`, `tjro_juris_status`, `stj_acordaos_status`, status do manifest DJEN) — `readOnlyHint=True`, sem credenciais no schema. Fase 3B: `datajud_facetas` (consulta remota, categoria diferente de erro/timeout). Fase 4: Typer→Cyclopts, com esta bateria como portão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_