### PR TITLE
feat: expõe datajud_facetas como tool FastMCP (RFC 0013 Fase 3B)

### DIFF
--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -1,6 +1,6 @@
 # RFC 0013 — Migração das CLIs Typer para Cyclopts + FastMCP
 
-- **Status:** Fase 1, Fase 2, Fase 2.5 e Fase 3A implementadas
+- **Status:** Fase 1, Fase 2, Fase 2.5, Fase 3A e Fase 3B implementadas
 - **Data:** 2026-07-21
 - **Base:** comparação de arquitetura com o repo irmão `pink` (mesma stack alvo:
   Cyclopts + FastMCP, tools declaradas uma vez, CLI como despachante genérico
@@ -224,13 +224,48 @@ key/secret/token/credential/password em `parameters` ou `output_schema`,
 para as quatro tools) e comportamento (`tool.fn(...)` chamado direto contra
 manifests fixture, caminho vazio e caminho populado).
 
-#### Fase 3B — consultas remotas (não implementada)
+#### Fase 3B — consultas remotas (implementada)
 
-`datajud_facetas` fica para depois, separado de propósito: consulta a API
-pública do DataJud (rede real), então tem uma categoria de erro diferente
-(timeout, rate limit, erro de rede) da fundação local/determinística da
-Fase 3A. Misturar as duas na mesma fase aumentaria o espaço de depuração
-sem necessidade.
+`datajud_facetas`, separado de propósito da Fase 3A: consulta a API pública
+do DataJud (rede real, `datajud.service.facetas` → `DataJudClient.facetas`),
+então tem uma categoria de erro diferente (timeout, rate limit, erro de
+rede) da fundação local/determinística da Fase 3A. Misturar as duas na
+mesma fase teria aumentado o espaço de depuração sem necessidade.
+
+Registrado em `tools/datajud.py`, junto de `datajud_status` (mesmo pacote
+fonte). `readOnlyHint=True`, `destructiveHint=False` como as demais tools —
+agrega, nunca muta — mas `openWorldHint=True`, diferente das quatro tools da
+Fase 3A: é a única que sai da máquina. Parâmetros: `tribunal` (default
+`DEFAULT_TRIBUNAL` do client), `por` (`Literal["classe", "assunto", "orgao",
+"grau", "sistema"]`, hardcoded em vez de derivado dinamicamente de
+`FACET_FIELDS` para evitar complicação de `Literal` dinâmico — guardado por
+um teste de schema que compara os dois conjuntos de chaves) e `limite`
+(`Annotated[int, Field(ge=1, le=100)]`). Retorno: `tribunal`, `por`, `total`
+(acervo inteiro, não só os buckets retornados) e `buckets` (lista de
+`{chave, qtd}`).
+
+Erros de `datajud.client` (`DataJudAuthError`, `DataJudRateLimitError`,
+`DataJudError` genérico de ES, mais `httpx.HTTPStatusError`/
+`TimeoutException`/`TransportError` não encapsulados — o mesmo
+`except (DataJudError, httpx.HTTPError)` que a CLI já usa) nunca sobem como
+exceção crua: `_facetas_tool_error()` mapeia cada categoria para uma
+mensagem de `fastmcp.exceptions.ToolError`, reportada dentro do canal de
+erro do MCP em vez de derrubar o transporte stdio. A correção de logging da
+Fase 3A (`_configure_stdio_safe_logging()` em `__main__.py`) é global ao
+processo, então já cobre qualquer `log.warning`/`log.error` que
+`DataJudClient._search_once` emitir nos ramos de rejeição ES — nenhuma
+correção adicional foi necessária aqui.
+
+Testado com `respx` (mesmo padrão de `tests/datajud/test_datajud_enrich.py`)
+mockando o endpoint HTTP: sucesso, 401, 429 esgotando o retry budget,
+rejeição ES esgotando o retry budget, erro ES genérico não retriável, outro
+status HTTP e erro de rede — sete casos, todos verificando que o resultado é
+um `ToolError` estruturado, nunca uma exceção crua. Não ganhou teste
+dedicado de transporte stdio real (diferente da Fase 3A): o caminho de
+sucesso de `facetas()` não loga nada (só os ramos de rejeição/erro da ES
+logam, em `warning`/`error`), e a correção de stdio já é genérica ao
+processo — um teste adicional testaria a mesma correção duas vezes, não um
+caminho novo.
 
 Operações de ingestão/upload de longa duração (o sync completo, `drain`,
 `consolidate`, `enrich` com upload) ficam só na CLI/CI em qualquer fase —
@@ -298,6 +333,24 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
   nenhuma das 4 tools) e de comportamento (manifest vazio e populado, por
   tool). `pytest`, `ruff check`, `ruff format --check` verdes.
 - Nenhuma tool de ingestão/upload — só as 4 de status.
+
+**Fase 3B (implementada):**
+- `datajud_facetas` em `tools/datajud.py`, `readOnlyHint=True`,
+  `destructiveHint=False`, `openWorldHint=True` (única tool que faz chamada
+  de rede), sem credencial em parâmetro ou retorno.
+- Toda a taxonomia de erro de `datajud.client` (`DataJudAuthError`,
+  `DataJudRateLimitError`, `DataJudError` de ES, `httpx.HTTPStatusError`,
+  `httpx.TimeoutException`/`TransportError`) mapeada para
+  `fastmcp.exceptions.ToolError` — nunca uma exceção crua atravessando o
+  transporte MCP.
+- `por` como `Literal` hardcoded, guardado por teste de schema que compara
+  o enum declarado com `datajud.client.FACET_FIELDS.keys()` (drift guard).
+- `tests/causaganha_mcp/test_datajud_facetas.py`: sete casos via `respx`
+  (sucesso + seis modos de falha), cada um afirmando `ToolError`.
+  `tests/causaganha_mcp/test_tool_schema.py` estendido para as 5 tools.
+  `pytest`, `ruff check`, `ruff format --check` verdes.
+- `server.py`'s `instructions` atualizado para não afirmar mais que o
+  servidor inteiro é sem chamada de rede.
 
 ## 4. Riscos
 

--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -259,13 +259,43 @@ correção adicional foi necessária aqui.
 Testado com `respx` (mesmo padrão de `tests/datajud/test_datajud_enrich.py`)
 mockando o endpoint HTTP: sucesso, 401, 429 esgotando o retry budget,
 rejeição ES esgotando o retry budget, erro ES genérico não retriável, outro
-status HTTP e erro de rede — sete casos, todos verificando que o resultado é
-um `ToolError` estruturado, nunca uma exceção crua. Não ganhou teste
-dedicado de transporte stdio real (diferente da Fase 3A): o caminho de
-sucesso de `facetas()` não loga nada (só os ramos de rejeição/erro da ES
-logam, em `warning`/`error`), e a correção de stdio já é genérica ao
-processo — um teste adicional testaria a mesma correção duas vezes, não um
-caminho novo.
+status HTTP, erro de rede, resposta não JSON e o orçamento MCP em uso — nove
+casos, todos verificando que o resultado é um `ToolError` estruturado, nunca
+uma exceção crua. Não ganhou teste dedicado de transporte stdio real
+(diferente da Fase 3A): o caminho de sucesso de `facetas()` não loga nada
+(só os ramos de rejeição/erro da ES logam, em `warning`/`error`), e a
+correção de stdio já é genérica ao processo — um teste adicional testaria a
+mesma correção duas vezes, não um caminho novo.
+
+Duas correções de review antes do merge:
+
+- **Orçamento de tempo próprio para a chamada MCP.** `DataJudClient` tem
+  defaults calibrados para o `enrich` da CLI — ingestão em lote de longa
+  duração, onde vale esperar minutos por um hiccup do DataJud: `timeout=90s`,
+  `max_retries=5` (6 tentativas), backoff 2/4/8/16/30s. Herdar isso
+  integralmente na tool deixaria uma indisponibilidade custar até ~10 minutos
+  antes do `ToolError` (e um 429 persistente, ~1 minuto só em backoff) —
+  tempo longo o bastante para um host MCP desistir de esperar antes do erro
+  estruturado chegar. `datajud.service.facetas()` ganhou parâmetros opcionais
+  (`request_timeout`, `max_retries`, `backoff_base`, todos `None` por
+  default — a CLI continua sem passá-los, comportamento idêntico ao de
+  antes); a tool passa um orçamento interno próprio, não exposto no schema
+  (`_FACETAS_TIMEOUT=20s`, `_FACETAS_MAX_RETRIES=2`,
+  `_FACETAS_BACKOFF_BASE=1.0`, pior caso ~1 minuto em vez de ~10).
+  `test_facetas_uses_a_tighter_budget_than_the_ingestion_client` espiona os
+  kwargs que a tool passa a `DataJudClient` para confirmar isso sem precisar
+  de sleeps reais.
+- **Resposta não JSON não tinha lugar na taxonomia.**
+  `DataJudClient._search_once()` chamava `resp.json()` sem tratamento — um
+  WAF/gateway devolvendo HTML ou corpo truncado sob HTTP 200 levanta
+  `JSONDecodeError` (um `ValueError`), que não é `DataJudError` nem
+  `httpx.HTTPError` e vazava cru pelo `except` da tool. Corrigido com uma
+  nova classe `DataJudProtocolError(DataJudError)` e um `_parse_json_body()`
+  que traduz só o `ValueError` de `resp.json()` — não um `except ValueError`
+  amplo, que mascararia bug de programação — numa mensagem com status e
+  content-type, sem ecoar o corpo. Coberto em
+  `tests/datajud/test_datajud_client.py` (nível do client) e
+  `tests/causaganha_mcp/test_datajud_facetas.py` (nível da tool).
 
 Operações de ingestão/upload de longa duração (o sync completo, `drain`,
 `consolidate`, `enrich` com upload) ficam só na CLI/CI em qualquer fase —
@@ -339,14 +369,22 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
   `destructiveHint=False`, `openWorldHint=True` (única tool que faz chamada
   de rede), sem credencial em parâmetro ou retorno.
 - Toda a taxonomia de erro de `datajud.client` (`DataJudAuthError`,
-  `DataJudRateLimitError`, `DataJudError` de ES, `httpx.HTTPStatusError`,
+  `DataJudRateLimitError`, `DataJudError` de ES, `DataJudProtocolError` de
+  corpo não JSON, `httpx.HTTPStatusError`,
   `httpx.TimeoutException`/`TransportError`) mapeada para
   `fastmcp.exceptions.ToolError` — nunca uma exceção crua atravessando o
   transporte MCP.
 - `por` como `Literal` hardcoded, guardado por teste de schema que compara
   o enum declarado com `datajud.client.FACET_FIELDS.keys()` (drift guard).
-- `tests/causaganha_mcp/test_datajud_facetas.py`: sete casos via `respx`
-  (sucesso + seis modos de falha), cada um afirmando `ToolError`.
+- Orçamento de tempo/retry próprio da tool (`_FACETAS_TIMEOUT=20s`,
+  `_FACETAS_MAX_RETRIES=2`, `_FACETAS_BACKOFF_BASE=1.0`), não exposto no
+  schema, independente dos defaults de `DataJudClient` calibrados para
+  ingestão em lote — pior caso ~1 minuto em vez de ~10.
+- `tests/causaganha_mcp/test_datajud_facetas.py`: nove casos via `respx`
+  (sucesso + sete modos de falha + orçamento em uso), cada um afirmando
+  `ToolError` (exceto o de orçamento, que inspeciona os kwargs passados a
+  `DataJudClient`). `tests/datajud/test_datajud_client.py` cobre
+  `DataJudProtocolError` no nível do client.
   `tests/causaganha_mcp/test_tool_schema.py` estendido para as 5 tools.
   `pytest`, `ruff check`, `ruff format --check` verdes.
 - `server.py`'s `instructions` atualizado para não afirmar mais que o

--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -244,58 +244,94 @@ um teste de schema que compara os dois conjuntos de chaves) e `limite`
 (acervo inteiro, não só os buckets retornados) e `buckets` (lista de
 `{chave, qtd}`).
 
-Erros de `datajud.client` (`DataJudAuthError`, `DataJudRateLimitError`,
-`DataJudError` genérico de ES, mais `httpx.HTTPStatusError`/
-`TimeoutException`/`TransportError` não encapsulados — o mesmo
-`except (DataJudError, httpx.HTTPError)` que a CLI já usa) nunca sobem como
-exceção crua: `_facetas_tool_error()` mapeia cada categoria para uma
-mensagem de `fastmcp.exceptions.ToolError`, reportada dentro do canal de
-erro do MCP em vez de derrubar o transporte stdio. A correção de logging da
-Fase 3A (`_configure_stdio_safe_logging()` em `__main__.py`) é global ao
-processo, então já cobre qualquer `log.warning`/`log.error` que
-`DataJudClient._search_once` emitir nos ramos de rejeição ES — nenhuma
-correção adicional foi necessária aqui.
+**Tradução de exceções na fronteira MCP, não como rede de segurança contra
+crash.** As exceções de domínio (`datajud.client`'s `DataJudAuthError`,
+`DataJudRateLimitError`, `DataJudProtocolError`, `DataJudError` genérico de
+ES) permanecem independentes do FastMCP — nenhuma delas importa `fastmcp`,
+mesma separação que a CLI já usa (`except (DataJudError, httpx.HTTPError)`).
+Na fronteira MCP, `_facetas_tool_error()` traduz explicitamente cada
+categoria conhecida para uma mensagem de `fastmcp.exceptions.ToolError`.
+Isso não é o que impede o transporte de cair: o próprio FastMCP já contém
+qualquer exceção levantada durante a execução normal de uma tool e a
+converte num tool-execution error (`server.py`'s `call_tool` deixa
+`FastMCPError` passar, envolve o resto em `ToolError`, com mensagens
+especiais para 429/timeout, respeitando `mask_error_details`) — isso nunca
+esteve em risco. O que a tradução explícita garante é outra coisa: mensagens
+públicas estáveis, acionáveis e seguras, que sobrevivem a
+`mask_error_details=True` (o fallback genérico do FastMCP substituiria
+qualquer exceção que não seja já um `ToolError` por um "Error calling tool
+..." completamente opaco nesse modo) — sem depender do `str()` interno de
+cada exceção, que pode mudar de redação ou, no caso do erro genérico de ES,
+carregar o payload cru do Elasticsearch. Exceções fora dessa lista conhecida
+continuam contidas pelo fallback do FastMCP — defesa em profundidade, não o
+contrato principal de erros da tool.
+
+Isso é diferente da correção de stdio da Fase 3A
+(`_configure_stdio_safe_logging()` em `__main__.py`, ainda necessária e já
+genérica ao processo): aquela era corrupção do canal de transporte (bytes de
+log indo parar em stdout, que é exclusivamente JSON-RPC), não uma exceção de
+função — uma classe de falha que o `except Exception` do FastMCP não cobre
+porque nunca chega como exceção Python. As duas proteções continuam
+necessárias, mas por motivos diferentes.
 
 Testado com `respx` (mesmo padrão de `tests/datajud/test_datajud_enrich.py`)
 mockando o endpoint HTTP: sucesso, 401, 429 esgotando o retry budget,
-rejeição ES esgotando o retry budget, erro ES genérico não retriável, outro
-status HTTP, erro de rede, resposta não JSON e o orçamento MCP em uso — nove
-casos, todos verificando que o resultado é um `ToolError` estruturado, nunca
-uma exceção crua. Não ganhou teste dedicado de transporte stdio real
-(diferente da Fase 3A): o caminho de sucesso de `facetas()` não loga nada
-(só os ramos de rejeição/erro da ES logam, em `warning`/`error`), e a
-correção de stdio já é genérica ao processo — um teste adicional testaria a
-mesma correção duas vezes, não um caminho novo.
+rejeição ES esgotando o retry budget, erro ES genérico não retriável (com
+asserção explícita de que o payload do ES não vaza na mensagem pública),
+outro status HTTP, erro de rede, resposta não JSON, o orçamento MCP em uso e
+o deadline duro da tool — dez casos. Não ganhou teste dedicado de transporte
+stdio real (diferente da Fase 3A): o caminho de sucesso de `facetas()` não
+loga nada (só os ramos de rejeição/erro da ES logam, em `warning`/`error`),
+e a correção de stdio já é genérica ao processo — um teste adicional
+testaria a mesma correção duas vezes, não um caminho novo.
 
-Duas correções de review antes do merge:
+Correções de review antes do merge:
 
-- **Orçamento de tempo próprio para a chamada MCP.** `DataJudClient` tem
-  defaults calibrados para o `enrich` da CLI — ingestão em lote de longa
-  duração, onde vale esperar minutos por um hiccup do DataJud: `timeout=90s`,
-  `max_retries=5` (6 tentativas), backoff 2/4/8/16/30s. Herdar isso
-  integralmente na tool deixaria uma indisponibilidade custar até ~10 minutos
-  antes do `ToolError` (e um 429 persistente, ~1 minuto só em backoff) —
-  tempo longo o bastante para um host MCP desistir de esperar antes do erro
-  estruturado chegar. `datajud.service.facetas()` ganhou parâmetros opcionais
-  (`request_timeout`, `max_retries`, `backoff_base`, todos `None` por
-  default — a CLI continua sem passá-los, comportamento idêntico ao de
-  antes); a tool passa um orçamento interno próprio, não exposto no schema
-  (`_FACETAS_TIMEOUT=20s`, `_FACETAS_MAX_RETRIES=2`,
-  `_FACETAS_BACKOFF_BASE=1.0`, pior caso ~1 minuto em vez de ~10).
+- **Orçamento de tempo próprio para a chamada MCP, em duas camadas.**
+  `DataJudClient` tem defaults calibrados para o `enrich` da CLI — ingestão
+  em lote de longa duração, onde vale esperar minutos por um hiccup do
+  DataJud: `timeout=90s`, `max_retries=5` (6 tentativas), backoff
+  2/4/8/16/30s. Herdar isso integralmente na tool deixaria uma
+  indisponibilidade custar até ~10 minutos antes do `ToolError` (e um 429
+  persistente, ~1 minuto só em backoff) — tempo longo o bastante para um
+  host MCP desistir de esperar antes do erro estruturado chegar.
+  `datajud.service.facetas()` ganhou parâmetros opcionais (`request_timeout`,
+  `max_retries`, `backoff_base`, todos `None` por default — a CLI continua
+  sem passá-los, comportamento idêntico ao de antes); a tool passa um
+  orçamento interno próprio, não exposto no schema (`_FACETAS_TIMEOUT=15s`,
+  `_FACETAS_MAX_RETRIES=1`, `_FACETAS_BACKOFF_BASE=1.0`, pior caso ~31s em
+  vez de ~10 minutos). Uma segunda camada, independente: `@mcp.tool(timeout=
+  _FACETAS_TOOL_TIMEOUT)` (45s), o deadline nativo do FastMCP
+  (`anyio.fail_after`), como backstop acima do pior caso do orçamento do
+  client — cobre qualquer travamento que o timeout do próprio client não
+  pegue, ou uma futura mudança no orçamento que o faça crescer de novo; ao
+  disparar, vira um `McpError` genérico (não uma das mensagens tratadas de
+  `_facetas_tool_error()`), mas ainda contido pelo FastMCP, nunca cru.
   `test_facetas_uses_a_tighter_budget_than_the_ingestion_client` espiona os
-  kwargs que a tool passa a `DataJudClient` para confirmar isso sem precisar
-  de sleeps reais.
+  kwargs que a tool passa a `DataJudClient`; `test_facetas_has_a_
+  hard_interactive_timeout_as_backstop` confirma o deadline da tool — nenhum
+  dos dois precisa de sleeps reais.
 - **Resposta não JSON não tinha lugar na taxonomia.**
   `DataJudClient._search_once()` chamava `resp.json()` sem tratamento — um
   WAF/gateway devolvendo HTML ou corpo truncado sob HTTP 200 levanta
   `JSONDecodeError` (um `ValueError`), que não é `DataJudError` nem
-  `httpx.HTTPError` e vazava cru pelo `except` da tool. Corrigido com uma
-  nova classe `DataJudProtocolError(DataJudError)` e um `_parse_json_body()`
-  que traduz só o `ValueError` de `resp.json()` — não um `except ValueError`
-  amplo, que mascararia bug de programação — numa mensagem com status e
-  content-type, sem ecoar o corpo. Coberto em
-  `tests/datajud/test_datajud_client.py` (nível do client) e
-  `tests/causaganha_mcp/test_datajud_facetas.py` (nível da tool).
+  `httpx.HTTPError`. Sem tradução no client, isso pularia a taxonomia de
+  domínio inteira e cairia direto no fallback genérico do FastMCP —
+  perdendo toda orientação acionável com masking ligado, ou expondo detalhes
+  instáveis sem masking. Corrigido com uma nova classe
+  `DataJudProtocolError(DataJudError)` e um `_parse_json_body()` que traduz
+  só o `ValueError` de `resp.json()` — não um `except ValueError` amplo, que
+  mascararia bug de programação — numa mensagem com status e content-type,
+  sem ecoar o corpo. Coberto em `tests/datajud/test_datajud_client.py`
+  (nível do client) e `tests/causaganha_mcp/test_datajud_facetas.py` (nível
+  da tool).
+- **O fallback genérico de `_facetas_tool_error()` vazava `str(exc)`.**
+  `return ToolError(f"DataJud query failed: {exc}")` acoplava a mensagem
+  pública ao texto interno de qualquer exceção não coberta pelos ramos
+  explícitos — e o `DataJudError` genérico (erro de ES não-transiente em
+  `_search_once`) embute o payload cru do Elasticsearch nesse texto. Trocado
+  por uma mensagem fixa, sem interpolação; a causa real continua disponível
+  via `raise ... from exc` para logs.
 
 Operações de ingestão/upload de longa duração (o sync completo, `drain`,
 `consolidate`, `enrich` com upload) ficam só na CLI/CI em qualquer fase —
@@ -371,21 +407,26 @@ de mudar qualquer workflow. O callback bare de `djen-backup` precisa de um
 - Toda a taxonomia de erro de `datajud.client` (`DataJudAuthError`,
   `DataJudRateLimitError`, `DataJudError` de ES, `DataJudProtocolError` de
   corpo não JSON, `httpx.HTTPStatusError`,
-  `httpx.TimeoutException`/`TransportError`) mapeada para
-  `fastmcp.exceptions.ToolError` — nunca uma exceção crua atravessando o
-  transporte MCP.
+  `httpx.TimeoutException`/`TransportError`) traduzida explicitamente para
+  `fastmcp.exceptions.ToolError`, com mensagens públicas estáveis e sem
+  interpolar `str(exc)` no ramo de fallback (não vaza payload de ES nem
+  outro detalhe interno instável) — não porque isso evite um crash de
+  transporte (o FastMCP já contém qualquer exceção de tool sozinho), mas
+  porque preserva orientação acionável mesmo sob `mask_error_details=True`.
 - `por` como `Literal` hardcoded, guardado por teste de schema que compara
   o enum declarado com `datajud.client.FACET_FIELDS.keys()` (drift guard).
-- Orçamento de tempo/retry próprio da tool (`_FACETAS_TIMEOUT=20s`,
-  `_FACETAS_MAX_RETRIES=2`, `_FACETAS_BACKOFF_BASE=1.0`), não exposto no
-  schema, independente dos defaults de `DataJudClient` calibrados para
-  ingestão em lote — pior caso ~1 minuto em vez de ~10.
-- `tests/causaganha_mcp/test_datajud_facetas.py`: nove casos via `respx`
-  (sucesso + sete modos de falha + orçamento em uso), cada um afirmando
-  `ToolError` (exceto o de orçamento, que inspeciona os kwargs passados a
-  `DataJudClient`). `tests/datajud/test_datajud_client.py` cobre
-  `DataJudProtocolError` no nível do client.
-  `tests/causaganha_mcp/test_tool_schema.py` estendido para as 5 tools.
+- Orçamento de tempo/retry em duas camadas: interno do client
+  (`_FACETAS_TIMEOUT=15s`, `_FACETAS_MAX_RETRIES=1`,
+  `_FACETAS_BACKOFF_BASE=1.0`, não exposto no schema, pior caso ~31s em vez
+  dos ~10min do perfil de ingestão) e um deadline nativo do FastMCP na tool
+  (`@mcp.tool(timeout=45s)`, backstop acima do pior caso do client).
+- `tests/causaganha_mcp/test_datajud_facetas.py`: dez casos via `respx`
+  (sucesso + sete modos de falha + orçamento do client em uso + deadline da
+  tool), cada um de falha afirmando `ToolError` (o do fallback genérico
+  também afirma que o payload de ES não aparece na mensagem).
+  `tests/datajud/test_datajud_client.py` cobre `DataJudProtocolError` no
+  nível do client. `tests/causaganha_mcp/test_tool_schema.py` estendido
+  para as 5 tools.
   `pytest`, `ruff check`, `ruff format --check` verdes.
 - `server.py`'s `instructions` atualizado para não afirmar mais que o
   servidor inteiro é sem chamada de rede.

--- a/src/causaganha_mcp/server.py
+++ b/src/causaganha_mcp/server.py
@@ -8,13 +8,16 @@ this module (a test, a supervisor, another tool) should not get side
 effects it didn't ask for. Each ``tools/*.py`` module exposes a
 ``register(mcp)`` function instead of decorating at import time.
 
-Fase 3A scope: read-only, local, deterministic status tools only —
+Fase 3A scope: read-only, local, deterministic status tools —
 ``datajud_status``, ``tjro_juris_status``, ``stj_acordaos_status``,
 ``djen_backup_status``. None of them touch Internet Archive credentials or
 make network calls; each reads whatever manifest already exists on local
-disk. Ingestion/upload operations (the full sync, ``drain``, ``consolidate``,
-``enrich`` with upload) stay CLI/CI-only per the RFC — they never become
-tools.
+disk. Fase 3B adds ``datajud_facetas``: still read-only and credential-free,
+but it makes a real call to the public DataJud API — a different error
+category (timeout, rate limit, network) from the local/deterministic Fase
+3A foundation, hence ``openWorldHint=True`` on that one tool only. Ingestion/
+upload operations (the full sync, ``drain``, ``consolidate``, ``enrich``
+with upload) stay CLI/CI-only per the RFC — they never become tools.
 """
 
 from __future__ import annotations
@@ -29,13 +32,15 @@ def build_server() -> FastMCP:
     mcp = FastMCP(
         name="causaganha_mcp",
         instructions=(
-            "Read-only status tools over CausaGanha's four ingestion pipelines "
-            "(djen-backup, tjro-juris, stj-acordaos, datajud). Each tool reads "
-            "a local manifest file — no network calls, no credentials, no "
-            "mutation. For ingestion, upload, or backfill operations, use the "
-            "corresponding CLI (djen-backup, tjro-juris, stj-acordaos, "
-            "datajud) or the scheduled CI workflows — those are not exposed "
-            "here by design."
+            "Read-only tools over CausaGanha's four ingestion pipelines "
+            "(djen-backup, tjro-juris, stj-acordaos, datajud). Most tools "
+            "read a local manifest file only — no network call, no "
+            "credentials, no mutation; `datajud_facetas` is the one "
+            "exception, querying the public DataJud API live (still "
+            "read-only, still no credentials in its schema). For ingestion, "
+            "upload, or backfill operations, use the corresponding CLI "
+            "(djen-backup, tjro-juris, stj-acordaos, datajud) or the "
+            "scheduled CI workflows — those are not exposed here by design."
         ),
     )
     datajud.register(mcp)

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -31,13 +31,25 @@ if TYPE_CHECKING:
 # ingestion, where riding out a DataJud hiccup is worth minutes of waiting.
 # An interactive MCP call is a different budget: an unlucky timeout there
 # could keep this tool open for ~10 minutes before producing a ToolError
-# (RFC 0013 Fase 3B review) — long enough for a host to give up waiting
-# before the structured error even arrives. These numbers trade some of
-# that ingestion-grade resilience for a call that fails within roughly a
-# minute worst case (3 attempts * 20s timeout + ~3s of backoff).
-_FACETAS_TIMEOUT = 20.0
-_FACETAS_MAX_RETRIES = 2
+# (RFC 0013 Fase 3B review), long enough for a host to give up waiting on
+# the call entirely. These numbers trade some of that ingestion-grade
+# resilience for a call whose worst case — 2 attempts * 15s timeout + ~1s
+# of backoff — stays well under half a minute.
+_FACETAS_TIMEOUT = 15.0
+_FACETAS_MAX_RETRIES = 1
 _FACETAS_BACKOFF_BASE = 1.0
+
+# Second, independent layer of defense: FastMCP's own per-tool deadline
+# (`@mcp.tool(timeout=...)`, backed by `anyio.fail_after`, surfaced to the
+# caller as a generic McpError → ToolError, not one of `_facetas_tool_error`'s
+# tailored messages). The budget above only bounds `DataJudClient`'s own
+# retry loop; this bounds the tool call as a whole, regardless of what
+# happens inside it — a hang the client's own timeout doesn't catch, a
+# future change to the retry budget that drifts it back up, anything.
+# Set comfortably above the tuned client budget's own worst case (~31s) so
+# it stays a backstop: the common failure path should still resolve via
+# the client's own tailored errors well before this fires.
+_FACETAS_TOOL_TIMEOUT = 45.0
 
 
 class DatajudStatusResult(BaseModel):
@@ -96,7 +108,15 @@ def _facetas_tool_error(exc: Exception) -> ToolError:
         )
     if isinstance(exc, httpx.HTTPStatusError):
         return ToolError(f"DataJud returned HTTP {exc.response.status_code} for this query.")
-    return ToolError(f"DataJud query failed: {exc}")
+    # Deliberately doesn't interpolate str(exc): a bare DataJudError here is
+    # the non-transient-ES-error branch of DataJudClient._search_once, whose
+    # message embeds the raw Elasticsearch error payload — not something to
+    # promise as a stable, safe public tool message. The real exception is
+    # still attached via `raise ... from exc` for logs/debugging.
+    return ToolError(
+        "DataJud could not complete this aggregation. Retry later; if the "
+        "error persists, the upstream query may be unavailable."
+    )
 
 
 def register(mcp: FastMCP) -> None:
@@ -144,6 +164,7 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="datajud_facetas",
+        timeout=_FACETAS_TOOL_TIMEOUT,
         annotations={
             "title": "DataJud facet aggregation",
             "readOnlyHint": True,
@@ -180,11 +201,11 @@ def register(mcp: FastMCP) -> None:
             first.
 
         Raises:
-            A structured error (via MCP's tool-error channel, not a crash)
-            when DataJud rejects the API key, rate-limits past the retry
-            budget, returns an unparseable body, or is unreachable. Uses a
-            tighter internal timeout/retry budget than the `datajud enrich`
-            CLI (roughly a minute worst case, not minutes).
+            A structured tool error (never a raw exception) when DataJud
+            rejects the API key, rate-limits past the retry budget, returns
+            an unparseable body, or is unreachable. Uses a tighter internal
+            timeout/retry budget than the `datajud enrich` CLI, plus a hard
+            per-call deadline — well under a minute worst case, not minutes.
         """
         try:
             total, buckets = await service.facetas(

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -1,13 +1,23 @@
-"""``datajud_status`` tool (RFC 0013 Fase 3A)."""
+"""``datajud_status`` and ``datajud_facetas`` tools (RFC 0013 Fase 3A/3B)."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Literal
 
+import httpx
+from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
 from datajud import service
+from datajud.client import (
+    API_KEY_ENV,
+    DEFAULT_TRIBUNAL,
+    WIKI_ACESSO_URL,
+    DataJudAuthError,
+    DataJudError,
+    DataJudRateLimitError,
+)
 
 
 if TYPE_CHECKING:
@@ -25,8 +35,54 @@ class DatajudStatusResult(BaseModel):
     com_erro: int = Field(default=0, description="CNJs whose last consult failed.")
 
 
+class DatajudFacetaBucket(BaseModel):
+    """One aggregation bucket returned by ``datajud_facetas``."""
+
+    chave: str = Field(description="Facet value (e.g. a classe or assunto name).")
+    qtd: int = Field(description="Document count for this value.")
+
+
+class DatajudFacetasResult(BaseModel):
+    """Aggregation of a tribunal's DataJud acervo by one dimension."""
+
+    tribunal: str = Field(description="Tribunal queried, lowercase (e.g. 'tjro').")
+    por: str = Field(description="Dimension aggregated by.")
+    total: int = Field(
+        description="Total documents in the tribunal's acervo — all facet "
+        "values, not just the buckets returned below."
+    )
+    buckets: list[DatajudFacetaBucket] = Field(
+        description="Top facet values by document count, largest first."
+    )
+
+
+def _facetas_tool_error(exc: Exception) -> ToolError:
+    """Map the DataJud client's error taxonomy to a structured ``ToolError``."""
+    if isinstance(exc, DataJudAuthError):
+        return ToolError(
+            "DataJud rejected the configured API key (HTTP 401). This is an "
+            "operator-level credential problem, not something retriable from "
+            f"here — fetch a current key at {WIKI_ACESSO_URL} and set the "
+            f"{API_KEY_ENV} environment variable."
+        )
+    if isinstance(exc, DataJudRateLimitError):
+        return ToolError(
+            "DataJud rate-limited this request past the retry budget. "
+            "Recoverable: wait a bit and call datajud_facetas again."
+        )
+    if isinstance(exc, httpx.TimeoutException | httpx.TransportError):
+        return ToolError(
+            "Network error reaching DataJud (timeout or connection failure). "
+            "Recoverable: retry datajud_facetas; if it persists, the DataJud "
+            "API itself may be down."
+        )
+    if isinstance(exc, httpx.HTTPStatusError):
+        return ToolError(f"DataJud returned HTTP {exc.response.status_code} for this query.")
+    return ToolError(f"DataJud query failed: {exc}")
+
+
 def register(mcp: FastMCP) -> None:
-    """Register ``datajud_status`` on *mcp*."""
+    """Register ``datajud_status`` and ``datajud_facetas`` on *mcp*."""
 
     @mcp.tool(
         name="datajud_status",
@@ -66,4 +122,59 @@ def register(mcp: FastMCP) -> None:
             com_docs=result.com_docs,
             sem_docs=result.sem_docs,
             com_erro=result.com_erro,
+        )
+
+    @mcp.tool(
+        name="datajud_facetas",
+        annotations={
+            "title": "DataJud facet aggregation",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )
+    async def datajud_facetas(
+        tribunal: str = DEFAULT_TRIBUNAL,
+        por: Literal["classe", "assunto", "orgao", "grau", "sistema"] = "classe",
+        limite: Annotated[
+            int, Field(ge=1, le=100, description="Max number of buckets to return.")
+        ] = 15,
+    ) -> DatajudFacetasResult:
+        """Aggregate a tribunal's DataJud acervo by one dimension (classe, assunto, ...).
+
+        Queries the live public DataJud API (network call, unlike
+        `datajud_status`) to count documents grouped by *por*, without
+        downloading any document. Use this to answer questions like "what
+        are the top 10 classes in TJRO's acervo?" without fetching or
+        enriching individual processos.
+
+        Args:
+            tribunal: Tribunal to query, lowercase (e.g. "tjro"). Defaults to
+                the same tribunal the `datajud` CLI defaults to.
+            por: Dimension to aggregate by.
+            limite: Max buckets to return, 1-100. The `total` field always
+                reflects the full acervo, even when `limite` truncates the
+                bucket list.
+
+        Returns:
+            The full acervo total plus the top `limite` buckets, largest
+            first.
+
+        Raises:
+            A structured error (via MCP's tool-error channel, not a crash)
+            when DataJud rejects the API key, rate-limits past the retry
+            budget, or is unreachable.
+        """
+        try:
+            total, buckets = await service.facetas(tribunal, por, limite)
+        except (DataJudError, httpx.HTTPError) as exc:
+            raise _facetas_tool_error(exc) from exc
+        return DatajudFacetasResult(
+            tribunal=tribunal,
+            por=por,
+            total=total,
+            buckets=[
+                DatajudFacetaBucket(chave=bucket["chave"], qtd=bucket["qtd"]) for bucket in buckets
+            ],
         )

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -16,12 +16,28 @@ from datajud.client import (
     WIKI_ACESSO_URL,
     DataJudAuthError,
     DataJudError,
+    DataJudProtocolError,
     DataJudRateLimitError,
 )
 
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+
+# Internal MCP call budget for `datajud_facetas` — NOT exposed as a tool
+# parameter. `DataJudClient`'s own defaults (timeout=90s, max_retries=5,
+# 2/4/8/16/30s backoff) are tuned for the `enrich` CLI's long-running batch
+# ingestion, where riding out a DataJud hiccup is worth minutes of waiting.
+# An interactive MCP call is a different budget: an unlucky timeout there
+# could keep this tool open for ~10 minutes before producing a ToolError
+# (RFC 0013 Fase 3B review) — long enough for a host to give up waiting
+# before the structured error even arrives. These numbers trade some of
+# that ingestion-grade resilience for a call that fails within roughly a
+# minute worst case (3 attempts * 20s timeout + ~3s of backoff).
+_FACETAS_TIMEOUT = 20.0
+_FACETAS_MAX_RETRIES = 2
+_FACETAS_BACKOFF_BASE = 1.0
 
 
 class DatajudStatusResult(BaseModel):
@@ -70,6 +86,8 @@ def _facetas_tool_error(exc: Exception) -> ToolError:
             "DataJud rate-limited this request past the retry budget. "
             "Recoverable: wait a bit and call datajud_facetas again."
         )
+    if isinstance(exc, DataJudProtocolError):
+        return ToolError(f"DataJud returned an unparseable response: {exc}")
     if isinstance(exc, httpx.TimeoutException | httpx.TransportError):
         return ToolError(
             "Network error reaching DataJud (timeout or connection failure). "
@@ -164,10 +182,19 @@ def register(mcp: FastMCP) -> None:
         Raises:
             A structured error (via MCP's tool-error channel, not a crash)
             when DataJud rejects the API key, rate-limits past the retry
-            budget, or is unreachable.
+            budget, returns an unparseable body, or is unreachable. Uses a
+            tighter internal timeout/retry budget than the `datajud enrich`
+            CLI (roughly a minute worst case, not minutes).
         """
         try:
-            total, buckets = await service.facetas(tribunal, por, limite)
+            total, buckets = await service.facetas(
+                tribunal,
+                por,
+                limite,
+                request_timeout=_FACETAS_TIMEOUT,
+                max_retries=_FACETAS_MAX_RETRIES,
+                backoff_base=_FACETAS_BACKOFF_BASE,
+            )
         except (DataJudError, httpx.HTTPError) as exc:
             raise _facetas_tool_error(exc) from exc
         return DatajudFacetasResult(

--- a/src/datajud/client.py
+++ b/src/datajud/client.py
@@ -91,6 +91,16 @@ class DataJudRateLimitError(DataJudError):
     """Both rate-limit flavors persisted beyond the retry budget."""
 
 
+class DataJudProtocolError(DataJudError):
+    """DataJud returned a non-JSON body (e.g. a WAF/gateway HTML error page).
+
+    Not retried — a malformed body under a 2xx status is not one of the two
+    known transient rejection flavors (see ``is_es_rejection``), so treating
+    it as a permanent nominal error rather than looping the retry budget is
+    the correct default.
+    """
+
+
 class _TransientRejectionError(Exception):
     """Internal marker for retriable rejections (HTTP 429 or ES rejection)."""
 
@@ -244,7 +254,7 @@ class DataJudClient:
         async with self._limiter:
             resp = await self._http.post(self._endpoint, json=body)
         _raise_for_status_flavor(resp)
-        payload = resp.json()
+        payload = _parse_json_body(resp)
         if is_es_rejection(payload):
             log.warning("datajud_es_rejection", tribunal=self.tribunal)
             msg = "es_rejected_execution_exception (ES search queue full)"
@@ -332,6 +342,27 @@ def _raise_for_status_flavor(resp: httpx.Response) -> None:
         msg = "HTTP 429 (gateway rate limit)"
         raise _TransientRejectionError(msg)
     resp.raise_for_status()
+
+
+def _parse_json_body(resp: httpx.Response) -> dict:
+    """Parse *resp*'s body as JSON, raising a nominal error on malformed bodies.
+
+    A 2xx status is not proof of a well-formed body — a WAF/gateway can
+    return HTML or a truncated body under HTTP 200. That's not one of the
+    known rejection flavors (see ``is_es_rejection``), so ``resp.json()``'s
+    ``JSONDecodeError`` (a ``ValueError``) is translated here, narrowly, into
+    :class:`DataJudProtocolError` — never left to leak out as a bare
+    ``ValueError``, and never silently swallowed either. The body itself is
+    not echoed (could be large or binary); only status and content-type are.
+    """
+    try:
+        return resp.json()
+    except ValueError as exc:
+        msg = (
+            f"DataJud returned a non-JSON body for HTTP {resp.status_code} "
+            f"(content-type: {resp.headers.get('content-type', 'unknown')})"
+        )
+        raise DataJudProtocolError(msg) from exc
 
 
 def _normalize_cnjs(cnjs: Sequence[str]) -> list[str]:

--- a/src/datajud/service.py
+++ b/src/datajud/service.py
@@ -316,9 +316,30 @@ def enrich(
     )
 
 
-async def facetas(tribunal: str, por: str, limite: int) -> tuple[int, list[dict]]:
-    """Aggregate the acervo by *por* (classe/assunto/orgao/...) without downloading docs."""
-    async with DataJudClient(tribunal=tribunal) as client:
+async def facetas(
+    tribunal: str,
+    por: str,
+    limite: int,
+    *,
+    request_timeout: float | None = None,
+    max_retries: int | None = None,
+    backoff_base: float | None = None,
+) -> tuple[int, list[dict]]:
+    """Aggregate the acervo by *por* (classe/assunto/orgao/...) without downloading docs.
+
+    ``request_timeout``/``max_retries``/``backoff_base`` override
+    ``DataJudClient``'s ingestion-tuned defaults when passed — the CLI
+    leaves them unset (same behavior as before); the MCP tool passes a
+    tighter budget of its own (see ``causaganha_mcp.tools.datajud``).
+    """
+    client_kwargs: dict[str, float | int] = {}
+    if request_timeout is not None:
+        client_kwargs["timeout"] = request_timeout
+    if max_retries is not None:
+        client_kwargs["max_retries"] = max_retries
+    if backoff_base is not None:
+        client_kwargs["backoff_base"] = backoff_base
+    async with DataJudClient(tribunal=tribunal, **client_kwargs) as client:
         return await client.facetas(por, limite=limite)
 
 

--- a/tests/causaganha_mcp/test_datajud_facetas.py
+++ b/tests/causaganha_mcp/test_datajud_facetas.py
@@ -1,0 +1,141 @@
+"""Behavior tests for the ``datajud_facetas`` MCP tool (RFC 0013 Fase 3B).
+
+Unlike Fase 3A's status tools, `facetas` hits a real HTTP endpoint (the
+public DataJud API) — so these tests mock it with `respx` (the same pattern
+`tests/datajud/test_datajud_enrich.py` uses for the CLI) instead of building
+a local manifest fixture. The behavior under test is the mapping from
+`datajud.client`'s error taxonomy to `fastmcp.exceptions.ToolError` — a
+crash here would corrupt the JSON-RPC transport (see
+`test_stdio_transport.py`), so every DataJud failure mode must surface as a
+structured tool error instead.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastmcp.exceptions import ToolError
+
+from causaganha_mcp.server import build_server
+from datajud.client import search_endpoint
+
+
+ENDPOINT = search_endpoint("tjro")
+
+
+def _facetas_payload(total: int, buckets: list[tuple[str, int]]) -> dict:
+    return {
+        "hits": {"total": {"value": total, "relation": "eq"}},
+        "aggregations": {
+            "facetas": {"buckets": [{"key": chave, "doc_count": qtd} for chave, qtd in buckets]}
+        },
+    }
+
+
+@pytest.fixture
+def mcp():
+    return build_server()
+
+
+async def _facetas_fn(mcp):
+    tool = await mcp.get_tool("datajud_facetas")
+    return tool.fn
+
+
+async def test_facetas_success_returns_total_and_buckets(mcp) -> None:
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(
+            200, json=_facetas_payload(42, [("Procedimento Comum Cível", 30), ("Execução", 12)])
+        )
+        result = await fn(tribunal="tjro", por="classe", limite=15)
+
+    assert result.tribunal == "tjro"
+    assert result.por == "classe"
+    assert result.total == 42
+    assert [(b.chave, b.qtd) for b in result.buckets] == [
+        ("Procedimento Comum Cível", 30),
+        ("Execução", 12),
+    ]
+
+
+async def test_facetas_auth_error_becomes_tool_error(mcp) -> None:
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(401)
+        with pytest.raises(ToolError, match="401"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_rate_limit_exhaustion_becomes_tool_error(mcp, monkeypatch) -> None:
+    from datajud import service
+
+    original = service.DataJudClient
+    monkeypatch.setattr(
+        service,
+        "DataJudClient",
+        lambda **kw: original(**{**kw, "backoff_base": 0.0, "max_retries": 1}),
+    )
+
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(429)
+        with pytest.raises(ToolError, match="rate-limited"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_es_rejection_exhaustion_becomes_tool_error(mcp, monkeypatch) -> None:
+    from datajud import service
+
+    original = service.DataJudClient
+    monkeypatch.setattr(
+        service,
+        "DataJudClient",
+        lambda **kw: original(**{**kw, "backoff_base": 0.0, "max_retries": 1}),
+    )
+
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(
+            200,
+            json={"error": {"root_cause": [{"type": "es_rejected_execution_exception"}]}},
+        )
+        with pytest.raises(ToolError, match="rate-limited"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_generic_es_error_becomes_tool_error(mcp) -> None:
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(
+            200,
+            json={"error": {"root_cause": [{"type": "query_shard_exception"}]}},
+        )
+        with pytest.raises(ToolError, match="DataJud query failed"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_other_http_status_becomes_tool_error(mcp) -> None:
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(500)
+        with pytest.raises(ToolError, match="500"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_network_error_becomes_tool_error(mcp, monkeypatch) -> None:
+    from datajud import service
+
+    original = service.DataJudClient
+    monkeypatch.setattr(
+        service,
+        "DataJudClient",
+        lambda **kw: original(**{**kw, "backoff_base": 0.0, "max_retries": 1}),
+    )
+
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
+        with pytest.raises(ToolError, match="Network error"):
+            await fn(tribunal="tjro", por="classe", limite=15)

--- a/tests/causaganha_mcp/test_datajud_facetas.py
+++ b/tests/causaganha_mcp/test_datajud_facetas.py
@@ -4,10 +4,17 @@ Unlike Fase 3A's status tools, `facetas` hits a real HTTP endpoint (the
 public DataJud API) — so these tests mock it with `respx` (the same pattern
 `tests/datajud/test_datajud_enrich.py` uses for the CLI) instead of building
 a local manifest fixture. The behavior under test is the mapping from
-`datajud.client`'s error taxonomy to `fastmcp.exceptions.ToolError` — a
-crash here would corrupt the JSON-RPC transport (see
-`test_stdio_transport.py`), so every DataJud failure mode must surface as a
-structured tool error instead.
+`datajud.client`'s error taxonomy to `fastmcp.exceptions.ToolError`.
+
+This mapping isn't about preventing a transport crash — FastMCP already
+contains any exception raised during tool execution and converts it into a
+tool-execution error on its own (see `server.py`'s `call_tool`). What the
+explicit `_facetas_tool_error()` mapping buys instead: stable, actionable,
+payload-free public messages that survive `mask_error_details=True`
+(FastMCP's own generic fallback replaces anything that isn't already a
+`ToolError` with a bare "Error calling tool ..." in that mode), rather than
+leaking `str(exc)` — which for at least one DataJud exception embeds the
+raw Elasticsearch error payload.
 """
 
 from __future__ import annotations
@@ -105,15 +112,23 @@ async def test_facetas_es_rejection_exhaustion_becomes_tool_error(mcp, monkeypat
             await fn(tribunal="tjro", por="classe", limite=15)
 
 
-async def test_facetas_generic_es_error_becomes_tool_error(mcp) -> None:
+async def test_facetas_generic_es_error_becomes_a_safe_tool_error(mcp) -> None:
+    """The fallback branch must not echo str(exc) — it can carry the raw ES payload.
+
+    `DataJudError`'s own message here is
+    ``f"...: {payload.get('error')}"`` — genuinely unstable, upstream-defined
+    content that has no business being promised as this tool's public
+    contract. The mapped `ToolError` message is fixed and payload-free.
+    """
     fn = await _facetas_fn(mcp)
     with respx.mock() as router:
         router.post(ENDPOINT).respond(
             200,
             json={"error": {"root_cause": [{"type": "query_shard_exception"}]}},
         )
-        with pytest.raises(ToolError, match="DataJud query failed"):
+        with pytest.raises(ToolError, match="could not complete this aggregation") as exc_info:
             await fn(tribunal="tjro", por="classe", limite=15)
+        assert "query_shard_exception" not in str(exc_info.value)
 
 
 async def test_facetas_other_http_status_becomes_tool_error(mcp) -> None:
@@ -122,6 +137,20 @@ async def test_facetas_other_http_status_becomes_tool_error(mcp) -> None:
         router.post(ENDPOINT).respond(500)
         with pytest.raises(ToolError, match="500"):
             await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_has_a_hard_interactive_timeout_as_backstop(mcp) -> None:
+    """The tool declares its own deadline — independent of DataJudClient's budget.
+
+    This is the second, outer layer of defense (RFC 0013 Fase 3B follow-up
+    review): even if the client-level budget drifted back up, or something
+    hung in a way the client's own timeout doesn't cover, FastMCP's
+    `anyio.fail_after(timeout)` still bounds the call as a whole.
+    """
+    from causaganha_mcp.tools import datajud as tool_module
+
+    tool = await mcp.get_tool("datajud_facetas")
+    assert tool.timeout == tool_module._FACETAS_TOOL_TIMEOUT
 
 
 async def test_facetas_network_error_becomes_tool_error(mcp, monkeypatch) -> None:

--- a/tests/causaganha_mcp/test_datajud_facetas.py
+++ b/tests/causaganha_mcp/test_datajud_facetas.py
@@ -139,3 +139,44 @@ async def test_facetas_network_error_becomes_tool_error(mcp, monkeypatch) -> Non
         router.post(ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
         with pytest.raises(ToolError, match="Network error"):
             await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_non_json_response_becomes_tool_error(mcp) -> None:
+    """A WAF/gateway can return HTML under HTTP 200 — must not leak a bare ValueError."""
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(
+            200, content=b"<html>blocked by WAF</html>", headers={"content-type": "text/html"}
+        )
+        with pytest.raises(ToolError, match="unparseable"):
+            await fn(tribunal="tjro", por="classe", limite=15)
+
+
+async def test_facetas_uses_a_tighter_budget_than_the_ingestion_client(mcp, monkeypatch) -> None:
+    """Production must not inherit `DataJudClient`'s ~10-minute ingestion worst case.
+
+    Spies on the kwargs the tool actually passes to `DataJudClient` — no
+    real retry/backoff needs to happen (the mocked response succeeds on the
+    first attempt), so this is a fast, direct check that the tool's call
+    path uses its own internal budget rather than the client's defaults.
+    """
+    from causaganha_mcp.tools import datajud as tool_module
+    from datajud import service
+
+    captured: dict = {}
+    original = service.DataJudClient
+
+    def spy(**kwargs: float | str) -> object:
+        captured.update(kwargs)
+        return original(**kwargs)
+
+    monkeypatch.setattr(service, "DataJudClient", spy)
+
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(200, json=_facetas_payload(1, [("x", 1)]))
+        await fn(tribunal="tjro", por="classe", limite=15)
+
+    assert captured["timeout"] == tool_module._FACETAS_TIMEOUT
+    assert captured["max_retries"] == tool_module._FACETAS_MAX_RETRIES
+    assert captured["backoff_base"] == tool_module._FACETAS_BACKOFF_BASE

--- a/tests/causaganha_mcp/test_tool_schema.py
+++ b/tests/causaganha_mcp/test_tool_schema.py
@@ -1,10 +1,13 @@
-"""Schema-level guarantees for causaganha_mcp tools (RFC 0013 Fase 3A).
+"""Schema-level guarantees for causaganha_mcp tools (RFC 0013 Fase 3A/3B).
 
 Fase 3A's explicit acceptance bar: every tool is read-only (`readOnlyHint`),
 and no credential ever appears in a tool's input or output schema — not
 "empty", not "optional", genuinely absent as a field. Same bar Fase 2.5's
 `cli_contract` gate set for the CLIs themselves (see
-`tests/cli_contract/test_semantic_argv_contract.py`).
+`tests/cli_contract/test_semantic_argv_contract.py`). Fase 3B's
+`datajud_facetas` is read-only too (it aggregates, never mutates) even
+though — unlike the Fase 3A tools — it makes a real network call
+(`openWorldHint=True`), so it stays in the same read-only/no-credential bar.
 """
 
 from __future__ import annotations
@@ -12,10 +15,12 @@ from __future__ import annotations
 import pytest
 
 from causaganha_mcp.server import build_server
+from datajud.client import FACET_FIELDS
 
 
 TOOL_NAMES = [
     "datajud_status",
+    "datajud_facetas",
     "tjro_juris_status",
     "stj_acordaos_status",
     "djen_backup_status",
@@ -63,7 +68,21 @@ async def test_tool_has_a_description(mcp, name) -> None:
     assert len(tool.description) > 20  # sanity floor, not a real constraint
 
 
-async def test_server_exposes_exactly_the_fase_3a_tools(mcp) -> None:
-    """No ingestion/upload tool exists yet — Fase 3A is read-only status only."""
+async def test_server_exposes_exactly_the_known_tools(mcp) -> None:
+    """No ingestion/upload tool exists — every tool here is read-only."""
     tools = await mcp.list_tools()
     assert {t.name for t in tools} == set(TOOL_NAMES)
+
+
+async def test_facetas_por_enum_matches_facet_fields(mcp) -> None:
+    """Guard against `por`'s hardcoded Literal drifting from `FACET_FIELDS`.
+
+    The tool declares `por` as a hardcoded `Literal[...]` (see
+    `tools/datajud.py`) rather than deriving it dynamically from
+    `datajud.client.FACET_FIELDS` — this test is the drift guard that keeps
+    the two in sync.
+    """
+    tool = await mcp.get_tool("datajud_facetas")
+    assert tool is not None
+    por_schema = tool.parameters["properties"]["por"]
+    assert set(por_schema["enum"]) == set(FACET_FIELDS.keys())

--- a/tests/datajud/test_datajud_client.py
+++ b/tests/datajud/test_datajud_client.py
@@ -21,6 +21,7 @@ from datajud.client import (
     DataJudAuthError,
     DataJudClient,
     DataJudError,
+    DataJudProtocolError,
     DataJudRateLimitError,
     get_api_key,
     is_es_error,
@@ -298,6 +299,27 @@ async def test_facetas_uses_keyword_field_and_parses_buckets():
     # text fields must be aggregated via .keyword (raw text field → HTTP 400)
     assert sent["aggs"]["facetas"]["terms"]["field"] == "classe.nome.keyword"
     assert sent["size"] == 0
+
+
+# ── Malformed bodies ─────────────────────────────────────────────────────
+# A 2xx status is not proof of a well-formed body — a WAF/gateway can
+# return HTML or a truncated body under HTTP 200 (see RFC 0013 Fase 3B
+# review: this used to leak a bare JSONDecodeError past the client's error
+# taxonomy, which a downstream MCP tool's `except (DataJudError,
+# httpx.HTTPError)` wouldn't catch).
+
+
+async def test_non_json_200_body_raises_protocol_error_not_bare_value_error():
+    with respx.mock() as router:
+        route = router.post(ENDPOINT).respond(
+            200, content=b"<html>blocked by WAF</html>", headers={"content-type": "text/html"}
+        )
+        async with _client() as client:
+            with pytest.raises(DataJudProtocolError, match="non-JSON"):
+                await client.search({"query": {"match_all": {}}})
+
+    # Not one of the known transient rejection flavors → not retried.
+    assert route.call_count == 1
 
 
 # ── Transport errors ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

RFC 0013 Fase 3B: adiciona `datajud_facetas` ao servidor `causaganha_mcp`, junto das quatro tools de status da Fase 3A (#852).

Diferente daquelas — locais e determinísticas — esta consulta a API pública do DataJud em tempo real (`datajud.service.facetas` → `DataJudClient.facetas`) para agregar o acervo de um tribunal por `classe`/`assunto`/`orgao`/`grau`/`sistema`, sem baixar nenhum documento. Por isso fica numa fase separada: tem uma categoria de erro própria (timeout, rate limit, erro de rede) que a fundação local da Fase 3A não tinha.

**O que muda:**
- `src/causaganha_mcp/tools/datajud.py`: nova tool `datajud_facetas` (`readOnlyHint=True`, `destructiveHint=False`, `openWorldHint=True` — a única das 5 tools que sai da máquina). Parâmetros `tribunal`, `por` (`Literal` das 5 dimensões de `FACET_FIELDS`) e `limite` (1-100). Toda a taxonomia de erro do client (`DataJudAuthError`, `DataJudRateLimitError`, erro de ES em HTTP 200, `httpx.HTTPStatusError`, timeout/rede) é mapeada em `_facetas_tool_error()` para `fastmcp.exceptions.ToolError` — nunca uma exceção crua atravessando o transporte stdio.
- `tests/causaganha_mcp/test_datajud_facetas.py`: sete casos via `respx` (sucesso + seis modos de falha), mesmo padrão de `tests/datajud/test_datajud_enrich.py`.
- `tests/causaganha_mcp/test_tool_schema.py`: `datajud_facetas` entra em `TOOL_NAMES`; novo teste de drift-guard comparando o `Literal` hardcoded de `por` com `datajud.client.FACET_FIELDS.keys()`.
- `src/causaganha_mcp/server.py`: `instructions` atualizado — nem toda tool é sem chamada de rede agora.
- `docs/rfc/0013-migracao-cyclopts-fastmcp.md`: Fase 3B marcada como implementada (conteúdo, critérios de aceitação).

Nenhuma mudança de escopo além do combinado: `datajud_facetas` é a única tool nova; nenhuma operação de ingestão/upload vira tool.

## Test plan

- [x] `uv run pytest tests/causaganha_mcp -q` — 34 testes, todos verdes
- [x] `uv run pytest -q` (suíte completa) — verde
- [x] `uv run ruff check .` — sem findings
- [x] `uv run ruff format --check .` — sem findings

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. — N/A, não toca CLI/argv, só adiciona uma tool MCP.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_