### PR TITLE
feat: expõe status dos pipelines como tools FastMCP read-only

### DIFF
--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -1,6 +1,6 @@
 # RFC 0013 — Migração das CLIs Typer para Cyclopts + FastMCP
 
-- **Status:** Fase 1, Fase 2 e Fase 2.5 implementadas
+- **Status:** Fase 1, Fase 2, Fase 2.5 e Fase 3A implementadas
 - **Data:** 2026-07-21
 - **Base:** comparação de arquitetura com o repo irmão `pink` (mesma stack alvo:
   Cyclopts + FastMCP, tools declaradas uma vez, CLI como despachante genérico
@@ -186,10 +186,55 @@ casos que a review de Fase 2 marcou como perigosos:
 ### Fase 3 — tools MCP
 
 Tools sobre a camada de serviço, começando pelas de leitura sem efeito
-destrutivo: `datajud status`/`facetas`, `tjro-juris status`, `stj-acordaos
-status`, consultas de manifest. Operações de ingestão/upload de longa duração
-(o sync completo, `drain`, `consolidate`) ficam só na CLI/CI — nunca viram
-tool.
+destrutivo. Duas fatias, para não misturar categorias de erro diferentes na
+mesma fundação de servidor:
+
+#### Fase 3A — status read-only local (implementada)
+
+Pacote novo `src/causaganha_mcp/` (dependência `fastmcp`, servidor
+`causaganha_mcp`, script `causaganha-mcp`). Quatro tools, uma por pacote,
+todas locais e determinísticas — leem um manifest do disco, sem chamada de
+rede, sem credencial:
+
+- `datajud_status` — `datajud.service.manifest_status`.
+- `tjro_juris_status` — `tjro_juris.service.manifest_status`.
+- `stj_acordaos_status` — `stj_acordaos.service.manifest_summary` (omite a
+  lista `rows` por economia de tokens — é resumo, não listagem).
+- `djen_backup_status` — `djen_backup.service.manifest_status`, função nova
+  nesta fase (`djen_backup` não tinha um comando `status` de CLI); só lê o
+  CSV local, nunca o parquet canônico no IA (`docs/planning/
+  manifest-source-of-truth.md`), então pode ficar atrás do estado real.
+
+Registro de tool é explícito (`tools/*.py` expõe `register(mcp)`, chamado
+por `server.build_server()`) — não decoração em import time. Motivo: é
+exatamente a mesma lição da Fase 2 sobre `djen_backup`'s antigo
+`structlog.configure()` de import — um processo que importa este módulo
+(um teste, outra tool) não deveria disparar side effect nenhum. E, por
+falar em side effect de import: esta fase encontrou e removeu outro, o
+`djen_backup/__init__.py` ainda reconfigurava `stdout`/`stderr` na
+importação — resíduo que a Fase 2 não tinha pego porque só tocou
+`__main__.py`. Sem isso corrigido, `from djen_backup import service` (o
+que `causaganha_mcp` precisa fazer) reconfiguraria stdio do processo do
+servidor MCP inteiro.
+
+Cada tool tem `readOnlyHint=True`, `destructiveHint=False`, retorno
+Pydantic estruturado, e é coberta por dois tipos de teste
+(`tests/causaganha_mcp/`): schema (nenhum campo com substring
+key/secret/token/credential/password em `parameters` ou `output_schema`,
+para as quatro tools) e comportamento (`tool.fn(...)` chamado direto contra
+manifests fixture, caminho vazio e caminho populado).
+
+#### Fase 3B — consultas remotas (não implementada)
+
+`datajud_facetas` fica para depois, separado de propósito: consulta a API
+pública do DataJud (rede real), então tem uma categoria de erro diferente
+(timeout, rate limit, erro de rede) da fundação local/determinística da
+Fase 3A. Misturar as duas na mesma fase aumentaria o espaço de depuração
+sem necessidade.
+
+Operações de ingestão/upload de longa duração (o sync completo, `drain`,
+`consolidate`, `enrich` com upload) ficam só na CLI/CI em qualquer fase —
+nunca viram tool.
 
 ### Fase 4 — Typer → Cyclopts
 
@@ -239,6 +284,20 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
   efetivamente o entrega.
 - `pytest`, `ruff check`, `ruff format --check` verdes. Nenhuma mudança de
   código de produção.
+
+**Fase 3A (implementada):**
+- `src/causaganha_mcp/` com `datajud_status`, `tjro_juris_status`,
+  `stj_acordaos_status`, `djen_backup_status` — todas `readOnlyHint=True`,
+  locais (leem manifest do disco), sem credencial em parâmetro ou retorno.
+- Registro de tool explícito (`register(mcp)`), não decoração em import
+  time — mesmo princípio da Fase 2.
+- Side effect de import residual em `djen_backup/__init__.py`
+  (reconfiguração de `stdout`/`stderr` fora de `configure_runtime()`)
+  identificado e removido — a Fase 2 só tinha coberto `__main__.py`.
+- `tests/causaganha_mcp/`: testes de schema (sem campo credencial-like em
+  nenhuma das 4 tools) e de comportamento (manifest vazio e populado, por
+  tool). `pytest`, `ruff check`, `ruff format --check` verdes.
+- Nenhuma tool de ingestão/upload — só as 4 de status.
 
 ## 4. Riscos
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "aiolimiter>=1.2.1",
     "anyio>=4.0",
     "aiohttp>=3.9.0",
+    "fastmcp>=2.0", # causaganha_mcp — RFC 0013 Fase 3
 ]
 
 [dependency-groups]
@@ -89,6 +90,7 @@ stj-acordaos = "stj_acordaos.__main__:app"
 tjro-juris = "tjro_juris.__main__:app"
 datajud = "datajud.__main__:app"
 segmenter-dataset = "segmenter_dataset.__main__:app"
+causaganha-mcp = "causaganha_mcp.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     "aiolimiter>=1.2.1",
     "anyio>=4.0",
     "aiohttp>=3.9.0",
-    "fastmcp>=2.0", # causaganha_mcp — RFC 0013 Fase 3
+    # causaganha_mcp — RFC 0013 Fase 3. Floor covers both APIs actually used:
+    # tool annotations (readOnlyHint etc.) landed in 2.2.7; structured
+    # output/output_schema, which the tools' Pydantic return types and
+    # tests/causaganha_mcp/test_tool_schema.py depend on, landed in 2.10.0.
+    # Matches the floor already adopted in the sibling repo `pink`.
+    "fastmcp>=3.4.2",
 ]
 
 [dependency-groups]

--- a/src/causaganha_mcp/__init__.py
+++ b/src/causaganha_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""causaganha_mcp: read-only FastMCP tools over the causaganha service layer (RFC 0013 Fase 3)."""
+
+__version__ = "0.1.0"

--- a/src/causaganha_mcp/__main__.py
+++ b/src/causaganha_mcp/__main__.py
@@ -1,0 +1,14 @@
+"""Entry point for ``causaganha-mcp`` — runs the server over stdio."""
+
+from __future__ import annotations
+
+from causaganha_mcp.server import mcp
+
+
+def main() -> None:
+    """Run the MCP server over stdio (local, single-client transport)."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/causaganha_mcp/__main__.py
+++ b/src/causaganha_mcp/__main__.py
@@ -2,11 +2,31 @@
 
 from __future__ import annotations
 
+import sys
+
+import structlog
+
 from causaganha_mcp.server import mcp
+
+
+def _configure_stdio_safe_logging() -> None:
+    """Send structlog output to stderr, never stdout.
+
+    In MCP stdio transport, stdout is exclusively the JSON-RPC channel — a
+    single ordinary log line (e.g. ``ManifestSTJ.load()``'s
+    ``log.info("stj_manifest_loaded", ...)``, or
+    ``SyncManifest.load_from_disk()``'s equivalent) written to stdout via
+    structlog's default ``PrintLogger`` corrupts every message after it.
+    Called from ``main()``, not at import time — importing this module (a
+    test, another tool) must not reconfigure global structlog state; only
+    actually running the server should.
+    """
+    structlog.configure(logger_factory=structlog.PrintLoggerFactory(file=sys.stderr))
 
 
 def main() -> None:
     """Run the MCP server over stdio (local, single-client transport)."""
+    _configure_stdio_safe_logging()
     mcp.run()
 
 

--- a/src/causaganha_mcp/server.py
+++ b/src/causaganha_mcp/server.py
@@ -1,0 +1,48 @@
+"""FastMCP server assembly for ``causaganha_mcp`` (RFC 0013 Fase 3).
+
+Tool registration happens explicitly inside ``build_server()``, not as an
+import-time side effect of decorating module-level functions — the same
+lesson RFC 0013 Fase 2 drew from ``djen_backup``'s old import-time
+``structlog.configure()``/stdio reconfiguration: a process that imports
+this module (a test, a supervisor, another tool) should not get side
+effects it didn't ask for. Each ``tools/*.py`` module exposes a
+``register(mcp)`` function instead of decorating at import time.
+
+Fase 3A scope: read-only, local, deterministic status tools only —
+``datajud_status``, ``tjro_juris_status``, ``stj_acordaos_status``,
+``djen_backup_status``. None of them touch Internet Archive credentials or
+make network calls; each reads whatever manifest already exists on local
+disk. Ingestion/upload operations (the full sync, ``drain``, ``consolidate``,
+``enrich`` with upload) stay CLI/CI-only per the RFC — they never become
+tools.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from causaganha_mcp.tools import datajud, djen_backup, stj_acordaos, tjro_juris
+
+
+def build_server() -> FastMCP:
+    """Construct a fresh ``causaganha_mcp`` server with all tools registered."""
+    mcp = FastMCP(
+        name="causaganha_mcp",
+        instructions=(
+            "Read-only status tools over CausaGanha's four ingestion pipelines "
+            "(djen-backup, tjro-juris, stj-acordaos, datajud). Each tool reads "
+            "a local manifest file — no network calls, no credentials, no "
+            "mutation. For ingestion, upload, or backfill operations, use the "
+            "corresponding CLI (djen-backup, tjro-juris, stj-acordaos, "
+            "datajud) or the scheduled CI workflows — those are not exposed "
+            "here by design."
+        ),
+    )
+    datajud.register(mcp)
+    tjro_juris.register(mcp)
+    stj_acordaos.register(mcp)
+    djen_backup.register(mcp)
+    return mcp
+
+
+mcp = build_server()

--- a/src/causaganha_mcp/tools/__init__.py
+++ b/src/causaganha_mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tool modules for ``causaganha_mcp``, one per source package (RFC 0013 Fase 3)."""

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -1,0 +1,69 @@
+"""``datajud_status`` tool (RFC 0013 Fase 3A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from datajud import service
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+class DatajudStatusResult(BaseModel):
+    """Summary of the local DataJud manifest."""
+
+    found: bool = Field(description="False when the manifest doesn't exist or has no entries.")
+    total: int = Field(default=0, description="CNJs consulted so far.")
+    ok: int = Field(default=0, description="CNJs whose last consult succeeded.")
+    com_docs: int = Field(default=0, description="Consulted CNJs with at least one document.")
+    sem_docs: int = Field(default=0, description="Consulted CNJs with zero documents found.")
+    com_erro: int = Field(default=0, description="CNJs whose last consult failed.")
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ``datajud_status`` on *mcp*."""
+
+    @mcp.tool(
+        name="datajud_status",
+        annotations={
+            "title": "DataJud manifest status",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
+    def datajud_status(data_dir: str = str(service.DEFAULT_DATA_DIR)) -> DatajudStatusResult:
+        """Summarize the local DataJud manifest: how many CNJs are consulted and found.
+
+        Reads `datajud-manifest.csv` under `data_dir` from local disk only —
+        no network call, no credentials involved. Use this to check the
+        progress of `datajud enrich` runs (e.g. after the daily
+        `datajud-enrich.yml` cron) without a shell. This tool never triggers
+        a new consult or upload; for that, use the `datajud` CLI's `enrich`
+        command.
+
+        Args:
+            data_dir: Directory containing the DataJud manifest and parquets.
+                Defaults to "data/datajud", the path the scheduled workflow uses.
+
+        Returns:
+            found=False (all counts zero) when the manifest doesn't exist yet
+            or has no entries — not an error, just an empty pipeline.
+        """
+        result = service.manifest_status(Path(data_dir))
+        if result is None:
+            return DatajudStatusResult(found=False)
+        return DatajudStatusResult(
+            found=True,
+            total=result.total,
+            ok=result.ok,
+            com_docs=result.com_docs,
+            sem_docs=result.sem_docs,
+            com_erro=result.com_erro,
+        )

--- a/src/causaganha_mcp/tools/djen_backup.py
+++ b/src/causaganha_mcp/tools/djen_backup.py
@@ -1,0 +1,67 @@
+"""``djen_backup_status`` tool (RFC 0013 Fase 3A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from djen_backup import service
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+class DjenBackupStatusResult(BaseModel):
+    """Summary of the local DJEN sync manifest."""
+
+    total: int = Field(description="Total (tribunal, date) entries recorded.")
+    uploaded: int = Field(description="Entries already uploaded to Internet Archive.")
+    available: int = Field(description="Entries confirmed available on DJEN, pending upload.")
+    absent: int = Field(description="Entries confirmed absent on DJEN (no publication).")
+    unknown: int = Field(description="Entries not yet checked against DJEN.")
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ``djen_backup_status`` on *mcp*."""
+
+    @mcp.tool(
+        name="djen_backup_status",
+        annotations={
+            "title": "DJEN sync manifest status",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
+    def djen_backup_status(
+        manifest_file: str = str(service.DEFAULT_MANIFEST_FILE),
+    ) -> DjenBackupStatusResult:
+        """Summarize the local DJEN sync manifest: coverage across tribunals and dates.
+
+        Reads `sync-manifest.csv` from local disk only — no network call, no
+        IA fetch, no credentials involved. The canonical source of truth is
+        the `sync-manifest.parquet` on Internet Archive (see
+        `docs/planning/manifest-source-of-truth.md`); this tool only sees
+        whatever local CSV cache already exists on this machine, which can
+        lag behind IA. Never triggers a sync, upload, or reset; for that, use
+        the `djen-backup` CLI.
+
+        Args:
+            manifest_file: Path to the local manifest CSV. Defaults to
+                "data/sync-manifest.csv".
+
+        Returns:
+            All-zero counts when the manifest doesn't exist yet or is empty.
+        """
+        result = service.manifest_status(Path(manifest_file))
+        return DjenBackupStatusResult(
+            total=result.total,
+            uploaded=result.uploaded,
+            available=result.available,
+            absent=result.absent,
+            unknown=result.unknown,
+        )

--- a/src/causaganha_mcp/tools/stj_acordaos.py
+++ b/src/causaganha_mcp/tools/stj_acordaos.py
@@ -1,0 +1,63 @@
+"""``stj_acordaos_status`` tool (RFC 0013 Fase 3A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from stj_acordaos import service
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+class StjAcordaosStatusResult(BaseModel):
+    """Summary of the local STJ acórdãos manifest."""
+
+    count: int = Field(description="Total files (ZIPs, monthly JSONs, parquet) recorded.")
+    uploaded: int = Field(description="Files already uploaded to Internet Archive.")
+    pending: int = Field(description="Files downloaded/built but not yet uploaded.")
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ``stj_acordaos_status`` on *mcp*."""
+
+    @mcp.tool(
+        name="stj_acordaos_status",
+        annotations={
+            "title": "STJ acórdãos manifest status",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
+    def stj_acordaos_status(
+        manifest_path: str = str(service.DEFAULT_MANIFEST),
+    ) -> StjAcordaosStatusResult:
+        """Summarize the local STJ acórdãos manifest: files tracked and upload progress.
+
+        Reads the manifest CSV from local disk only — no network call, no
+        credentials involved. Per-file details (filename, tipo, status) are
+        intentionally omitted from this summary to keep the response small;
+        use the `stj-acordaos` CLI's `status` command for the full listing.
+        Never triggers a new download or upload; for that, use the
+        `stj-acordaos` CLI's `download`/`upload` commands.
+
+        Args:
+            manifest_path: Path to `stj-manifest.csv`. Defaults to
+                "data/stj/stj-manifest.csv", the path the scheduled workflow uses.
+
+        Returns:
+            All-zero counts when the manifest doesn't exist yet or is empty —
+            not an error, just an empty pipeline.
+        """
+        result = service.manifest_summary(Path(manifest_path))
+        return StjAcordaosStatusResult(
+            count=result.count,
+            uploaded=result.uploaded,
+            pending=result.pending,
+        )

--- a/src/causaganha_mcp/tools/tjro_juris.py
+++ b/src/causaganha_mcp/tools/tjro_juris.py
@@ -1,0 +1,66 @@
+"""``tjro_juris_status`` tool (RFC 0013 Fase 3A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from tjro_juris import service
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+# tjro_juris.service has no DEFAULT_DATA_DIR constant — the CLI takes
+# data_dir as a required positional argument. This matches the literal
+# argv tjro-sync.yml uses ("tjro-juris crawl data/tjro-juris ...").
+_DEFAULT_DATA_DIR = "data/tjro-juris"
+
+
+class TjroJurisStatusResult(BaseModel):
+    """Summary of the local TJRO JURIS manifest."""
+
+    total: int = Field(description="Total (tipo, mes_ano) windows recorded.")
+    uploaded: int = Field(description="Windows already uploaded to Internet Archive.")
+    pending: int = Field(description="Windows crawled but not yet uploaded.")
+
+
+def register(mcp: FastMCP) -> None:
+    """Register ``tjro_juris_status`` on *mcp*."""
+
+    @mcp.tool(
+        name="tjro_juris_status",
+        annotations={
+            "title": "TJRO JURIS manifest status",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
+    def tjro_juris_status(data_dir: str = _DEFAULT_DATA_DIR) -> TjroJurisStatusResult:
+        """Summarize the local TJRO JURIS manifest: crawled windows and upload progress.
+
+        Reads `tjro-juris-manifest.csv` under `data_dir` from local disk
+        only — no network call, no credentials involved. Use this to check
+        progress of the daily `tjro-sync.yml` backfill (`--desde-ano 1988`)
+        without a shell. Never triggers a new crawl or upload; for that, use
+        the `tjro-juris` CLI's `crawl`/`upload` commands.
+
+        Args:
+            data_dir: Directory containing the manifest and parquets.
+                Defaults to "data/tjro-juris", the path the scheduled workflow uses.
+
+        Returns:
+            All-zero counts when the manifest doesn't exist yet or is empty —
+            not an error, just an empty pipeline.
+        """
+        result = service.manifest_status(Path(data_dir))
+        return TjroJurisStatusResult(
+            total=result.total,
+            uploaded=result.uploaded,
+            pending=result.pending,
+        )

--- a/src/djen_backup/__init__.py
+++ b/src/djen_backup/__init__.py
@@ -1,13 +1,3 @@
 """djen-backup: Complete backup of Brazil's DJEN to the Internet Archive."""
 
-# Safely reconfigure standard output and standard error encoding error handling on Windows
-import contextlib
-import sys
-
-
-for stream in (sys.stdout, sys.stderr):
-    if stream and stream.encoding and stream.encoding.lower() != "utf-8":
-        with contextlib.suppress(AttributeError):
-            stream.reconfigure(errors="replace")
-
 __version__ = "0.1.0"

--- a/src/djen_backup/service.py
+++ b/src/djen_backup/service.py
@@ -16,8 +16,11 @@ from typing import TYPE_CHECKING
 from djen_backup.credentials import get_ia_s3_auth
 from djen_backup.drain import drain as _run_drain
 from djen_backup.engine import ManifestObserver, SyncConfig, SyncSummary, run_sync
-from djen_backup.manifest import SyncManifest
+from djen_backup.manifest import ManifestCounts, SyncManifest
 from djen_backup.probe import probe as _run_probe
+
+
+DEFAULT_MANIFEST_FILE = Path("data/sync-manifest.csv")
 
 
 if TYPE_CHECKING:
@@ -165,3 +168,15 @@ def reset_manifest(manifest_file: Path, *, tribunal: str | None, reset_all: bool
         manifest.save_to_disk(manifest_file)
 
     return ResetResult(count=count)
+
+
+def manifest_status(manifest_file: Path = DEFAULT_MANIFEST_FILE) -> ManifestCounts:
+    """Summarize the local manifest: total/uploaded/available/absent/unknown counts.
+
+    Local-disk-only — does not fetch or merge the IA parquet (see
+    ``engine.run_sync`` for that), so it's safe to call without network
+    access; the counts may lag behind IA if the local CSV cache is stale.
+    """
+    manifest = SyncManifest()
+    manifest.load_from_disk(manifest_file)
+    return manifest.counts()

--- a/tests/causaganha_mcp/test_stdio_transport.py
+++ b/tests/causaganha_mcp/test_stdio_transport.py
@@ -1,0 +1,82 @@
+"""Real stdio-transport regression test (RFC 0013 Fase 3A review).
+
+`test_tool_behavior.py` calls `tool.fn(...)` directly — it captures the
+correct return *value* but never touches the actual JSON-RPC transport, so
+it cannot catch a bug where a tool's dependencies write to stdout: in MCP
+stdio transport, stdout is exclusively the JSON-RPC channel, and structlog's
+default `PrintLogger` writes there unless explicitly configured otherwise.
+`ManifestSTJ.load()` and `SyncManifest.load_from_disk()` both call
+`log.info(...)` when the manifest file actually has entries to load — so
+this only reproduces with a *populated* manifest, which is exactly the
+scenario exercised here.
+
+This spawns the real server as a subprocess over real stdio
+(`PythonStdioTransport`) and drives it with `fastmcp.Client`, the same way
+a real MCP host would. `caplog` on the `mcp.client.stdio` logger is the
+deterministic signal: a corrupted JSON-RPC stream makes the client log
+"Failed to parse JSONRPC message from server" via `logger.exception(...)`
+(see `mcp/client/stdio/__init__.py`) — checking for that beats asserting on
+the call's return value, which can still come back correct by chance
+depending on how the stray line lands relative to message boundaries.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fastmcp import Client
+from fastmcp.client.transports import PythonStdioTransport
+
+from djen_backup.manifest import HEADER
+from stj_acordaos.manifest import ManifestSTJ
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+_MAIN_SCRIPT = Path(__file__).parents[2] / "src" / "causaganha_mcp" / "__main__.py"
+
+
+async def test_stj_acordaos_status_over_real_stdio_does_not_corrupt_json_rpc(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest_path = tmp_path / "stj-manifest.csv"
+    manifest = ManifestSTJ(manifest_path)
+    manifest.upsert("20260531.json.json", "json", "2026-05-31", "uploaded", 12)
+    manifest.save()  # triggers ManifestSTJ.load()'s log.info() on the next load
+
+    transport = PythonStdioTransport(script_path=_MAIN_SCRIPT, python_cmd=sys.executable)
+    with caplog.at_level(logging.WARNING, logger="mcp.client.stdio"):
+        async with Client(transport) as client:
+            result = await client.call_tool(
+                "stj_acordaos_status", {"manifest_path": str(manifest_path)}
+            )
+
+    assert result.data.count == 1
+    assert result.data.uploaded == 1
+    assert not any("Failed to parse" in r.message for r in caplog.records), caplog.text
+
+
+async def test_djen_backup_status_over_real_stdio_does_not_corrupt_json_rpc(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest_file = tmp_path / "sync-manifest.csv"
+    manifest_file.write_text(
+        f"{HEADER}\nTJRO,2026-01-01,uploaded,available,200,2026-01-01T00:00:00\n",
+        encoding="utf-8",
+    )  # triggers SyncManifest.load_from_disk()'s log.info()
+
+    transport = PythonStdioTransport(script_path=_MAIN_SCRIPT, python_cmd=sys.executable)
+    with caplog.at_level(logging.WARNING, logger="mcp.client.stdio"):
+        async with Client(transport) as client:
+            result = await client.call_tool(
+                "djen_backup_status", {"manifest_file": str(manifest_file)}
+            )
+
+    assert result.data.total == 1
+    assert result.data.uploaded == 1
+    assert not any("Failed to parse" in r.message for r in caplog.records), caplog.text

--- a/tests/causaganha_mcp/test_tool_behavior.py
+++ b/tests/causaganha_mcp/test_tool_behavior.py
@@ -1,0 +1,157 @@
+"""Behavior tests for causaganha_mcp status tools (RFC 0013 Fase 3A).
+
+Calls each tool's underlying function directly (`tool.fn(...)`) against a
+manifest fixture built with the same package's own manifest API — no
+FastMCP transport involved, since the transport isn't what these tools do
+differently from the CLI's own `status` commands; the mapping from
+manifest state to a small, structured, credential-free result is.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from causaganha_mcp.server import build_server
+from datajud.manifest import STATUS_OK, ManifestDataJud
+from djen_backup.manifest import HEADER, SyncManifest
+from stj_acordaos.manifest import ManifestSTJ
+from tjro_juris.manifest import ManifestJuris, ManifestJurisEntry
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def mcp():
+    return build_server()
+
+
+async def _tool_fn(mcp, name: str):
+    tool = await mcp.get_tool(name)
+    return tool.fn
+
+
+# ── datajud_status ──────────────────────────────────────────────────────
+
+
+async def test_datajud_status_empty_manifest(mcp, tmp_path: Path) -> None:
+    fn = await _tool_fn(mcp, "datajud_status")
+    result = fn(data_dir=str(tmp_path / "datajud"))
+    assert result.found is False
+    assert result.total == 0
+
+
+async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
+    data_dir = tmp_path / "datajud"
+    data_dir.mkdir()
+    manifest = ManifestDataJud.load_local(data_dir / "datajud-manifest.csv")
+    manifest.upsert("00000010220248220001", "tjro", docs=2, status=STATUS_OK)
+    manifest.upsert("00000020320248220002", "tjro", docs=0, status=STATUS_OK)
+    manifest.upsert("00000030420248220003", "tjro", docs=0, status="erro")
+    manifest.save_local(data_dir / "datajud-manifest.csv")
+
+    fn = await _tool_fn(mcp, "datajud_status")
+    result = fn(data_dir=str(data_dir))
+
+    assert result.found is True
+    assert result.total == 3
+    assert result.ok == 2
+    assert result.com_docs == 1
+    assert result.sem_docs == 1
+    assert result.com_erro == 1
+
+
+# ── tjro_juris_status ───────────────────────────────────────────────────
+
+
+async def test_tjro_juris_status_empty_manifest(mcp, tmp_path: Path) -> None:
+    fn = await _tool_fn(mcp, "tjro_juris_status")
+    result = fn(data_dir=str(tmp_path / "tjro-juris"))
+    assert result.total == 0
+    assert result.uploaded == 0
+    assert result.pending == 0
+
+
+async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None:
+    data_dir = tmp_path / "tjro-juris"
+    data_dir.mkdir()
+    manifest = ManifestJuris()
+    manifest.upsert(
+        ManifestJurisEntry(tipo="ACÓRDÃO", mes_ano="2026-06", ia_status="uploaded", n_docs=5)
+    )
+    manifest.upsert(ManifestJurisEntry(tipo="ACÓRDÃO", mes_ano="2026-07", ia_status="", n_docs=3))
+    manifest.save_local(data_dir / "tjro-juris-manifest.csv")
+
+    fn = await _tool_fn(mcp, "tjro_juris_status")
+    result = fn(data_dir=str(data_dir))
+
+    assert result.total == 2
+    assert result.uploaded == 1
+    assert result.pending == 1
+
+
+# ── stj_acordaos_status ─────────────────────────────────────────────────
+
+
+async def test_stj_acordaos_status_empty_manifest(mcp, tmp_path: Path) -> None:
+    fn = await _tool_fn(mcp, "stj_acordaos_status")
+    result = fn(manifest_path=str(tmp_path / "stj-manifest.csv"))
+    assert result.count == 0
+    assert result.uploaded == 0
+    assert result.pending == 0
+
+
+async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> None:
+    manifest_path = tmp_path / "stj-manifest.csv"
+    manifest = ManifestSTJ(manifest_path)
+    manifest.upsert("20260531.json.json", "json", "2026-05-31", "uploaded", 12)
+    manifest.upsert("20260630.json.json", "json", "2026-06-30", "", 0)
+    manifest.save()
+
+    fn = await _tool_fn(mcp, "stj_acordaos_status")
+    result = fn(manifest_path=str(manifest_path))
+
+    assert result.count == 2
+    assert result.uploaded == 1
+    assert result.pending == 1
+
+
+# ── djen_backup_status ──────────────────────────────────────────────────
+
+
+async def test_djen_backup_status_empty_manifest(mcp, tmp_path: Path) -> None:
+    fn = await _tool_fn(mcp, "djen_backup_status")
+    result = fn(manifest_file=str(tmp_path / "sync-manifest.csv"))
+    assert result.total == 0
+    assert result.uploaded == 0
+    assert result.available == 0
+    assert result.absent == 0
+    assert result.unknown == 0
+
+
+async def test_djen_backup_status_populated_manifest(mcp, tmp_path: Path) -> None:
+    manifest_file = tmp_path / "sync-manifest.csv"
+    manifest_file.write_text(
+        f"{HEADER}\n"
+        "TJRO,2026-01-01,uploaded,available,200,2026-01-01T00:00:00\n"
+        "TJRO,2026-01-02,,available,200,2026-01-02T00:00:00\n"
+        "TJRO,2026-01-03,,absent,404,2026-01-03T00:00:00\n"
+        "TJRO,2026-01-04,,,,\n",
+        encoding="utf-8",
+    )
+    # Sanity: confirm the fixture round-trips through the manifest's own
+    # loader the same way the tool does, before trusting the tool's counts.
+    manifest = SyncManifest()
+    assert manifest.load_from_disk(manifest_file) == 4
+
+    fn = await _tool_fn(mcp, "djen_backup_status")
+    result = fn(manifest_file=str(manifest_file))
+
+    assert result.total == 4
+    assert result.uploaded == 1
+    assert result.available == 1
+    assert result.absent == 1
+    assert result.unknown == 1

--- a/tests/causaganha_mcp/test_tool_schema.py
+++ b/tests/causaganha_mcp/test_tool_schema.py
@@ -1,0 +1,69 @@
+"""Schema-level guarantees for causaganha_mcp tools (RFC 0013 Fase 3A).
+
+Fase 3A's explicit acceptance bar: every tool is read-only (`readOnlyHint`),
+and no credential ever appears in a tool's input or output schema — not
+"empty", not "optional", genuinely absent as a field. Same bar Fase 2.5's
+`cli_contract` gate set for the CLIs themselves (see
+`tests/cli_contract/test_semantic_argv_contract.py`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from causaganha_mcp.server import build_server
+
+
+TOOL_NAMES = [
+    "datajud_status",
+    "tjro_juris_status",
+    "stj_acordaos_status",
+    "djen_backup_status",
+]
+
+_CREDENTIAL_SUBSTRINGS = ("key", "secret", "token", "credential", "password")
+
+
+def _property_names(schema: dict | None) -> set[str]:
+    if not schema:
+        return set()
+    return set(schema.get("properties", {}).keys())
+
+
+@pytest.fixture
+def mcp():
+    return build_server()
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+async def test_tool_is_read_only(mcp, name) -> None:
+    tool = await mcp.get_tool(name)
+    assert tool is not None
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.destructiveHint is False
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+async def test_tool_has_no_credential_fields(mcp, name) -> None:
+    tool = await mcp.get_tool(name)
+    assert tool is not None
+    field_names = _property_names(tool.parameters) | _property_names(tool.output_schema)
+    for field_name in field_names:
+        lowered = field_name.lower()
+        for bad in _CREDENTIAL_SUBSTRINGS:
+            assert bad not in lowered, f"{name}: field {field_name!r} looks credential-like"
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+async def test_tool_has_a_description(mcp, name) -> None:
+    """Tools are selected by their description (mcp-coding skill) — never blank."""
+    tool = await mcp.get_tool(name)
+    assert tool is not None
+    assert tool.description
+    assert len(tool.description) > 20  # sanity floor, not a real constraint
+
+
+async def test_server_exposes_exactly_the_fase_3a_tools(mcp) -> None:
+    """No ingestion/upload tool exists yet — Fase 3A is read-only status only."""
+    tools = await mcp.list_tools()
+    assert {t.name for t in tools} == set(TOOL_NAMES)


### PR DESCRIPTION
## Resumo

RFC 0013 Fase 3A — primeira fatia da exposição MCP: quatro tools read-only, locais e determinísticas, uma por pipeline de ingestão. Sem Cyclopts, sem consultas remotas (isso é Fase 3B), sem mudança de comportamento das CLIs existentes.

## O que mudou

- **Novo pacote `src/causaganha_mcp/`** (dependência `fastmcp`, servidor `causaganha_mcp`, script `causaganha-mcp`):
  - `datajud_status` — `datajud.service.manifest_status`.
  - `tjro_juris_status` — `tjro_juris.service.manifest_status`.
  - `stj_acordaos_status` — `stj_acordaos.service.manifest_summary` (omite a lista `rows` por economia de tokens — é resumo, não listagem).
  - `djen_backup_status` — `djen_backup.service.manifest_status`, **função nova** nesta fase (`djen_backup` não tinha `status` de CLI). Só lê o CSV local, nunca o parquet canônico no IA — pode ficar atrás do estado real, documentado na docstring da tool.
  - Todas `readOnlyHint=True`, `destructiveHint=False`, sem chamada de rede, sem credencial em parâmetro ou retorno.
  - Registro de tool explícito (`tools/*.py` expõe `register(mcp)`, chamado por `server.build_server()`) — não decoração em import time, mesma lição da Fase 2 sobre side effects de import.
- **Achado incidental corrigido**: `djen_backup/__init__.py` ainda reconfigurava `stdout`/`stderr` na importação do pacote — resíduo que a Fase 2 não pegou por só ter tocado `__main__.py`. Sem isso, `from djen_backup import service` (o que `causaganha_mcp` precisa fazer) reconfiguraria o stdio do processo do servidor MCP inteiro.
- **`docs/rfc/0013-migracao-cyclopts-fastmcp.md`**: Fase 3 dividida em 3A (esta PR) e 3B (`datajud_facetas`, consulta remota — categoria de erro diferente, fica para depois).

## Testes

`tests/causaganha_mcp/`:
- **Schema** (`test_tool_schema.py`): `readOnlyHint`/`destructiveHint` corretos, nenhum campo com substring `key`/`secret`/`token`/`credential`/`password` em `parameters` ou `output_schema` de nenhuma das 4 tools, descrição não vazia, exatamente as 4 tools de Fase 3A registradas.
- **Comportamento** (`test_tool_behavior.py`): `tool.fn(...)` chamado direto (sem transporte MCP) contra manifests fixture — caminho vazio/ausente e caminho populado, por tool.

| Gate | Resultado |
| --- | --- |
| Suíte completa (`--junitxml`) | 793 testes (772 + 21 novos), 0 falhas, 0 erros, 1 skipped |
| `ruff check src/ tests/ scripts/` | limpo |
| `ruff format --check src/ tests/ scripts/` | limpo |
| `uv run causaganha-mcp` (stdio) | sobe corretamente |

## Fora de escopo

`datajud_facetas` (Fase 3B) — consulta rede real à API do DataJud, categoria de erro diferente (timeout, rate limit, erro de rede) da fundação local/determinística desta fase. Nenhuma operação de ingestão/upload vira tool em fase alguma — `drain`, `consolidate`, `enrich` com upload continuam exclusivamente CLI/CI.

## Próximas fases

Fase 3B: `datajud_facetas`. Fase 4: Typer→Cyclopts, com `tests/cli_contract/` (Fase 2.5) como portão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_