### PR TITLE
feat: experiência operacional v1 do MCP — causaganha_status + PT-BR (RFC 0014 M1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Registered entry points (`pyproject.toml` `[project.scripts]`):
 | `stj-acordaos` | STJ acórdãos collection |
 | `tjro-juris` | TJRO jurisprudence collection |
 | `datajud` | DataJud process metadata enrichment |
+| `causaganha-mcp` | MCP server exposing read-only status tools to AI assistants (see [below](#use-o-causaganha-no-seu-assistente)) |
 
 ### `djen-backup` — sync engine
 
@@ -135,6 +136,37 @@ When the CNJ rotates the key (usually visible as HTTP 401 responses), add the ne
 uv run --env-file .env datajud enrich --tribunal tjro --skip-upload
 ```
 
+## Use o CausaGanha no seu assistente
+
+Além da CLI e do dashboard web, o CausaGanha expõe um servidor [MCP](https://modelcontextprotocol.io/) (`causaganha-mcp`) — um conjunto de tools que um assistente de IA (Claude, ChatGPT, etc.) pode chamar diretamente, sem passar por um shell.
+
+Configure no seu host MCP (ex.: `claude_desktop_config.json` ou equivalente):
+
+```json
+{
+  "mcpServers": {
+    "causaganha": {
+      "command": "uv",
+      "args": ["run", "--directory", "/caminho/para/causaganha", "causaganha-mcp"]
+    }
+  }
+}
+```
+
+Seis tools hoje, em dois grupos:
+
+- **Locais, sem chamada de rede** — leem só o manifest de cada pipeline neste disco: `causaganha_status` (panorama dos quatro pipelines numa só chamada), `datajud_status`, `tjro_juris_status`, `stj_acordaos_status`, `djen_backup_status` (o mesmo detalhe de `causaganha_status`, mas por pipeline).
+- **Consulta ao vivo** — `datajud_facetas` é a única que sai da máquina: consulta a API pública do DataJud em tempo real.
+
+Nenhuma delas dispara ingestão, upload ou backfill — para isso, use a CLI ou os workflows agendados (ver acima).
+
+Perguntas que dá pra fazer direto pro assistente, sem abrir terminal:
+
+- "Como estão os pipelines?"
+- "Há uploads pendentes?"
+- "Quais são as principais classes do TJRO?"
+- "Quais assuntos aparecem mais no acervo do TJRO?"
+- "Os dados locais podem estar desatualizados?"
 
 ## Web frontend
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ uv run --env-file .env datajud enrich --tribunal tjro --skip-upload
 
 ## Use o CausaGanha no seu assistente
 
-Além da CLI e do dashboard web, o CausaGanha expõe um servidor [MCP](https://modelcontextprotocol.io/) (`causaganha-mcp`) — um conjunto de tools que um assistente de IA (Claude, ChatGPT, etc.) pode chamar diretamente, sem passar por um shell.
+Além da CLI e do dashboard web, o CausaGanha expõe um servidor [MCP](https://modelcontextprotocol.io/) (`causaganha-mcp`) — um conjunto de tools que um assistente de IA pode chamar diretamente, sem passar por um shell.
 
-Configure no seu host MCP (ex.: `claude_desktop_config.json` ou equivalente):
+`causaganha-mcp` roda por padrão como um processo local sobre stdio. Isso funciona em hosts com suporte a stdio local, como o Claude Desktop — configure em `claude_desktop_config.json` (ou equivalente):
 
 ```json
 {
@@ -152,6 +152,8 @@ Configure no seu host MCP (ex.: `claude_desktop_config.json` ou equivalente):
   }
 }
 ```
+
+**ChatGPT não usa essa receita.** O modo Developer/conectores MCP do ChatGPT exige um endpoint remoto (ou o Secure MCP Tunnel) — não conecta a um processo `stdio` local como o acima, e depende de plano/modo específicos. Ver a [documentação oficial](https://help.openai.com/pt-br/articles/12584461-developer-mode-and-full-mcp-connectors-in-chatgpt-beta). Servir `causaganha-mcp` remotamente para ChatGPT (ou outro host que só fale HTTP) ainda não está configurado neste repositório.
 
 Seis tools hoje, em dois grupos:
 

--- a/docs/rfc/0013-migracao-cyclopts-fastmcp.md
+++ b/docs/rfc/0013-migracao-cyclopts-fastmcp.md
@@ -1,6 +1,9 @@
 # RFC 0013 — Migração das CLIs Typer para Cyclopts + FastMCP
 
 - **Status:** Fase 1, Fase 2, Fase 2.5, Fase 3A e Fase 3B implementadas
+  (PRs #849, #850, #851, #852, #853). Fase 3 está fechada — trabalho de
+  produto sobre o servidor MCP continua em RFC 0014. Fase 4 (Typer →
+  Cyclopts) segue pendente, sem PR aberto.
 - **Data:** 2026-07-21
 - **Base:** comparação de arquitetura com o repo irmão `pink` (mesma stack alvo:
   Cyclopts + FastMCP, tools declaradas uma vez, CLI como despachante genérico
@@ -336,6 +339,18 @@ Correções de review antes do merge:
 Operações de ingestão/upload de longa duração (o sync completo, `drain`,
 `consolidate`, `enrich` com upload) ficam só na CLI/CI em qualquer fase —
 nunca viram tool.
+
+**Fase 3 está fechada aqui — fronteira de escopo com a RFC 0014.** As cinco
+tools read-only (`datajud_status`, `tjro_juris_status`, `stj_acordaos_status`,
+`djen_backup_status`, `datajud_facetas`) cobrem o que esta RFC se propôs:
+expor a camada de serviço via FastMCP sem tocar ingestão/upload. Qualquer
+trabalho adicional sobre o servidor MCP — onboarding/descoberta, textos em
+português nas superfícies exibidas, uma tool agregadora de status, campos de
+freshness/proveniência (`encontrado`, `ultima_atualizacao`, `fonte`,
+`canonica`, `aviso`), ou `processo_consultar` — é um eixo de produto, não de
+migração de framework, e fica em **RFC 0014 — MCP como superfície de
+produto**. Esta RFC não será estendida com esse escopo; só Fase 4 (abaixo)
+continua pendente aqui.
 
 ### Fase 4 — Typer → Cyclopts
 

--- a/docs/rfc/0014-mcp-superficie-produto.md
+++ b/docs/rfc/0014-mcp-superficie-produto.md
@@ -171,9 +171,14 @@ própria depois de M1.
 ## 4. Critérios de aceitação
 
 **M1:**
-- README com a seção de onboarding MCP: configuração stdio copiável,
-  distinção tools locais vs. `datajud_facetas`, cinco perguntas de exemplo.
-- `title`/`description`/nomes de campo de todas as tools em português.
+- README com a seção de onboarding MCP: configuração stdio copiável para
+  hosts com suporte a stdio local (ex.: Claude Desktop), nota separada de
+  que ChatGPT exige implantação remota/túnel (não a mesma receita), cinco
+  perguntas de exemplo.
+- `title`/`description`/nomes de campo de todas as tools em português — em
+  `parameters` (`diretorio_dados`, `caminho_manifesto`, `arquivo_manifesto`)
+  tanto quanto em `output_schema`, com teste de schema exato cobrindo os
+  dois lados (review da #854: a primeira versão só travava o output).
 - Envelope `encontrado`/`ultima_atualizacao`/`fonte`/`canonica`/`aviso`
   presente e testado (schema exato) nas quatro tools locais; `consultado_em`
   + tribunal normalizado em `datajud_facetas`.
@@ -182,8 +187,12 @@ própria depois de M1.
   indistinguível de pipeline vazio.
 - `causaganha_status` implementada, chamando `service.py` de cada pacote
   diretamente (teste que falha se algum dia importar `causaganha_mcp.tools`).
-- Manifest ausente em um pipeline não derruba `causaganha_status` — teste
-  cobrindo esse caso explicitamente.
+- Manifest ausente OU malformado em um pipeline não derruba
+  `causaganha_status` — testado para os dois casos: falha de I/O (`OSError`)
+  e conteúdo malformado (`ManifestFormatError`, nova classe em
+  `tjro_juris.manifest`/`datajud.manifest`, que traduz o `KeyError`/
+  `ValueError` de um `csv.DictReader` numa linha sem coluna esperada ou com
+  número inválido — review da #854: a primeira versão só cobria I/O).
 - `pytest`, `ruff check`, `ruff format --check` verdes.
 
 **M2 (quando a investigação e a PR acontecerem):**

--- a/docs/rfc/0014-mcp-superficie-produto.md
+++ b/docs/rfc/0014-mcp-superficie-produto.md
@@ -1,0 +1,216 @@
+# RFC 0014 — MCP como superfície de produto
+
+- **Status:** Proposto
+- **Data:** 2026-07-22
+- **Depende de:** RFC 0013 (Fase 3A/3B — fundação `causaganha_mcp`: cinco tools
+  read-only, `register(mcp)` explícito, tradução de exceções na fronteira),
+  RFC 0005 (processo como recurso unificado — base de dados para
+  `processo_consultar`)
+- **Escopo:** Descoberta/onboarding do servidor MCP, textos em português nas
+  superfícies exibidas ao host, uma tool agregadora de status com
+  freshness/proveniência estruturadas, e `processo_consultar` como a primeira
+  tool MCP voltada ao usuário final (não ao operador).
+
+## 1. Problema
+
+RFC 0013 construiu a fundação do servidor `causaganha_mcp`: cinco tools
+read-only (`datajud_status`, `tjro_juris_status`, `stj_acordaos_status`,
+`djen_backup_status`, `datajud_facetas`), registro explícito, tradução de
+erro na fronteira MCP. Isso resolveu "o servidor existe e funciona
+corretamente". Não resolveu "alguém descobre que o servidor existe" nem "o
+servidor entrega o que define o produto".
+
+Quatro lacunas concretas:
+
+- **Descoberta.** O README não lista `causaganha-mcp` entre os entrypoints —
+  só CLI/Python e web. Instalar o projeto inteiro hoje não revela que o
+  servidor existe, muito menos como configurá-lo num host MCP.
+- **Idioma.** Titles, descriptions e nomes de campo das tools estão em
+  inglês, mesmo sendo texto que o host MCP pode exibir diretamente ao
+  usuário final — que, para este produto, é brasileiro.
+- **Fragmentação operacional.** As quatro tools de status têm formatos
+  heterogêneos (`count` no STJ vs. `total` nos demais), semânticas
+  implícitas (o que "zero" significa varia por pipeline) e uma ressalva
+  importante — o DJEN lê `sync-manifest.csv` local, não o parquet canônico
+  no Internet Archive, podendo estar atrasado — enterrada na docstring, não
+  no retorno. Um agente precisa chamar as quatro, e já saber essas
+  diferenças de antemão, para montar um panorama.
+- **Ausência do produto principal.** O causaganha já tem um dossiê
+  reconciliado por CNJ (RFC 0005: `processos_unificados.parquet`,
+  `processo_documentos.parquet`, com normalização de CNJ, paginação e
+  apresentação já implementadas no dashboard web). O servidor MCP não expõe
+  nada disso — só panoramas agregados de pipeline, que servem ao operador,
+  não a quem quer saber o que está acontecendo num processo específico.
+
+## 2. Proposta
+
+Dois milestones sequenciais, cada um um PR.
+
+### M1 — Experiência operacional (onboarding, PT-BR, status agregado)
+
+**Onboarding.** Seção no README ("Use o CausaGanha no seu assistente") com:
+configuração copiável do transporte stdio; distinção explícita entre as
+tools locais (determinísticas, sem rede) e `datajud_facetas` (rede real);
+cinco perguntas de exemplo cobrindo os casos de uso reais — "Como estão os
+pipelines?", "Há uploads pendentes?", "Quais são as principais classes do
+TJRO?", "Quais assuntos aparecem mais?", "Os dados locais podem estar
+desatualizados?".
+
+**Português nas superfícies exibidas.** `title`, `description` de cada tool
+e os nomes/descrições de campo em `parameters`/`output_schema` passam para
+português — são texto de produto, não identificador de código. Nomes de
+função Python continuam em inglês (convenção do resto do repo); só o que o
+protocolo MCP expõe ao host muda.
+
+**Uniformização de schema (mudança deliberada, com teste de schema
+exato).** Em vez de reconciliar nomes ad hoc, todas as tools locais passam a
+retornar o mesmo envelope de campos:
+
+```
+encontrado        bool    — False quando não há manifest/dados nesta máquina
+total / contagens  int     — específico de cada pipeline, mas sempre presente
+ultima_atualizacao str|null — ver regra de proveniência abaixo
+fonte              str     — "manifest_local" | "cache_local"
+canonica           bool    — False quando a fonte não é a canônica (IA)
+aviso              str|null — texto livre, só quando há ressalva real
+```
+
+Corrige também uma inconsistência hoje existente: `datajud_status` já
+distingue manifest ausente com `encontrado=False`; `tjro_juris_status` e
+`stj_acordaos_status` transformam arquivo ausente em contagens zeradas — um
+agente não consegue hoje distinguir "pipeline genuinamente vazio" de
+"nenhum dado nesta máquina". Ambos os casos passam a usar `encontrado=False`.
+
+`datajud_facetas` (não é um pipeline local, mas ganha os campos que fazem
+sentido para uma consulta ao vivo): `consultado_em` (timestamp da própria
+consulta, não de um manifest), `tribunal` normalizado em minúsculas no
+retorno.
+
+**`causaganha_status` — tool agregadora.** Uma única tool que retorna todos
+os pipelines locais num envelope comum:
+
+```json
+{
+  "pipelines": [
+    {
+      "nome": "djen",
+      "encontrado": true,
+      "total": 12000,
+      "concluido": 11500,
+      "pendente": 300,
+      "ultima_atualizacao": "2026-07-21T10:00:00-04:00",
+      "fonte": "cache_local",
+      "canonica": false,
+      "aviso": "Pode estar atrás do manifest canônico no Internet Archive."
+    }
+  ]
+}
+```
+
+Nome deliberadamente `status`/`overview`, não `health`: `saudável`/
+`degradado` exigiria regras de negócio e limiares de freshness que ainda não
+existem — inventá-los agora seria arquitetura por atalho.
+
+### M2 — `processo_consultar` (fatia de produto para o usuário final)
+
+Primeira tool MCP que serve diretamente quem quer saber sobre um processo
+específico, não o operador do pipeline:
+
+```
+processo_consultar(cnj, incluir_documentos=true, limite_documentos=10)
+```
+
+Retorno: CNJ normalizado (e mascarado onde a apresentação web já mascara);
+quais fontes têm contribuição para esse CNJ; resumo DJEN; decisão/JURIS;
+STJ quando houver; capa oficial DataJud; timestamp de atualização do
+dataset; documentos mais recentes; `web_url` para abrir o dossiê completo no
+dashboard.
+
+**Fica fora deste RFC como implementação — só como milestone.** Antes de
+escrever código, uma investigação decide a fonte de dados da tool: parquets
+canônicos/remotos do Internet Archive, cache local opcional, ou ambos com
+proveniência explícita (mesma disciplina de `fonte`/`canonica` de M1). A
+investigação também mapeia a semântica já implementada no dashboard web
+(normalização de CNJ, junção de fontes, paginação, freshness — RFC 0005) para
+reaproveitar, não portar TypeScript mecanicamente para Python. Ganha PR
+própria depois de M1.
+
+## 3. Regras específicas (para não abrir atalhos)
+
+- **`causaganha_status` reutiliza as funções/modelos de `service.py` de cada
+  pacote diretamente** (mesma chamada que `datajud_status` etc. já fazem) —
+  nunca chama as quatro tools através do próprio protocolo MCP. Ir por dentro
+  do protocolo para montar uma resposta que o próprio protocolo vai servir de
+  novo é indireção sem propósito, e acopla a tool agregadora ao registro de
+  tools do servidor em vez de à camada de serviço.
+- **Sem `saudável`/`degradado`.** Toda tool de status (individual ou
+  agregada) retorna fatos — `encontrado`, contagens, `ultima_atualizacao`,
+  `fonte`, `canonica`, `aviso` — nunca um veredito. Inferir "saúde" exige
+  limiares de freshness e regras de negócio que este RFC não define.
+- **Manifest ausente em um pipeline gera resultado parcial, não falha
+  agregada.** Em `causaganha_status`, um pipeline com `encontrado=False`
+  aparece normalmente na lista (com contagens zeradas) — nunca derruba a
+  tool inteira nem vira `ToolError`. Ausência de dado local é esperada, não
+  excepcional.
+- **`ultima_atualizacao` tem proveniência precisa, documentada por campo.**
+  Três fontes possíveis, nunca combinadas silenciosamente: timestamp de uma
+  entrada do manifest (`updated_at`, já presente em `SyncManifest`/
+  `ManifestSTJ`/`ManifestJuris`; `ManifestDataJud` guarda o equivalente sob
+  o nome `consultado_em` por entrada — `datajud_status` deriva
+  `ultima_atualizacao` do máximo desses valores, não reintroduz outro nome),
+  metadado de modificação do arquivo (`mtime`, só quando o manifest não
+  guarda timestamp por entrada), ou o horário da própria consulta (caso de
+  `datajud_facetas`, onde não existe manifest — daí o nome `consultado_em`
+  no retorno dessa tool específica, não `ultima_atualizacao`, para deixar
+  claro que é o instante da chamada, não de um dado persistido). Cada tool
+  documenta explicitamente
+  qual das três está usando; nunca apresentar `mtime` do arquivo local como
+  se fosse "quando o pipeline rodou pela última vez" sem identificá-lo como
+  tal.
+
+## 4. Critérios de aceitação
+
+**M1:**
+- README com a seção de onboarding MCP: configuração stdio copiável,
+  distinção tools locais vs. `datajud_facetas`, cinco perguntas de exemplo.
+- `title`/`description`/nomes de campo de todas as tools em português.
+- Envelope `encontrado`/`ultima_atualizacao`/`fonte`/`canonica`/`aviso`
+  presente e testado (schema exato) nas quatro tools locais; `consultado_em`
+  + tribunal normalizado em `datajud_facetas`.
+- `tjro_juris_status`/`stj_acordaos_status` usam `encontrado=False` para
+  manifest ausente (paridade com `datajud_status`), não mais contagem zerada
+  indistinguível de pipeline vazio.
+- `causaganha_status` implementada, chamando `service.py` de cada pacote
+  diretamente (teste que falha se algum dia importar `causaganha_mcp.tools`).
+- Manifest ausente em um pipeline não derruba `causaganha_status` — teste
+  cobrindo esse caso explicitamente.
+- `pytest`, `ruff check`, `ruff format --check` verdes.
+
+**M2 (quando a investigação e a PR acontecerem):**
+- Decisão de fonte de dados documentada (parquet IA / cache local / ambos)
+  antes do primeiro código de `processo_consultar`.
+- `processo_consultar` reaproveita a semântica de normalização/junção/
+  paginação/freshness já implementada no dashboard web (RFC 0005), sem
+  reimplementação paralela divergente.
+- Mesma disciplina de M1: fatos com proveniência, não veredito; `ToolError`
+  estruturado para falha real, resultado parcial para ausência de dado.
+
+## 5. Riscos
+
+- **Uniformizar nomes de campo agora é mudança de schema deliberada, feita
+  antes de haver consumidores reais do servidor.** Adiar isso até depois do
+  onboarding (M1 é justamente o que cria os primeiros consumidores) seria
+  quebra de compatibilidade num momento pior. Coberto com teste de schema
+  exato por tool, não só ausência de campo credencial-like (padrão já
+  existente em `test_tool_schema.py`, RFC 0013).
+- **PT-BR nos textos exibidos ao host é uma escolha de produto, não
+  universal.** Hosts MCP genéricos (não necessariamente usados só por
+  brasileiros) podem preferir inglês. Aceito conscientemente: o produto e a
+  base de usuários são brasileiros; nomes de função/módulo Python
+  continuam em inglês, então o custo de reverter (se necessário) fica
+  isolado nas strings de `title`/`description`/`Field(description=...)`.
+- **`processo_consultar` é a peça de maior risco de escopo.** Fica
+  deliberadamente fora da implementação deste RFC — só a investigação e o
+  contrato de dados entram aqui — para não repetir o erro que RFC 0013
+  evitou na sua própria Fase 3 (misturar fundação com escopo de
+  investigação ainda aberta).

--- a/src/causaganha_mcp/server.py
+++ b/src/causaganha_mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server assembly for ``causaganha_mcp`` (RFC 0013 Fase 3).
+"""FastMCP server assembly for ``causaganha_mcp`` (RFC 0013 Fase 3, RFC 0014).
 
 Tool registration happens explicitly inside ``build_server()``, not as an
 import-time side effect of decorating module-level functions — the same
@@ -8,7 +8,7 @@ this module (a test, a supervisor, another tool) should not get side
 effects it didn't ask for. Each ``tools/*.py`` module exposes a
 ``register(mcp)`` function instead of decorating at import time.
 
-Fase 3A scope: read-only, local, deterministic status tools —
+RFC 0013 Fase 3A scope: read-only, local, deterministic status tools —
 ``datajud_status``, ``tjro_juris_status``, ``stj_acordaos_status``,
 ``djen_backup_status``. None of them touch Internet Archive credentials or
 make network calls; each reads whatever manifest already exists on local
@@ -18,13 +18,19 @@ category (timeout, rate limit, network) from the local/deterministic Fase
 3A foundation, hence ``openWorldHint=True`` on that one tool only. Ingestion/
 upload operations (the full sync, ``drain``, ``consolidate``, ``enrich``
 with upload) stay CLI/CI-only per the RFC — they never become tools.
+
+RFC 0014 M1 adds ``causaganha_status`` (a panorama over the same four local
+pipelines, calling their ``service.py`` directly — never the other tools via
+the MCP protocol itself) and translates every tool's ``title``/
+``description``/output field names to Portuguese, since the product and its
+users are Brazilian and this text can be shown directly to a host's user.
 """
 
 from __future__ import annotations
 
 from fastmcp import FastMCP
 
-from causaganha_mcp.tools import datajud, djen_backup, stj_acordaos, tjro_juris
+from causaganha_mcp.tools import datajud, djen_backup, status, stj_acordaos, tjro_juris
 
 
 def build_server() -> FastMCP:
@@ -32,21 +38,23 @@ def build_server() -> FastMCP:
     mcp = FastMCP(
         name="causaganha_mcp",
         instructions=(
-            "Read-only tools over CausaGanha's four ingestion pipelines "
-            "(djen-backup, tjro-juris, stj-acordaos, datajud). Most tools "
-            "read a local manifest file only — no network call, no "
-            "credentials, no mutation; `datajud_facetas` is the one "
-            "exception, querying the public DataJud API live (still "
-            "read-only, still no credentials in its schema). For ingestion, "
-            "upload, or backfill operations, use the corresponding CLI "
-            "(djen-backup, tjro-juris, stj-acordaos, datajud) or the "
-            "scheduled CI workflows — those are not exposed here by design."
+            "Tools somente-leitura sobre os quatro pipelines de ingestão do "
+            "CausaGanha (djen-backup, tjro-juris, stj-acordaos, datajud), "
+            "mais um panorama agregado (causaganha_status). A maioria lê só "
+            "um manifest local — sem chamada de rede, sem credencial, sem "
+            "mutação; `datajud_facetas` é a exceção, consultando a API "
+            "pública do DataJud ao vivo (ainda somente-leitura, ainda sem "
+            "credencial no schema). Para ingestão, upload ou backfill, use a "
+            "CLI correspondente (djen-backup, tjro-juris, stj-acordaos, "
+            "datajud) ou os workflows agendados — isso não é exposto aqui "
+            "por design."
         ),
     )
     datajud.register(mcp)
     tjro_juris.register(mcp)
     stj_acordaos.register(mcp)
     djen_backup.register(mcp)
+    status.register(mcp)
     return mcp
 
 

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -1,7 +1,8 @@
-"""``datajud_status`` and ``datajud_facetas`` tools (RFC 0013 Fase 3A/3B)."""
+"""``datajud_status`` e ``datajud_facetas`` (RFC 0013 Fase 3A/3B, RFC 0014 M1)."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
@@ -25,107 +26,128 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
-# Internal MCP call budget for `datajud_facetas` — NOT exposed as a tool
-# parameter. `DataJudClient`'s own defaults (timeout=90s, max_retries=5,
-# 2/4/8/16/30s backoff) are tuned for the `enrich` CLI's long-running batch
-# ingestion, where riding out a DataJud hiccup is worth minutes of waiting.
-# An interactive MCP call is a different budget: an unlucky timeout there
-# could keep this tool open for ~10 minutes before producing a ToolError
-# (RFC 0013 Fase 3B review), long enough for a host to give up waiting on
-# the call entirely. These numbers trade some of that ingestion-grade
-# resilience for a call whose worst case — 2 attempts * 15s timeout + ~1s
-# of backoff — stays well under half a minute.
+# Orçamento interno de tempo/retry para a chamada MCP de datajud_facetas —
+# NÃO é um parâmetro da tool. Os defaults do DataJudClient (timeout=90s,
+# max_retries=5, backoff 2/4/8/16/30s) são calibrados para o `enrich` da
+# CLI — ingestão em lote de longa duração, onde vale esperar minutos por um
+# hiccup do DataJud. Uma chamada MCP interativa tem outro orçamento: um
+# timeout azarado poderia deixar esta tool aberta por ~10 minutos antes de
+# produzir o ToolError (RFC 0013 Fase 3B review) — tempo longo o bastante
+# para o host desistir de esperar. Estes números trocam parte dessa
+# resiliência de ingestão por um pior caso — 2 tentativas * 15s de timeout
+# + ~1s de backoff — que fica bem abaixo de meio minuto.
 _FACETAS_TIMEOUT = 15.0
 _FACETAS_MAX_RETRIES = 1
 _FACETAS_BACKOFF_BASE = 1.0
 
-# Second, independent layer of defense: FastMCP's own per-tool deadline
-# (`@mcp.tool(timeout=...)`, backed by `anyio.fail_after`, surfaced to the
-# caller as a generic McpError → ToolError, not one of `_facetas_tool_error`'s
-# tailored messages). The budget above only bounds `DataJudClient`'s own
-# retry loop; this bounds the tool call as a whole, regardless of what
-# happens inside it — a hang the client's own timeout doesn't catch, a
-# future change to the retry budget that drifts it back up, anything.
-# Set comfortably above the tuned client budget's own worst case (~31s) so
-# it stays a backstop: the common failure path should still resolve via
-# the client's own tailored errors well before this fires.
+# Segunda camada de defesa, independente: o deadline nativo do FastMCP na
+# tool (`@mcp.tool(timeout=...)`, via `anyio.fail_after`, que vira um
+# McpError → ToolError genérico, não uma das mensagens tratadas de
+# `_facetas_tool_error`). O orçamento acima só limita o retry loop do
+# DataJudClient; este limita a chamada inteira, incluindo qualquer
+# travamento que o timeout do próprio client não cubra. Definido
+# confortavelmente acima do pior caso do orçamento do client (~31s) para
+# continuar sendo um backstop: o caminho comum de falha deve resolver via
+# as mensagens tratadas do client antes deste disparar.
 _FACETAS_TOOL_TIMEOUT = 45.0
 
 
 class DatajudStatusResult(BaseModel):
-    """Summary of the local DataJud manifest."""
+    """Resumo do manifest local do DataJud."""
 
-    found: bool = Field(description="False when the manifest doesn't exist or has no entries.")
-    total: int = Field(default=0, description="CNJs consulted so far.")
-    ok: int = Field(default=0, description="CNJs whose last consult succeeded.")
-    com_docs: int = Field(default=0, description="Consulted CNJs with at least one document.")
-    sem_docs: int = Field(default=0, description="Consulted CNJs with zero documents found.")
-    com_erro: int = Field(default=0, description="CNJs whose last consult failed.")
+    encontrado: bool = Field(
+        description="False quando o manifest não existe ou não tem nenhuma entrada."
+    )
+    total: int = Field(default=0, description="CNJs consultados até agora.")
+    ok: int = Field(default=0, description="CNJs cuja última consulta teve sucesso.")
+    com_docs: int = Field(default=0, description="CNJs consultados com pelo menos um documento.")
+    sem_docs: int = Field(
+        default=0, description="CNJs consultados sem nenhum documento encontrado."
+    )
+    com_erro: int = Field(default=0, description="CNJs cuja última consulta falhou.")
+    ultima_atualizacao: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) da consulta mais recente registrada no manifest, "
+        "ou None quando não há nenhuma entrada.",
+    )
+    fonte: Literal["manifest_local"] = Field(
+        default="manifest_local", description="Este manifest local é a fonte dos dados."
+    )
+    canonica: bool = Field(
+        default=True,
+        description="True: este manifest é a própria fonte de verdade do pipeline DataJud "
+        "(não há um artefato remoto canônico separado dele).",
+    )
+    aviso: str | None = Field(default=None, description="Ressalva relevante, quando houver.")
 
 
 class DatajudFacetaBucket(BaseModel):
-    """One aggregation bucket returned by ``datajud_facetas``."""
+    """Um grupo (bucket) da agregação retornada por ``datajud_facetas``."""
 
-    chave: str = Field(description="Facet value (e.g. a classe or assunto name).")
-    qtd: int = Field(description="Document count for this value.")
+    chave: str = Field(description="Valor da faceta (ex.: nome de uma classe ou assunto).")
+    qtd: int = Field(description="Quantidade de documentos com esse valor.")
 
 
 class DatajudFacetasResult(BaseModel):
-    """Aggregation of a tribunal's DataJud acervo by one dimension."""
+    """Agregação do acervo de um tribunal por uma dimensão do DataJud."""
 
-    tribunal: str = Field(description="Tribunal queried, lowercase (e.g. 'tjro').")
-    por: str = Field(description="Dimension aggregated by.")
+    tribunal: str = Field(description="Tribunal consultado, normalizado em minúsculas.")
+    por: str = Field(description="Dimensão usada na agregação.")
     total: int = Field(
-        description="Total documents in the tribunal's acervo — all facet "
-        "values, not just the buckets returned below."
+        description="Total de documentos no acervo do tribunal — todos os valores da "
+        "faceta, não só os grupos retornados abaixo."
     )
-    buckets: list[DatajudFacetaBucket] = Field(
-        description="Top facet values by document count, largest first."
+    grupos: list[DatajudFacetaBucket] = Field(
+        description="Principais valores da faceta por quantidade de documentos, maior primeiro."
+    )
+    consultado_em: str = Field(
+        description="Timestamp (ISO 8601) desta própria consulta — não há manifest local "
+        "para datajud_facetas, então não existe um 'última atualização' persistido."
     )
 
 
 def _facetas_tool_error(exc: Exception) -> ToolError:
-    """Map the DataJud client's error taxonomy to a structured ``ToolError``."""
+    """Mapeia a taxonomia de erro do client DataJud para um ``ToolError`` estruturado."""
     if isinstance(exc, DataJudAuthError):
         return ToolError(
-            "DataJud rejected the configured API key (HTTP 401). This is an "
-            "operator-level credential problem, not something retriable from "
-            f"here — fetch a current key at {WIKI_ACESSO_URL} and set the "
-            f"{API_KEY_ENV} environment variable."
+            "O DataJud rejeitou a chave de API configurada (HTTP 401). É um "
+            "problema de credencial do operador, não algo que se resolve "
+            f"tentando de novo — busque uma chave atual em {WIKI_ACESSO_URL} "
+            f"e configure a variável de ambiente {API_KEY_ENV}."
         )
     if isinstance(exc, DataJudRateLimitError):
         return ToolError(
-            "DataJud rate-limited this request past the retry budget. "
-            "Recoverable: wait a bit and call datajud_facetas again."
+            "O DataJud limitou esta requisição além do orçamento de retry. "
+            "Recuperável: espere um pouco e chame datajud_facetas de novo."
         )
     if isinstance(exc, DataJudProtocolError):
-        return ToolError(f"DataJud returned an unparseable response: {exc}")
+        return ToolError(f"O DataJud retornou uma resposta não interpretável: {exc}")
     if isinstance(exc, httpx.TimeoutException | httpx.TransportError):
         return ToolError(
-            "Network error reaching DataJud (timeout or connection failure). "
-            "Recoverable: retry datajud_facetas; if it persists, the DataJud "
-            "API itself may be down."
+            "Erro de rede ao acessar o DataJud (timeout ou falha de conexão). "
+            "Recuperável: tente datajud_facetas de novo; se persistir, a "
+            "própria API do DataJud pode estar fora do ar."
         )
     if isinstance(exc, httpx.HTTPStatusError):
-        return ToolError(f"DataJud returned HTTP {exc.response.status_code} for this query.")
-    # Deliberately doesn't interpolate str(exc): a bare DataJudError here is
-    # the non-transient-ES-error branch of DataJudClient._search_once, whose
-    # message embeds the raw Elasticsearch error payload — not something to
-    # promise as a stable, safe public tool message. The real exception is
-    # still attached via `raise ... from exc` for logs/debugging.
+        return ToolError(f"O DataJud retornou HTTP {exc.response.status_code} para esta consulta.")
+    # Deliberadamente não interpola str(exc): um DataJudError puro aqui é o
+    # ramo de erro de ES não-transiente de DataJudClient._search_once, cuja
+    # mensagem embute o payload cru do Elasticsearch — não é algo para
+    # prometer como mensagem pública estável e segura. A causa real continua
+    # disponível via `raise ... from exc` para logs/depuração.
     return ToolError(
-        "DataJud could not complete this aggregation. Retry later; if the "
-        "error persists, the upstream query may be unavailable."
+        "O DataJud não conseguiu concluir esta agregação. Tente de novo mais "
+        "tarde; se persistir, a consulta upstream pode estar indisponível."
     )
 
 
 def register(mcp: FastMCP) -> None:
-    """Register ``datajud_status`` and ``datajud_facetas`` on *mcp*."""
+    """Registra ``datajud_status`` e ``datajud_facetas`` em *mcp*."""
 
     @mcp.tool(
         name="datajud_status",
         annotations={
-            "title": "DataJud manifest status",
+            "title": "Status do manifest do DataJud",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -133,40 +155,39 @@ def register(mcp: FastMCP) -> None:
         },
     )
     def datajud_status(data_dir: str = str(service.DEFAULT_DATA_DIR)) -> DatajudStatusResult:
-        """Summarize the local DataJud manifest: how many CNJs are consulted and found.
+        """Resume o manifest local do DataJud: quantos CNJs foram consultados e encontrados.
 
-        Reads `datajud-manifest.csv` under `data_dir` from local disk only —
-        no network call, no credentials involved. Use this to check the
-        progress of `datajud enrich` runs (e.g. after the daily
-        `datajud-enrich.yml` cron) without a shell. This tool never triggers
-        a new consult or upload; for that, use the `datajud` CLI's `enrich`
-        command.
+        Lê `datajud-manifest.csv` em `data_dir`, só do disco local — nenhuma
+        chamada de rede, nenhuma credencial envolvida. Use para checar o
+        progresso de execuções do `datajud enrich` (ex.: após o cron diário
+        `datajud-enrich.yml`) sem precisar de um shell. Nunca dispara uma
+        nova consulta ou upload; para isso, use o comando `enrich` da CLI
+        `datajud`. `encontrado=False` (contagens zeradas) quando o manifest
+        ainda não existe ou não tem entradas — não é um erro, só um
+        pipeline vazio.
 
         Args:
-            data_dir: Directory containing the DataJud manifest and parquets.
-                Defaults to "data/datajud", the path the scheduled workflow uses.
-
-        Returns:
-            found=False (all counts zero) when the manifest doesn't exist yet
-            or has no entries — not an error, just an empty pipeline.
+            data_dir: Diretório com o manifest e os parquets do DataJud.
+                Default "data/datajud", o caminho que o workflow agendado usa.
         """
         result = service.manifest_status(Path(data_dir))
         if result is None:
-            return DatajudStatusResult(found=False)
+            return DatajudStatusResult(encontrado=False)
         return DatajudStatusResult(
-            found=True,
+            encontrado=True,
             total=result.total,
             ok=result.ok,
             com_docs=result.com_docs,
             sem_docs=result.sem_docs,
             com_erro=result.com_erro,
+            ultima_atualizacao=result.ultima_atualizacao or None,
         )
 
     @mcp.tool(
         name="datajud_facetas",
         timeout=_FACETAS_TOOL_TIMEOUT,
         annotations={
-            "title": "DataJud facet aggregation",
+            "title": "Agregação por faceta no DataJud",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -177,35 +198,28 @@ def register(mcp: FastMCP) -> None:
         tribunal: str = DEFAULT_TRIBUNAL,
         por: Literal["classe", "assunto", "orgao", "grau", "sistema"] = "classe",
         limite: Annotated[
-            int, Field(ge=1, le=100, description="Max number of buckets to return.")
+            int, Field(ge=1, le=100, description="Máximo de grupos a retornar.")
         ] = 15,
     ) -> DatajudFacetasResult:
-        """Aggregate a tribunal's DataJud acervo by one dimension (classe, assunto, ...).
+        """Agrega o acervo de DataJud de um tribunal por uma dimensão (classe, assunto, ...).
 
-        Queries the live public DataJud API (network call, unlike
-        `datajud_status`) to count documents grouped by *por*, without
-        downloading any document. Use this to answer questions like "what
-        are the top 10 classes in TJRO's acervo?" without fetching or
-        enriching individual processos.
+        Consulta a API pública do DataJud ao vivo (chamada de rede, ao
+        contrário de `datajud_status`) para contar documentos agrupados por
+        *por*, sem baixar nenhum documento. Use para responder perguntas
+        como "quais são as 10 principais classes no acervo do TJRO?" sem
+        buscar ou enriquecer processos individuais. Retorna o total do
+        acervo inteiro mais os `limite` grupos com mais documentos.
+        Um orçamento interno de tempo mais apertado que o do `datajud
+        enrich` da CLI, mais um deadline rígido por chamada, mantêm o pior
+        caso bem abaixo de um minuto, não minutos.
 
         Args:
-            tribunal: Tribunal to query, lowercase (e.g. "tjro"). Defaults to
-                the same tribunal the `datajud` CLI defaults to.
-            por: Dimension to aggregate by.
-            limite: Max buckets to return, 1-100. The `total` field always
-                reflects the full acervo, even when `limite` truncates the
-                bucket list.
-
-        Returns:
-            The full acervo total plus the top `limite` buckets, largest
-            first.
-
-        Raises:
-            A structured tool error (never a raw exception) when DataJud
-            rejects the API key, rate-limits past the retry budget, returns
-            an unparseable body, or is unreachable. Uses a tighter internal
-            timeout/retry budget than the `datajud enrich` CLI, plus a hard
-            per-call deadline — well under a minute worst case, not minutes.
+            tribunal: Tribunal a consultar, minúsculo (ex.: "tjro"). Default
+                o mesmo tribunal que a CLI `datajud` usa por padrão.
+            por: Dimensão da agregação.
+            limite: Máximo de grupos a retornar, 1-100. O campo `total`
+                sempre reflete o acervo inteiro, mesmo quando `limite`
+                corta a lista de grupos.
         """
         try:
             total, buckets = await service.facetas(
@@ -219,10 +233,11 @@ def register(mcp: FastMCP) -> None:
         except (DataJudError, httpx.HTTPError) as exc:
             raise _facetas_tool_error(exc) from exc
         return DatajudFacetasResult(
-            tribunal=tribunal,
+            tribunal=tribunal.lower(),
             por=por,
             total=total,
-            buckets=[
+            grupos=[
                 DatajudFacetaBucket(chave=bucket["chave"], qtd=bucket["qtd"]) for bucket in buckets
             ],
+            consultado_em=datetime.now(UTC).isoformat(timespec="seconds"),
         )

--- a/src/causaganha_mcp/tools/datajud.py
+++ b/src/causaganha_mcp/tools/datajud.py
@@ -154,23 +154,26 @@ def register(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
     )
-    def datajud_status(data_dir: str = str(service.DEFAULT_DATA_DIR)) -> DatajudStatusResult:
+    def datajud_status(
+        diretorio_dados: str = str(service.DEFAULT_DATA_DIR),
+    ) -> DatajudStatusResult:
         """Resume o manifest local do DataJud: quantos CNJs foram consultados e encontrados.
 
-        Lê `datajud-manifest.csv` em `data_dir`, só do disco local — nenhuma
-        chamada de rede, nenhuma credencial envolvida. Use para checar o
-        progresso de execuções do `datajud enrich` (ex.: após o cron diário
-        `datajud-enrich.yml`) sem precisar de um shell. Nunca dispara uma
-        nova consulta ou upload; para isso, use o comando `enrich` da CLI
-        `datajud`. `encontrado=False` (contagens zeradas) quando o manifest
-        ainda não existe ou não tem entradas — não é um erro, só um
-        pipeline vazio.
+        Lê `datajud-manifest.csv` em `diretorio_dados`, só do disco local —
+        nenhuma chamada de rede, nenhuma credencial envolvida. Use para
+        checar o progresso de execuções do `datajud enrich` (ex.: após o
+        cron diário `datajud-enrich.yml`) sem precisar de um shell. Nunca
+        dispara uma nova consulta ou upload; para isso, use o comando
+        `enrich` da CLI `datajud`. `encontrado=False` (contagens zeradas)
+        quando o manifest ainda não existe ou não tem entradas — não é um
+        erro, só um pipeline vazio.
 
         Args:
-            data_dir: Diretório com o manifest e os parquets do DataJud.
-                Default "data/datajud", o caminho que o workflow agendado usa.
+            diretorio_dados: Diretório com o manifest e os parquets do
+                DataJud. Default "data/datajud", o caminho que o workflow
+                agendado usa.
         """
-        result = service.manifest_status(Path(data_dir))
+        result = service.manifest_status(Path(diretorio_dados))
         if result is None:
             return DatajudStatusResult(encontrado=False)
         return DatajudStatusResult(

--- a/src/causaganha_mcp/tools/djen_backup.py
+++ b/src/causaganha_mcp/tools/djen_backup.py
@@ -1,9 +1,9 @@
-"""``djen_backup_status`` tool (RFC 0013 Fase 3A)."""
+"""``djen_backup_status`` (RFC 0013 Fase 3A, RFC 0014 M1)."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -14,23 +14,55 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
-class DjenBackupStatusResult(BaseModel):
-    """Summary of the local DJEN sync manifest."""
+_CANONICAL_NOTE = (
+    "Origem local, não canônica: a fonte de verdade do DJEN é o "
+    "sync-manifest.parquet no Internet Archive (ver "
+    "docs/planning/manifest-source-of-truth.md) — este manifest local "
+    "pode estar atrasado em relação a ele."
+)
 
-    total: int = Field(description="Total (tribunal, date) entries recorded.")
-    uploaded: int = Field(description="Entries already uploaded to Internet Archive.")
-    available: int = Field(description="Entries confirmed available on DJEN, pending upload.")
-    absent: int = Field(description="Entries confirmed absent on DJEN (no publication).")
-    unknown: int = Field(description="Entries not yet checked against DJEN.")
+
+class DjenBackupStatusResult(BaseModel):
+    """Resumo do manifest local de sincronização do DJEN."""
+
+    encontrado: bool = Field(
+        description="False quando o manifest não existe ou não tem nenhuma entrada."
+    )
+    total: int = Field(default=0, description="Total de pares (tribunal, data) registrados.")
+    enviados: int = Field(default=0, description="Entradas já enviadas para o Internet Archive.")
+    disponiveis: int = Field(
+        default=0, description="Entradas confirmadas disponíveis no DJEN, aguardando envio."
+    )
+    ausentes: int = Field(
+        default=0, description="Entradas confirmadas ausentes no DJEN (sem publicação)."
+    )
+    desconhecidos: int = Field(
+        default=0, description="Entradas ainda não verificadas contra o DJEN."
+    )
+    ultima_atualizacao: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) da entrada mais recentemente atualizada no "
+        "manifest, ou None quando não há nenhuma entrada.",
+    )
+    fonte: Literal["cache_local"] = Field(
+        default="cache_local",
+        description="Cache local nesta máquina — não é a fonte canônica (ver `canonica`).",
+    )
+    canonica: Literal[False] = Field(
+        default=False,
+        description="Sempre False: a fonte de verdade do DJEN é o parquet no Internet "
+        "Archive, não este manifest local (ver `aviso`).",
+    )
+    aviso: str | None = Field(default=_CANONICAL_NOTE, description="Ressalva relevante.")
 
 
 def register(mcp: FastMCP) -> None:
-    """Register ``djen_backup_status`` on *mcp*."""
+    """Registra ``djen_backup_status`` em *mcp*."""
 
     @mcp.tool(
         name="djen_backup_status",
         annotations={
-            "title": "DJEN sync manifest status",
+            "title": "Status do manifest de sincronização do DJEN",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -40,28 +72,29 @@ def register(mcp: FastMCP) -> None:
     def djen_backup_status(
         manifest_file: str = str(service.DEFAULT_MANIFEST_FILE),
     ) -> DjenBackupStatusResult:
-        """Summarize the local DJEN sync manifest: coverage across tribunals and dates.
+        """Resume o manifest local de sincronização do DJEN: cobertura por tribunal e data.
 
-        Reads `sync-manifest.csv` from local disk only — no network call, no
-        IA fetch, no credentials involved. The canonical source of truth is
-        the `sync-manifest.parquet` on Internet Archive (see
-        `docs/planning/manifest-source-of-truth.md`); this tool only sees
-        whatever local CSV cache already exists on this machine, which can
-        lag behind IA. Never triggers a sync, upload, or reset; for that, use
-        the `djen-backup` CLI.
+        Lê `sync-manifest.csv` só do disco local — nenhuma chamada de rede,
+        nenhum fetch ao IA, nenhuma credencial envolvida. A fonte canônica
+        é o `sync-manifest.parquet` no Internet Archive (ver
+        `docs/planning/manifest-source-of-truth.md`); esta tool só vê o
+        cache CSV local que já existe nesta máquina, que pode estar
+        atrasado em relação ao IA — daí `canonica=False` e o `aviso` no
+        retorno. Nunca dispara uma sincronização, upload ou reset; para
+        isso, use a CLI `djen-backup`. `encontrado=False` (contagens
+        zeradas) quando o manifest ainda não existe ou não tem entradas.
 
         Args:
-            manifest_file: Path to the local manifest CSV. Defaults to
+            manifest_file: Caminho para o CSV do manifest local. Default
                 "data/sync-manifest.csv".
-
-        Returns:
-            All-zero counts when the manifest doesn't exist yet or is empty.
         """
         result = service.manifest_status(Path(manifest_file))
         return DjenBackupStatusResult(
+            encontrado=result.total > 0,
             total=result.total,
-            uploaded=result.uploaded,
-            available=result.available,
-            absent=result.absent,
-            unknown=result.unknown,
+            enviados=result.uploaded,
+            disponiveis=result.available,
+            ausentes=result.absent,
+            desconhecidos=result.unknown,
+            ultima_atualizacao=result.ultima_atualizacao or None,
         )

--- a/src/causaganha_mcp/tools/djen_backup.py
+++ b/src/causaganha_mcp/tools/djen_backup.py
@@ -70,7 +70,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     def djen_backup_status(
-        manifest_file: str = str(service.DEFAULT_MANIFEST_FILE),
+        arquivo_manifesto: str = str(service.DEFAULT_MANIFEST_FILE),
     ) -> DjenBackupStatusResult:
         """Resume o manifest local de sincronização do DJEN: cobertura por tribunal e data.
 
@@ -85,10 +85,10 @@ def register(mcp: FastMCP) -> None:
         zeradas) quando o manifest ainda não existe ou não tem entradas.
 
         Args:
-            manifest_file: Caminho para o CSV do manifest local. Default
-                "data/sync-manifest.csv".
+            arquivo_manifesto: Caminho para o CSV do manifest local.
+                Default "data/sync-manifest.csv".
         """
-        result = service.manifest_status(Path(manifest_file))
+        result = service.manifest_status(Path(arquivo_manifesto))
         return DjenBackupStatusResult(
             encontrado=result.total > 0,
             total=result.total,

--- a/src/causaganha_mcp/tools/status.py
+++ b/src/causaganha_mcp/tools/status.py
@@ -1,0 +1,237 @@
+"""``causaganha_status`` — panorama agregado dos quatro pipelines (RFC 0014 M1).
+
+Chama `service.py` de cada pacote diretamente (`datajud.service`,
+`tjro_juris.service`, `stj_acordaos.service`, `djen_backup.service`) — nunca
+as tools `*_status` através do próprio protocolo MCP. Ir por dentro do
+protocolo para montar uma resposta que o próprio protocolo vai servir de
+novo seria indireção sem propósito, e acoplaria esta tool ao registro de
+tools do servidor em vez de à camada de serviço (RFC 0014 §3).
+
+Cada pipeline aparece com `total` (comum, sem interpretação) e `contagens`
+— um dict específico do pipeline, com os mesmos nomes de campo que a tool
+`*_status` correspondente já usa. Não existe um "concluído"/"pendente"
+genérico: mapear isso teria exigido decidir, por exemplo, se uma entrada
+`ausente` do DJEN conta como concluída ou pendente — uma interpretação de
+negócio que a RFC 0014 explicitamente não autoriza ainda (§3: "sem
+saudável/degradado", só fatos).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+import datajud.service as datajud_service
+import djen_backup.service as djen_backup_service
+import stj_acordaos.service as stj_acordaos_service
+import tjro_juris.service as tjro_juris_service
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+_TJRO_JURIS_DEFAULT_DATA_DIR = "data/tjro-juris"
+
+_DJEN_CANONICAL_NOTE = (
+    "Origem local, não canônica: a fonte de verdade do DJEN é o "
+    "sync-manifest.parquet no Internet Archive — este manifest local pode "
+    "estar atrasado em relação a ele."
+)
+
+
+class PipelineStatus(BaseModel):
+    """Panorama de um único pipeline dentro do resultado agregado."""
+
+    nome: Literal["djen", "tjro_juris", "stj_acordaos", "datajud"] = Field(
+        description="Identificador do pipeline."
+    )
+    encontrado: bool = Field(
+        description="False quando não há manifest ou dado algum nesta máquina para este pipeline."
+    )
+    total: int = Field(description="Total de itens registrados (unidade específica do pipeline).")
+    contagens: dict[str, int] = Field(
+        description="Contagens específicas deste pipeline, com os mesmos nomes de campo "
+        "que a tool `<pipeline>_status` correspondente retorna."
+    )
+    ultima_atualizacao: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) da entrada mais recentemente atualizada, ou "
+        "None quando não há nenhuma entrada.",
+    )
+    fonte: Literal["manifest_local", "cache_local"] = Field(
+        description="'manifest_local': o manifest é a própria fonte de verdade. "
+        "'cache_local': cache que pode estar atrasado em relação a uma fonte canônica "
+        "remota (ver `canonica`/`aviso`)."
+    )
+    canonica: bool = Field(
+        description="False quando existe uma fonte remota mais autoritativa que este "
+        "manifest local (ver `aviso`)."
+    )
+    aviso: str | None = Field(default=None, description="Ressalva relevante, quando houver.")
+
+
+class CausaganhaStatusResult(BaseModel):
+    """Panorama agregado dos quatro pipelines locais do CausaGanha."""
+
+    pipelines: list[PipelineStatus] = Field(
+        description="Um item por pipeline: djen, tjro_juris, stj_acordaos, datajud."
+    )
+
+
+def _djen_status() -> PipelineStatus:
+    try:
+        result = djen_backup_service.manifest_status(djen_backup_service.DEFAULT_MANIFEST_FILE)
+    except OSError as exc:
+        return PipelineStatus(
+            nome="djen",
+            encontrado=False,
+            total=0,
+            contagens={},
+            fonte="cache_local",
+            canonica=False,
+            aviso=f"Não foi possível ler o manifest local: {exc}",
+        )
+    return PipelineStatus(
+        nome="djen",
+        encontrado=result.total > 0,
+        total=result.total,
+        contagens={
+            "enviados": result.uploaded,
+            "disponiveis": result.available,
+            "ausentes": result.absent,
+            "desconhecidos": result.unknown,
+        },
+        ultima_atualizacao=result.ultima_atualizacao or None,
+        fonte="cache_local",
+        canonica=False,
+        aviso=_DJEN_CANONICAL_NOTE,
+    )
+
+
+def _tjro_juris_status() -> PipelineStatus:
+    try:
+        result = tjro_juris_service.manifest_status(Path(_TJRO_JURIS_DEFAULT_DATA_DIR))
+    except OSError as exc:
+        return PipelineStatus(
+            nome="tjro_juris",
+            encontrado=False,
+            total=0,
+            contagens={},
+            fonte="manifest_local",
+            canonica=True,
+            aviso=f"Não foi possível ler o manifest local: {exc}",
+        )
+    return PipelineStatus(
+        nome="tjro_juris",
+        encontrado=result.total > 0,
+        total=result.total,
+        contagens={"enviados": result.uploaded, "pendentes": result.pending},
+        ultima_atualizacao=result.ultima_atualizacao or None,
+        fonte="manifest_local",
+        canonica=True,
+    )
+
+
+def _stj_acordaos_status() -> PipelineStatus:
+    try:
+        result = stj_acordaos_service.manifest_summary(stj_acordaos_service.DEFAULT_MANIFEST)
+    except OSError as exc:
+        return PipelineStatus(
+            nome="stj_acordaos",
+            encontrado=False,
+            total=0,
+            contagens={},
+            fonte="manifest_local",
+            canonica=True,
+            aviso=f"Não foi possível ler o manifest local: {exc}",
+        )
+    return PipelineStatus(
+        nome="stj_acordaos",
+        encontrado=result.count > 0,
+        total=result.count,
+        contagens={"enviados": result.uploaded, "pendentes": result.pending},
+        ultima_atualizacao=result.ultima_atualizacao or None,
+        fonte="manifest_local",
+        canonica=True,
+    )
+
+
+def _datajud_status() -> PipelineStatus:
+    try:
+        result = datajud_service.manifest_status(datajud_service.DEFAULT_DATA_DIR)
+    except OSError as exc:
+        return PipelineStatus(
+            nome="datajud",
+            encontrado=False,
+            total=0,
+            contagens={},
+            fonte="manifest_local",
+            canonica=True,
+            aviso=f"Não foi possível ler o manifest local: {exc}",
+        )
+    if result is None:
+        return PipelineStatus(
+            nome="datajud",
+            encontrado=False,
+            total=0,
+            contagens={},
+            fonte="manifest_local",
+            canonica=True,
+        )
+    return PipelineStatus(
+        nome="datajud",
+        encontrado=True,
+        total=result.total,
+        contagens={
+            "ok": result.ok,
+            "com_docs": result.com_docs,
+            "sem_docs": result.sem_docs,
+            "com_erro": result.com_erro,
+        },
+        ultima_atualizacao=result.ultima_atualizacao or None,
+        fonte="manifest_local",
+        canonica=True,
+    )
+
+
+def register(mcp: FastMCP) -> None:
+    """Registra ``causaganha_status`` em *mcp*."""
+
+    @mcp.tool(
+        name="causaganha_status",
+        annotations={
+            "title": "Panorama agregado dos pipelines do CausaGanha",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
+    def causaganha_status() -> CausaganhaStatusResult:
+        """Panorama dos quatro pipelines locais (DJEN, TJRO JURIS, STJ, DataJud) numa só chamada.
+
+        Chama a mesma camada de serviço que `djen_backup_status`,
+        `tjro_juris_status`, `stj_acordaos_status` e `datajud_status` usam
+        individualmente — não invoca essas tools via protocolo MCP. Um
+        pipeline sem manifest nesta máquina aparece com `encontrado=False`
+        e contagens vazias; isso nunca falha a chamada inteira, mesmo que
+        outros pipelines tenham dado.
+
+        Não retorna um veredito de saúde ("saudável"/"degradado") — só
+        fatos: total, contagens específicas do pipeline, quando foi
+        atualizado pela última vez, se a fonte é o próprio manifest ou um
+        cache que pode estar atrasado, e uma ressalva quando existir. Para
+        contagens detalhadas por pipeline, prefira a tool `<pipeline>_status`
+        individual — esta é um resumo amplo, não um substituto.
+        """
+        return CausaganhaStatusResult(
+            pipelines=[
+                _djen_status(),
+                _tjro_juris_status(),
+                _stj_acordaos_status(),
+                _datajud_status(),
+            ]
+        )

--- a/src/causaganha_mcp/tools/status.py
+++ b/src/causaganha_mcp/tools/status.py
@@ -14,6 +14,19 @@ genérico: mapear isso teria exigido decidir, por exemplo, se uma entrada
 `ausente` do DJEN conta como concluída ou pendente — uma interpretação de
 negócio que a RFC 0014 explicitamente não autoriza ainda (§3: "sem
 saudável/degradado", só fatos).
+
+Um pipeline quebrado (I/O ou manifest malformado) vira resultado parcial
+(`encontrado=False` + `aviso`), nunca falha a chamada inteira — cada
+`_<pipeline>_status()` captura só o que seu loader pode genuinamente
+levantar, nunca `except Exception`: `OSError` (falha de I/O, comum às
+quatro) mais `ManifestFormatError` só em `tjro_juris`/`datajud`, cujos
+loaders usam `csv.DictReader` com acesso direto a colunas
+(`row["tipo"]`/`int(row["docs"])` podem levantar `KeyError`/`ValueError`
+num CSV malformado — ver `ManifestFormatError` em cada `manifest.py`).
+`djen_backup`/`stj_acordaos` não precisam disso: seus loaders já usam
+`split(",")` posicional com checagem de tamanho de linha e
+`try/except ValueError` ao redor de cada conversão numérica/de data,
+então uma linha malformada é só ignorada, nunca uma exceção.
 """
 
 from __future__ import annotations
@@ -27,6 +40,8 @@ import datajud.service as datajud_service
 import djen_backup.service as djen_backup_service
 import stj_acordaos.service as stj_acordaos_service
 import tjro_juris.service as tjro_juris_service
+from datajud.manifest import ManifestFormatError as DatajudManifestFormatError
+from tjro_juris.manifest import ManifestFormatError as TjroJurisManifestFormatError
 
 
 if TYPE_CHECKING:
@@ -114,7 +129,7 @@ def _djen_status() -> PipelineStatus:
 def _tjro_juris_status() -> PipelineStatus:
     try:
         result = tjro_juris_service.manifest_status(Path(_TJRO_JURIS_DEFAULT_DATA_DIR))
-    except OSError as exc:
+    except (OSError, TjroJurisManifestFormatError) as exc:
         return PipelineStatus(
             nome="tjro_juris",
             encontrado=False,
@@ -162,7 +177,7 @@ def _stj_acordaos_status() -> PipelineStatus:
 def _datajud_status() -> PipelineStatus:
     try:
         result = datajud_service.manifest_status(datajud_service.DEFAULT_DATA_DIR)
-    except OSError as exc:
+    except (OSError, DatajudManifestFormatError) as exc:
         return PipelineStatus(
             nome="datajud",
             encontrado=False,

--- a/src/causaganha_mcp/tools/stj_acordaos.py
+++ b/src/causaganha_mcp/tools/stj_acordaos.py
@@ -1,9 +1,9 @@
-"""``stj_acordaos_status`` tool (RFC 0013 Fase 3A)."""
+"""``stj_acordaos_status`` (RFC 0013 Fase 3A, RFC 0014 M1)."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -15,20 +15,41 @@ if TYPE_CHECKING:
 
 
 class StjAcordaosStatusResult(BaseModel):
-    """Summary of the local STJ acórdãos manifest."""
+    """Resumo do manifest local de acórdãos do STJ."""
 
-    count: int = Field(description="Total files (ZIPs, monthly JSONs, parquet) recorded.")
-    uploaded: int = Field(description="Files already uploaded to Internet Archive.")
-    pending: int = Field(description="Files downloaded/built but not yet uploaded.")
+    encontrado: bool = Field(
+        description="False quando o manifest não existe ou não tem nenhuma entrada."
+    )
+    total: int = Field(
+        default=0, description="Total de arquivos (ZIPs, JSONs mensais, parquet) registrados."
+    )
+    enviados: int = Field(default=0, description="Arquivos já enviados para o Internet Archive.")
+    pendentes: int = Field(
+        default=0, description="Arquivos baixados/construídos mas ainda não enviados."
+    )
+    ultima_atualizacao: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) da entrada mais recentemente atualizada no "
+        "manifest, ou None quando não há nenhuma entrada.",
+    )
+    fonte: Literal["manifest_local"] = Field(
+        default="manifest_local", description="Este manifest local é a fonte dos dados."
+    )
+    canonica: bool = Field(
+        default=True,
+        description="True: este manifest é a própria fonte de verdade do pipeline STJ "
+        "acórdãos (não há um artefato remoto canônico separado dele).",
+    )
+    aviso: str | None = Field(default=None, description="Ressalva relevante, quando houver.")
 
 
 def register(mcp: FastMCP) -> None:
-    """Register ``stj_acordaos_status`` on *mcp*."""
+    """Registra ``stj_acordaos_status`` em *mcp*."""
 
     @mcp.tool(
         name="stj_acordaos_status",
         annotations={
-            "title": "STJ acórdãos manifest status",
+            "title": "Status do manifest de acórdãos do STJ",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -38,26 +59,27 @@ def register(mcp: FastMCP) -> None:
     def stj_acordaos_status(
         manifest_path: str = str(service.DEFAULT_MANIFEST),
     ) -> StjAcordaosStatusResult:
-        """Summarize the local STJ acórdãos manifest: files tracked and upload progress.
+        """Resume o manifest local de acórdãos do STJ: arquivos rastreados e progresso de envio.
 
-        Reads the manifest CSV from local disk only — no network call, no
-        credentials involved. Per-file details (filename, tipo, status) are
-        intentionally omitted from this summary to keep the response small;
-        use the `stj-acordaos` CLI's `status` command for the full listing.
-        Never triggers a new download or upload; for that, use the
-        `stj-acordaos` CLI's `download`/`upload` commands.
+        Lê o manifest CSV só do disco local — nenhuma chamada de rede,
+        nenhuma credencial envolvida. Detalhes por arquivo (nome, tipo,
+        status) são deliberadamente omitidos deste resumo para manter a
+        resposta pequena; use o comando `status` da CLI `stj-acordaos` para
+        a listagem completa. Nunca dispara um novo download ou upload; para
+        isso, use os comandos `download`/`upload` da CLI `stj-acordaos`.
+        `encontrado=False` (contagens zeradas) quando o manifest ainda não
+        existe ou não tem entradas — não é um erro, só um pipeline vazio.
 
         Args:
-            manifest_path: Path to `stj-manifest.csv`. Defaults to
-                "data/stj/stj-manifest.csv", the path the scheduled workflow uses.
-
-        Returns:
-            All-zero counts when the manifest doesn't exist yet or is empty —
-            not an error, just an empty pipeline.
+            manifest_path: Caminho para `stj-manifest.csv`. Default
+                "data/stj/stj-manifest.csv", o caminho que o workflow
+                agendado usa.
         """
         result = service.manifest_summary(Path(manifest_path))
         return StjAcordaosStatusResult(
-            count=result.count,
-            uploaded=result.uploaded,
-            pending=result.pending,
+            encontrado=result.count > 0,
+            total=result.count,
+            enviados=result.uploaded,
+            pendentes=result.pending,
+            ultima_atualizacao=result.ultima_atualizacao or None,
         )

--- a/src/causaganha_mcp/tools/stj_acordaos.py
+++ b/src/causaganha_mcp/tools/stj_acordaos.py
@@ -57,7 +57,7 @@ def register(mcp: FastMCP) -> None:
         },
     )
     def stj_acordaos_status(
-        manifest_path: str = str(service.DEFAULT_MANIFEST),
+        caminho_manifesto: str = str(service.DEFAULT_MANIFEST),
     ) -> StjAcordaosStatusResult:
         """Resume o manifest local de acórdãos do STJ: arquivos rastreados e progresso de envio.
 
@@ -71,11 +71,11 @@ def register(mcp: FastMCP) -> None:
         existe ou não tem entradas — não é um erro, só um pipeline vazio.
 
         Args:
-            manifest_path: Caminho para `stj-manifest.csv`. Default
+            caminho_manifesto: Caminho para `stj-manifest.csv`. Default
                 "data/stj/stj-manifest.csv", o caminho que o workflow
                 agendado usa.
         """
-        result = service.manifest_summary(Path(manifest_path))
+        result = service.manifest_summary(Path(caminho_manifesto))
         return StjAcordaosStatusResult(
             encontrado=result.count > 0,
             total=result.count,

--- a/src/causaganha_mcp/tools/tjro_juris.py
+++ b/src/causaganha_mcp/tools/tjro_juris.py
@@ -1,9 +1,9 @@
-"""``tjro_juris_status`` tool (RFC 0013 Fase 3A)."""
+"""``tjro_juris_status`` (RFC 0013 Fase 3A, RFC 0014 M1)."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -14,27 +14,44 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
-# tjro_juris.service has no DEFAULT_DATA_DIR constant — the CLI takes
-# data_dir as a required positional argument. This matches the literal
-# argv tjro-sync.yml uses ("tjro-juris crawl data/tjro-juris ...").
+# tjro_juris.service não tem uma constante DEFAULT_DATA_DIR — a CLI recebe
+# data_dir como argumento posicional obrigatório. Isso replica o argv literal
+# que tjro-sync.yml usa ("tjro-juris crawl data/tjro-juris ...").
 _DEFAULT_DATA_DIR = "data/tjro-juris"
 
 
 class TjroJurisStatusResult(BaseModel):
-    """Summary of the local TJRO JURIS manifest."""
+    """Resumo do manifest local do TJRO JURIS."""
 
-    total: int = Field(description="Total (tipo, mes_ano) windows recorded.")
-    uploaded: int = Field(description="Windows already uploaded to Internet Archive.")
-    pending: int = Field(description="Windows crawled but not yet uploaded.")
+    encontrado: bool = Field(
+        description="False quando o manifest não existe ou não tem nenhuma entrada."
+    )
+    total: int = Field(default=0, description="Total de janelas (tipo, mês/ano) registradas.")
+    enviados: int = Field(default=0, description="Janelas já enviadas para o Internet Archive.")
+    pendentes: int = Field(default=0, description="Janelas coletadas mas ainda não enviadas.")
+    ultima_atualizacao: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) da entrada mais recentemente atualizada no "
+        "manifest, ou None quando não há nenhuma entrada.",
+    )
+    fonte: Literal["manifest_local"] = Field(
+        default="manifest_local", description="Este manifest local é a fonte dos dados."
+    )
+    canonica: bool = Field(
+        default=True,
+        description="True: este manifest é a própria fonte de verdade do pipeline TJRO "
+        "JURIS (não há um artefato remoto canônico separado dele).",
+    )
+    aviso: str | None = Field(default=None, description="Ressalva relevante, quando houver.")
 
 
 def register(mcp: FastMCP) -> None:
-    """Register ``tjro_juris_status`` on *mcp*."""
+    """Registra ``tjro_juris_status`` em *mcp*."""
 
     @mcp.tool(
         name="tjro_juris_status",
         annotations={
-            "title": "TJRO JURIS manifest status",
+            "title": "Status do manifest do TJRO JURIS",
             "readOnlyHint": True,
             "destructiveHint": False,
             "idempotentHint": True,
@@ -42,25 +59,26 @@ def register(mcp: FastMCP) -> None:
         },
     )
     def tjro_juris_status(data_dir: str = _DEFAULT_DATA_DIR) -> TjroJurisStatusResult:
-        """Summarize the local TJRO JURIS manifest: crawled windows and upload progress.
+        """Resume o manifest local do TJRO JURIS: janelas coletadas e progresso de envio.
 
-        Reads `tjro-juris-manifest.csv` under `data_dir` from local disk
-        only — no network call, no credentials involved. Use this to check
-        progress of the daily `tjro-sync.yml` backfill (`--desde-ano 1988`)
-        without a shell. Never triggers a new crawl or upload; for that, use
-        the `tjro-juris` CLI's `crawl`/`upload` commands.
+        Lê `tjro-juris-manifest.csv` em `data_dir`, só do disco local —
+        nenhuma chamada de rede, nenhuma credencial envolvida. Use para
+        checar o progresso do backfill diário do `tjro-sync.yml`
+        (`--desde-ano 1988`) sem precisar de um shell. Nunca dispara uma
+        nova coleta ou upload; para isso, use os comandos `crawl`/`upload`
+        da CLI `tjro-juris`. `encontrado=False` (contagens zeradas) quando
+        o manifest ainda não existe ou não tem entradas — não é um erro,
+        só um pipeline vazio.
 
         Args:
-            data_dir: Directory containing the manifest and parquets.
-                Defaults to "data/tjro-juris", the path the scheduled workflow uses.
-
-        Returns:
-            All-zero counts when the manifest doesn't exist yet or is empty —
-            not an error, just an empty pipeline.
+            data_dir: Diretório com o manifest e os parquets. Default
+                "data/tjro-juris", o caminho que o workflow agendado usa.
         """
         result = service.manifest_status(Path(data_dir))
         return TjroJurisStatusResult(
+            encontrado=result.total > 0,
             total=result.total,
-            uploaded=result.uploaded,
-            pending=result.pending,
+            enviados=result.uploaded,
+            pendentes=result.pending,
+            ultima_atualizacao=result.ultima_atualizacao or None,
         )

--- a/src/causaganha_mcp/tools/tjro_juris.py
+++ b/src/causaganha_mcp/tools/tjro_juris.py
@@ -58,12 +58,12 @@ def register(mcp: FastMCP) -> None:
             "openWorldHint": False,
         },
     )
-    def tjro_juris_status(data_dir: str = _DEFAULT_DATA_DIR) -> TjroJurisStatusResult:
+    def tjro_juris_status(diretorio_dados: str = _DEFAULT_DATA_DIR) -> TjroJurisStatusResult:
         """Resume o manifest local do TJRO JURIS: janelas coletadas e progresso de envio.
 
-        Lê `tjro-juris-manifest.csv` em `data_dir`, só do disco local —
-        nenhuma chamada de rede, nenhuma credencial envolvida. Use para
-        checar o progresso do backfill diário do `tjro-sync.yml`
+        Lê `tjro-juris-manifest.csv` em `diretorio_dados`, só do disco
+        local — nenhuma chamada de rede, nenhuma credencial envolvida. Use
+        para checar o progresso do backfill diário do `tjro-sync.yml`
         (`--desde-ano 1988`) sem precisar de um shell. Nunca dispara uma
         nova coleta ou upload; para isso, use os comandos `crawl`/`upload`
         da CLI `tjro-juris`. `encontrado=False` (contagens zeradas) quando
@@ -71,10 +71,11 @@ def register(mcp: FastMCP) -> None:
         só um pipeline vazio.
 
         Args:
-            data_dir: Diretório com o manifest e os parquets. Default
-                "data/tjro-juris", o caminho que o workflow agendado usa.
+            diretorio_dados: Diretório com o manifest e os parquets.
+                Default "data/tjro-juris", o caminho que o workflow
+                agendado usa.
         """
-        result = service.manifest_status(Path(data_dir))
+        result = service.manifest_status(Path(diretorio_dados))
         return TjroJurisStatusResult(
             encontrado=result.total > 0,
             total=result.total,

--- a/src/datajud/manifest.py
+++ b/src/datajud/manifest.py
@@ -24,6 +24,10 @@ STATUS_OK = "ok"
 STATUS_ERRO = "erro"
 
 
+class ManifestFormatError(ValueError):
+    """The local manifest CSV is malformed (missing column, non-numeric docs, ...)."""
+
+
 @dataclass
 class ManifestDataJudEntry:
     """Consultation state of a single (cnj, tribunal) pair."""
@@ -48,20 +52,29 @@ class ManifestDataJud:
 
     @classmethod
     def load_local(cls, path: Path) -> ManifestDataJud:
-        """Load the manifest from a local CSV file (empty when missing)."""
+        """Load the manifest from a local CSV file (empty when missing).
+
+        Raises `ManifestFormatError` on a malformed row (missing column,
+        non-numeric `docs`) instead of leaking a bare `KeyError`/
+        `ValueError` — callers get one nominal exception type to handle.
+        """
         manifest = cls()
         if not path.exists():
             return manifest
         text = path.read_text(encoding="utf-8")
         reader = csv.DictReader(io.StringIO(text))
         for row in reader:
-            entry = ManifestDataJudEntry(
-                cnj=row["cnj"],
-                tribunal=row["tribunal"],
-                docs=int(row.get("docs", 0) or 0),
-                consultado_em=row.get("consultado_em", ""),
-                status=row.get("status", ""),
-            )
+            try:
+                entry = ManifestDataJudEntry(
+                    cnj=row["cnj"],
+                    tribunal=row["tribunal"],
+                    docs=int(row.get("docs", 0) or 0),
+                    consultado_em=row.get("consultado_em", ""),
+                    status=row.get("status", ""),
+                )
+            except (KeyError, ValueError) as exc:
+                msg = f"malformed row in {path}: {exc}"
+                raise ManifestFormatError(msg) from exc
             manifest._entries[cls._key(entry.cnj, entry.tribunal)] = entry
         return manifest
 

--- a/src/datajud/service.py
+++ b/src/datajud/service.py
@@ -350,6 +350,7 @@ class ManifestStatus:
     total: int
     ok: int
     com_docs: int
+    ultima_atualizacao: str = ""
 
     @property
     def sem_docs(self) -> int:
@@ -370,4 +371,7 @@ def manifest_status(data_dir: Path) -> ManifestStatus | None:
         return None
     ok = sum(1 for e in entries if e.status == STATUS_OK)
     com_docs = sum(1 for e in entries if e.status == STATUS_OK and e.docs > 0)
-    return ManifestStatus(total=len(entries), ok=ok, com_docs=com_docs)
+    ultima_atualizacao = max((e.consultado_em for e in entries if e.consultado_em), default="")
+    return ManifestStatus(
+        total=len(entries), ok=ok, com_docs=com_docs, ultima_atualizacao=ultima_atualizacao
+    )

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -80,6 +80,7 @@ class ManifestCounts(NamedTuple):
     available: int
     absent: int
     unknown: int
+    ultima_atualizacao: str = ""
 
 
 @dataclass
@@ -111,6 +112,11 @@ class SyncManifest:
         # Populated lazily on first counts() call; bulk operations (build,
         # prune, load_*) reset to None to force a full rebuild.
         self._counts_tally: dict[str, int] | None = None
+        # Latest entry updated_at, cached alongside _counts_tally (same
+        # rebuild-on-counts()/invalidate-on-mutation lifecycle) so exposing
+        # it doesn't reintroduce the O(N)-per-call cost the tally cache
+        # exists to avoid.
+        self._latest_updated_at: str | None = None
         # Cache of (tribunal, year) pairs that have uploaded entries
         self._uploaded_items: set[tuple[str, int]] | None = None
         # Keys mutated by mark_* since the last successful segment flush.
@@ -190,7 +196,15 @@ class SyncManifest:
     def _invalidate_caches(self) -> None:
         # Force a full rebuild on next counts() / has_uploaded_entries() call.
         self._counts_tally = None
+        self._latest_updated_at = None
         self._uploaded_items = None
+
+    def _track_latest_updated_at(self, updated_at: str) -> None:
+        """Incrementally extend the cached latest updated_at (no-op if not built yet)."""
+        if self._counts_tally is None:
+            return
+        if self._latest_updated_at is None or updated_at > self._latest_updated_at:
+            self._latest_updated_at = updated_at
 
     def prune(self) -> int:
         """Remove weekend entries (unless already uploaded). Returns count removed."""
@@ -221,6 +235,7 @@ class SyncManifest:
                     entry.updated_at = now
                     self._adjust_counts(old_cat, "uploaded")
                     self._track_uploaded(tribunal, d.year)
+                    self._track_latest_updated_at(now)
                     self._dirty.add(k)
                     changed += 1
         return changed
@@ -240,6 +255,7 @@ class SyncManifest:
                 entry.djen_status = interpret_djen_raw(raw)
                 entry.updated_at = datetime.now(UTC).isoformat(timespec="seconds")
                 self._adjust_counts(old_cat, self._categorize(entry))
+                self._track_latest_updated_at(entry.updated_at)
                 self._dirty.add(k)
 
     async def mark_djen_available(self, tribunal: str, d: date) -> None:
@@ -261,6 +277,7 @@ class SyncManifest:
                 entry.updated_at = datetime.now(UTC).isoformat(timespec="seconds")
                 self._adjust_counts(old_cat, "uploaded")
                 self._track_uploaded(tribunal, d.year)
+                self._track_latest_updated_at(entry.updated_at)
                 self._dirty.add(k)
 
     # ── Query methods ────────────────────────────────────────────────
@@ -279,9 +296,13 @@ class SyncManifest:
         """Return aggregate counts. O(1) when tally is warm, O(N) on rebuild."""
         if self._counts_tally is None:
             tally = {"uploaded": 0, "available": 0, "absent": 0, "unknown": 0}
+            latest = ""
             for e in self._entries.values():
                 tally[self._categorize(e)] += 1
+                if e.updated_at and e.updated_at > latest:
+                    latest = e.updated_at
             self._counts_tally = tally
+            self._latest_updated_at = latest
         t = self._counts_tally
         return ManifestCounts(
             total=len(self._entries),
@@ -289,6 +310,7 @@ class SyncManifest:
             available=t["available"],
             absent=t["absent"],
             unknown=t["unknown"],
+            ultima_atualizacao=self._latest_updated_at or "",
         )
 
     def items_needing_ia_check(self) -> list[tuple[str, int]]:

--- a/src/stj_acordaos/service.py
+++ b/src/stj_acordaos/service.py
@@ -294,6 +294,7 @@ class ManifestSummary:
     count: int
     uploaded: int
     rows: list[dict]
+    ultima_atualizacao: str = ""
 
     @property
     def pending(self) -> int:
@@ -307,4 +308,7 @@ def manifest_summary(manifest_path: Path) -> ManifestSummary:
     count = manifest.load()
     rows = manifest.to_df() if count else []
     uploaded = sum(1 for r in rows if r["ia_status"] == "uploaded")
-    return ManifestSummary(count=count, uploaded=uploaded, rows=rows)
+    ultima_atualizacao = max((r["updated_at"] for r in rows if r["updated_at"]), default="")
+    return ManifestSummary(
+        count=count, uploaded=uploaded, rows=rows, ultima_atualizacao=ultima_atualizacao
+    )

--- a/src/tjro_juris/manifest.py
+++ b/src/tjro_juris/manifest.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 HEADER = "tipo,mes_ano,ia_status,n_docs,updated_at"
 
 
+class ManifestFormatError(ValueError):
+    """The local manifest CSV is malformed (missing column, non-numeric n_docs, ...)."""
+
+
 @dataclass
 class ManifestJurisEntry:
     """A single (tipo, mes_ano) pair with crawl/upload status."""
@@ -40,20 +44,29 @@ class ManifestJuris:
 
     @classmethod
     def load_local(cls, path: Path) -> ManifestJuris:
-        """Load manifest from a local CSV file."""
+        """Load manifest from a local CSV file.
+
+        Raises `ManifestFormatError` on a malformed row (missing column,
+        non-numeric `n_docs`) instead of leaking a bare `KeyError`/
+        `ValueError` — callers get one nominal exception type to handle.
+        """
         m = cls()
         if not path.exists():
             return m
         text = path.read_text(encoding="utf-8")
         reader = csv.DictReader(io.StringIO(text))
         for row in reader:
-            entry = ManifestJurisEntry(
-                tipo=row["tipo"],
-                mes_ano=row["mes_ano"],
-                ia_status=row.get("ia_status", ""),
-                n_docs=int(row.get("n_docs", 0) or 0),
-                updated_at=row.get("updated_at", ""),
-            )
+            try:
+                entry = ManifestJurisEntry(
+                    tipo=row["tipo"],
+                    mes_ano=row["mes_ano"],
+                    ia_status=row.get("ia_status", ""),
+                    n_docs=int(row.get("n_docs", 0) or 0),
+                    updated_at=row.get("updated_at", ""),
+                )
+            except (KeyError, ValueError) as exc:
+                msg = f"malformed row in {path}: {exc}"
+                raise ManifestFormatError(msg) from exc
             m._entries[cls._key(entry.tipo, entry.mes_ano)] = entry
         return m
 

--- a/src/tjro_juris/service.py
+++ b/src/tjro_juris/service.py
@@ -334,6 +334,7 @@ class ManifestStatus:
 
     total: int
     uploaded: int
+    ultima_atualizacao: str = ""
 
     @property
     def pending(self) -> int:
@@ -346,7 +347,10 @@ def manifest_status(data_dir: Path) -> ManifestStatus:
     manifest = ManifestJuris.load_local(manifest_path(data_dir))
     entries = manifest.all_entries()
     uploaded = sum(1 for e in entries if e.ia_status == "uploaded")
-    return ManifestStatus(total=len(entries), uploaded=uploaded)
+    ultima_atualizacao = max((e.updated_at for e in entries if e.updated_at), default="")
+    return ManifestStatus(
+        total=len(entries), uploaded=uploaded, ultima_atualizacao=ultima_atualizacao
+    )
 
 
 def consolidate_parquets(data_dir: Path, year: int) -> tuple[Path, int]:

--- a/tests/causaganha_mcp/test_causaganha_status.py
+++ b/tests/causaganha_mcp/test_causaganha_status.py
@@ -122,3 +122,29 @@ async def test_one_pipeline_erroring_does_not_fail_the_whole_call(mcp, tmp_path,
     assert djen_entry.aviso is not None
     # The other three pipelines are unaffected.
     assert len(result.pipelines) == 4
+
+
+async def test_a_genuinely_malformed_manifest_also_yields_a_partial_result(
+    mcp, tmp_path, monkeypatch
+):
+    """RFC 0014 review: OSError alone doesn't cover a malformed (parseable-as-file,
+    unparseable-as-manifest) CSV — `ManifestJuris.load_local` raises `ManifestFormatError`
+    (KeyError/ValueError translated at the parsing boundary) for a row missing the
+    `tipo` column, which must be caught the same way as an I/O failure.
+    """
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data" / "tjro-juris"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tjro-juris-manifest.csv").write_text(
+        "mes_ano,ia_status,n_docs,updated_at\n2024-01,uploaded,10,\n", encoding="utf-8"
+    )
+
+    fn = await _status_fn(mcp)
+    result = fn()  # must not raise
+
+    tjro_juris_entry = next(p for p in result.pipelines if p.nome == "tjro_juris")
+    assert tjro_juris_entry.encontrado is False
+    assert tjro_juris_entry.aviso is not None
+    # The other three pipelines are unaffected.
+    assert len(result.pipelines) == 4
+    assert {p.nome for p in result.pipelines} == {"djen", "tjro_juris", "stj_acordaos", "datajud"}

--- a/tests/causaganha_mcp/test_causaganha_status.py
+++ b/tests/causaganha_mcp/test_causaganha_status.py
@@ -1,0 +1,124 @@
+"""Behavior tests for ``causaganha_status`` (RFC 0014 M1).
+
+Three specific guarantees from RFC 0014 §3, each with its own test:
+service-layer reuse (never the sibling tools via the MCP protocol), no
+health verdict (facts only), and a missing manifest producing a partial
+result per-pipeline rather than failing the whole call.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import causaganha_mcp.tools.status as status_module
+from causaganha_mcp.server import build_server
+from datajud.manifest import STATUS_OK, ManifestDataJud
+
+
+@pytest.fixture
+def mcp():
+    return build_server()
+
+
+async def _status_fn(mcp):
+    tool = await mcp.get_tool("causaganha_status")
+    return tool.fn
+
+
+async def test_all_four_pipelines_appear_even_with_no_local_data(mcp, tmp_path, monkeypatch):
+    # Redirect every pipeline's default path into an empty tmp_path so this
+    # test doesn't depend on (or pollute) the repo's real data/ directory.
+    monkeypatch.chdir(tmp_path)
+
+    fn = await _status_fn(mcp)
+    result = fn()
+
+    names = [p.nome for p in result.pipelines]
+    assert names == ["djen", "tjro_juris", "stj_acordaos", "datajud"]
+    for pipeline in result.pipelines:
+        assert pipeline.encontrado is False
+        assert pipeline.total == 0
+        assert pipeline.ultima_atualizacao is None
+    # DJEN alone is a local cache of a canonical remote source.
+    djen = result.pipelines[0]
+    assert djen.fonte == "cache_local"
+    assert djen.canonica is False
+    assert djen.aviso is not None
+    for pipeline in result.pipelines[1:]:
+        assert pipeline.fonte == "manifest_local"
+        assert pipeline.canonica is True
+
+
+async def test_datajud_pipeline_reflects_a_populated_manifest(mcp, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data" / "datajud"
+    data_dir.mkdir(parents=True)
+    manifest = ManifestDataJud.load_local(data_dir / "datajud-manifest.csv")
+    manifest.upsert("00000010220248220001", "tjro", docs=2, status=STATUS_OK)
+    manifest.save_local(data_dir / "datajud-manifest.csv")
+
+    fn = await _status_fn(mcp)
+    result = fn()
+
+    datajud_entry = next(p for p in result.pipelines if p.nome == "datajud")
+    assert datajud_entry.encontrado is True
+    assert datajud_entry.total == 1
+    assert datajud_entry.contagens == {"ok": 1, "com_docs": 1, "sem_docs": 0, "com_erro": 0}
+    assert datajud_entry.ultima_atualizacao is not None
+
+
+async def test_no_health_verdict_field_anywhere_in_the_schema(mcp) -> None:
+    """RFC 0014 §3: facts only — no invented 'saudável'/'degradado' field."""
+    tool = await mcp.get_tool("causaganha_status")
+    schema_text = str(tool.output_schema)
+    for banned in ("saudavel", "saúde", "health", "degradado", "status_geral"):
+        assert banned not in schema_text.lower()
+
+
+def test_reuses_service_layer_directly_not_the_other_tools_via_mcp() -> None:
+    """RFC 0014 §3: call service.py directly, never the sibling tools via MCP.
+
+    A source-level guard, not a behavioral one — the point is that
+    `tools/status.py` must not import the other `causaganha_mcp.tools.*`
+    modules or reach for `get_tool`/`call_tool`/a `fastmcp.Client`, which
+    would mean routing an in-process call through the MCP protocol just to
+    build a response the protocol is about to serve again.
+    """
+    source = inspect.getsource(status_module)
+    assert "causaganha_mcp.tools" not in source
+    assert "get_tool" not in source
+    assert "call_tool" not in source
+    assert "Client(" not in source
+    # Positive check: it does import every package's plain service module.
+    for module in (
+        "datajud.service",
+        "djen_backup.service",
+        "stj_acordaos.service",
+        "tjro_juris.service",
+    ):
+        assert module in source
+
+
+async def test_one_pipeline_erroring_does_not_fail_the_whole_call(mcp, tmp_path, monkeypatch):
+    """RFC 0014 §3: a broken manifest on one pipeline yields a partial result, not a crash."""
+    monkeypatch.chdir(tmp_path)
+
+    # A directory where djen's manifest file is expected raises OSError
+    # (IsADirectoryError, a subclass) on the read — a stand-in for "local
+    # disk is unhappy" without needing to actually corrupt a real file.
+    from djen_backup import service as djen_backup_service
+
+    broken_path = tmp_path / "data" / "sync-manifest.csv"
+    broken_path.mkdir(parents=True)
+    monkeypatch.setattr(djen_backup_service, "DEFAULT_MANIFEST_FILE", broken_path)
+
+    fn = await _status_fn(mcp)
+    result = fn()  # must not raise
+
+    djen_entry = next(p for p in result.pipelines if p.nome == "djen")
+    assert djen_entry.encontrado is False
+    assert djen_entry.aviso is not None
+    # The other three pipelines are unaffected.
+    assert len(result.pipelines) == 4

--- a/tests/causaganha_mcp/test_datajud_facetas.py
+++ b/tests/causaganha_mcp/test_datajud_facetas.py
@@ -1,4 +1,4 @@
-"""Behavior tests for the ``datajud_facetas`` MCP tool (RFC 0013 Fase 3B).
+"""Behavior tests for the ``datajud_facetas`` MCP tool (RFC 0013 Fase 3B, RFC 0014 M1).
 
 Unlike Fase 3A's status tools, `facetas` hits a real HTTP endpoint (the
 public DataJud API) — so these tests mock it with `respx` (the same pattern
@@ -15,6 +15,10 @@ payload-free public messages that survive `mask_error_details=True`
 `ToolError` with a bare "Error calling tool ..." in that mode), rather than
 leaking `str(exc)` — which for at least one DataJud exception embeds the
 raw Elasticsearch error payload.
+
+Error messages are now in Portuguese (RFC 0014 M1) — the `match=` regexes
+below use short, stable substrings, not full sentences, to avoid the tests
+becoming a second copy of the prose.
 """
 
 from __future__ import annotations
@@ -50,7 +54,7 @@ async def _facetas_fn(mcp):
     return tool.fn
 
 
-async def test_facetas_success_returns_total_and_buckets(mcp) -> None:
+async def test_facetas_success_returns_total_and_grupos(mcp) -> None:
     fn = await _facetas_fn(mcp)
     with respx.mock() as router:
         router.post(ENDPOINT).respond(
@@ -61,10 +65,20 @@ async def test_facetas_success_returns_total_and_buckets(mcp) -> None:
     assert result.tribunal == "tjro"
     assert result.por == "classe"
     assert result.total == 42
-    assert [(b.chave, b.qtd) for b in result.buckets] == [
+    assert [(g.chave, g.qtd) for g in result.grupos] == [
         ("Procedimento Comum Cível", 30),
         ("Execução", 12),
     ]
+    assert result.consultado_em  # non-empty ISO timestamp of this call
+
+
+async def test_facetas_normalizes_tribunal_to_lowercase(mcp) -> None:
+    fn = await _facetas_fn(mcp)
+    with respx.mock() as router:
+        router.post(ENDPOINT).respond(200, json=_facetas_payload(0, []))
+        result = await fn(tribunal="TJRO", por="classe", limite=15)
+
+    assert result.tribunal == "tjro"
 
 
 async def test_facetas_auth_error_becomes_tool_error(mcp) -> None:
@@ -88,7 +102,7 @@ async def test_facetas_rate_limit_exhaustion_becomes_tool_error(mcp, monkeypatch
     fn = await _facetas_fn(mcp)
     with respx.mock() as router:
         router.post(ENDPOINT).respond(429)
-        with pytest.raises(ToolError, match="rate-limited"):
+        with pytest.raises(ToolError, match="limitou esta requisição"):
             await fn(tribunal="tjro", por="classe", limite=15)
 
 
@@ -108,7 +122,7 @@ async def test_facetas_es_rejection_exhaustion_becomes_tool_error(mcp, monkeypat
             200,
             json={"error": {"root_cause": [{"type": "es_rejected_execution_exception"}]}},
         )
-        with pytest.raises(ToolError, match="rate-limited"):
+        with pytest.raises(ToolError, match="limitou esta requisição"):
             await fn(tribunal="tjro", por="classe", limite=15)
 
 
@@ -126,7 +140,7 @@ async def test_facetas_generic_es_error_becomes_a_safe_tool_error(mcp) -> None:
             200,
             json={"error": {"root_cause": [{"type": "query_shard_exception"}]}},
         )
-        with pytest.raises(ToolError, match="could not complete this aggregation") as exc_info:
+        with pytest.raises(ToolError, match="não conseguiu concluir esta agregação") as exc_info:
             await fn(tribunal="tjro", por="classe", limite=15)
         assert "query_shard_exception" not in str(exc_info.value)
 
@@ -166,7 +180,7 @@ async def test_facetas_network_error_becomes_tool_error(mcp, monkeypatch) -> Non
     fn = await _facetas_fn(mcp)
     with respx.mock() as router:
         router.post(ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
-        with pytest.raises(ToolError, match="Network error"):
+        with pytest.raises(ToolError, match="Erro de rede"):
             await fn(tribunal="tjro", por="classe", limite=15)
 
 
@@ -177,7 +191,7 @@ async def test_facetas_non_json_response_becomes_tool_error(mcp) -> None:
         router.post(ENDPOINT).respond(
             200, content=b"<html>blocked by WAF</html>", headers={"content-type": "text/html"}
         )
-        with pytest.raises(ToolError, match="unparseable"):
+        with pytest.raises(ToolError, match="não interpretável"):
             await fn(tribunal="tjro", por="classe", limite=15)
 
 

--- a/tests/causaganha_mcp/test_stdio_transport.py
+++ b/tests/causaganha_mcp/test_stdio_transport.py
@@ -53,7 +53,7 @@ async def test_stj_acordaos_status_over_real_stdio_does_not_corrupt_json_rpc(
     with caplog.at_level(logging.WARNING, logger="mcp.client.stdio"):
         async with Client(transport) as client:
             result = await client.call_tool(
-                "stj_acordaos_status", {"manifest_path": str(manifest_path)}
+                "stj_acordaos_status", {"caminho_manifesto": str(manifest_path)}
             )
 
     assert result.data.total == 1
@@ -74,7 +74,7 @@ async def test_djen_backup_status_over_real_stdio_does_not_corrupt_json_rpc(
     with caplog.at_level(logging.WARNING, logger="mcp.client.stdio"):
         async with Client(transport) as client:
             result = await client.call_tool(
-                "djen_backup_status", {"manifest_file": str(manifest_file)}
+                "djen_backup_status", {"arquivo_manifesto": str(manifest_file)}
             )
 
     assert result.data.total == 1

--- a/tests/causaganha_mcp/test_stdio_transport.py
+++ b/tests/causaganha_mcp/test_stdio_transport.py
@@ -56,8 +56,8 @@ async def test_stj_acordaos_status_over_real_stdio_does_not_corrupt_json_rpc(
                 "stj_acordaos_status", {"manifest_path": str(manifest_path)}
             )
 
-    assert result.data.count == 1
-    assert result.data.uploaded == 1
+    assert result.data.total == 1
+    assert result.data.enviados == 1
     assert not any("Failed to parse" in r.message for r in caplog.records), caplog.text
 
 
@@ -78,5 +78,5 @@ async def test_djen_backup_status_over_real_stdio_does_not_corrupt_json_rpc(
             )
 
     assert result.data.total == 1
-    assert result.data.uploaded == 1
+    assert result.data.enviados == 1
     assert not any("Failed to parse" in r.message for r in caplog.records), caplog.text

--- a/tests/causaganha_mcp/test_tool_behavior.py
+++ b/tests/causaganha_mcp/test_tool_behavior.py
@@ -1,4 +1,4 @@
-"""Behavior tests for causaganha_mcp status tools (RFC 0013 Fase 3A).
+"""Behavior tests for causaganha_mcp status tools (RFC 0013 Fase 3A, RFC 0014 M1).
 
 Calls each tool's underlying function directly (`tool.fn(...)`) against a
 manifest fixture built with the same package's own manifest API — no
@@ -40,8 +40,11 @@ async def _tool_fn(mcp, name: str):
 async def test_datajud_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "datajud_status")
     result = fn(data_dir=str(tmp_path / "datajud"))
-    assert result.found is False
+    assert result.encontrado is False
     assert result.total == 0
+    assert result.ultima_atualizacao is None
+    assert result.fonte == "manifest_local"
+    assert result.canonica is True
 
 
 async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
@@ -56,12 +59,13 @@ async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "datajud_status")
     result = fn(data_dir=str(data_dir))
 
-    assert result.found is True
+    assert result.encontrado is True
     assert result.total == 3
     assert result.ok == 2
     assert result.com_docs == 1
     assert result.sem_docs == 1
     assert result.com_erro == 1
+    assert result.ultima_atualizacao is not None
 
 
 # ── tjro_juris_status ───────────────────────────────────────────────────
@@ -70,9 +74,11 @@ async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
 async def test_tjro_juris_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "tjro_juris_status")
     result = fn(data_dir=str(tmp_path / "tjro-juris"))
+    assert result.encontrado is False
     assert result.total == 0
-    assert result.uploaded == 0
-    assert result.pending == 0
+    assert result.enviados == 0
+    assert result.pendentes == 0
+    assert result.ultima_atualizacao is None
 
 
 async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None:
@@ -88,9 +94,11 @@ async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None
     fn = await _tool_fn(mcp, "tjro_juris_status")
     result = fn(data_dir=str(data_dir))
 
+    assert result.encontrado is True
     assert result.total == 2
-    assert result.uploaded == 1
-    assert result.pending == 1
+    assert result.enviados == 1
+    assert result.pendentes == 1
+    assert result.ultima_atualizacao is not None
 
 
 # ── stj_acordaos_status ─────────────────────────────────────────────────
@@ -99,9 +107,11 @@ async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None
 async def test_stj_acordaos_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "stj_acordaos_status")
     result = fn(manifest_path=str(tmp_path / "stj-manifest.csv"))
-    assert result.count == 0
-    assert result.uploaded == 0
-    assert result.pending == 0
+    assert result.encontrado is False
+    assert result.total == 0
+    assert result.enviados == 0
+    assert result.pendentes == 0
+    assert result.ultima_atualizacao is None
 
 
 async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> None:
@@ -114,9 +124,11 @@ async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> No
     fn = await _tool_fn(mcp, "stj_acordaos_status")
     result = fn(manifest_path=str(manifest_path))
 
-    assert result.count == 2
-    assert result.uploaded == 1
-    assert result.pending == 1
+    assert result.encontrado is True
+    assert result.total == 2
+    assert result.enviados == 1
+    assert result.pendentes == 1
+    assert result.ultima_atualizacao is not None
 
 
 # ── djen_backup_status ──────────────────────────────────────────────────
@@ -125,11 +137,16 @@ async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> No
 async def test_djen_backup_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "djen_backup_status")
     result = fn(manifest_file=str(tmp_path / "sync-manifest.csv"))
+    assert result.encontrado is False
     assert result.total == 0
-    assert result.uploaded == 0
-    assert result.available == 0
-    assert result.absent == 0
-    assert result.unknown == 0
+    assert result.enviados == 0
+    assert result.disponiveis == 0
+    assert result.ausentes == 0
+    assert result.desconhecidos == 0
+    assert result.ultima_atualizacao is None
+    assert result.fonte == "cache_local"
+    assert result.canonica is False
+    assert result.aviso is not None
 
 
 async def test_djen_backup_status_populated_manifest(mcp, tmp_path: Path) -> None:
@@ -150,8 +167,13 @@ async def test_djen_backup_status_populated_manifest(mcp, tmp_path: Path) -> Non
     fn = await _tool_fn(mcp, "djen_backup_status")
     result = fn(manifest_file=str(manifest_file))
 
+    assert result.encontrado is True
     assert result.total == 4
-    assert result.uploaded == 1
-    assert result.available == 1
-    assert result.absent == 1
-    assert result.unknown == 1
+    assert result.enviados == 1
+    assert result.disponiveis == 1
+    assert result.ausentes == 1
+    assert result.desconhecidos == 1
+    assert result.ultima_atualizacao == "2026-01-03T00:00:00"
+    assert result.fonte == "cache_local"
+    assert result.canonica is False
+    assert result.aviso is not None

--- a/tests/causaganha_mcp/test_tool_behavior.py
+++ b/tests/causaganha_mcp/test_tool_behavior.py
@@ -39,7 +39,7 @@ async def _tool_fn(mcp, name: str):
 
 async def test_datajud_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "datajud_status")
-    result = fn(data_dir=str(tmp_path / "datajud"))
+    result = fn(diretorio_dados=str(tmp_path / "datajud"))
     assert result.encontrado is False
     assert result.total == 0
     assert result.ultima_atualizacao is None
@@ -57,7 +57,7 @@ async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
     manifest.save_local(data_dir / "datajud-manifest.csv")
 
     fn = await _tool_fn(mcp, "datajud_status")
-    result = fn(data_dir=str(data_dir))
+    result = fn(diretorio_dados=str(data_dir))
 
     assert result.encontrado is True
     assert result.total == 3
@@ -73,7 +73,7 @@ async def test_datajud_status_populated_manifest(mcp, tmp_path: Path) -> None:
 
 async def test_tjro_juris_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "tjro_juris_status")
-    result = fn(data_dir=str(tmp_path / "tjro-juris"))
+    result = fn(diretorio_dados=str(tmp_path / "tjro-juris"))
     assert result.encontrado is False
     assert result.total == 0
     assert result.enviados == 0
@@ -92,7 +92,7 @@ async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None
     manifest.save_local(data_dir / "tjro-juris-manifest.csv")
 
     fn = await _tool_fn(mcp, "tjro_juris_status")
-    result = fn(data_dir=str(data_dir))
+    result = fn(diretorio_dados=str(data_dir))
 
     assert result.encontrado is True
     assert result.total == 2
@@ -106,7 +106,7 @@ async def test_tjro_juris_status_populated_manifest(mcp, tmp_path: Path) -> None
 
 async def test_stj_acordaos_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "stj_acordaos_status")
-    result = fn(manifest_path=str(tmp_path / "stj-manifest.csv"))
+    result = fn(caminho_manifesto=str(tmp_path / "stj-manifest.csv"))
     assert result.encontrado is False
     assert result.total == 0
     assert result.enviados == 0
@@ -122,7 +122,7 @@ async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> No
     manifest.save()
 
     fn = await _tool_fn(mcp, "stj_acordaos_status")
-    result = fn(manifest_path=str(manifest_path))
+    result = fn(caminho_manifesto=str(manifest_path))
 
     assert result.encontrado is True
     assert result.total == 2
@@ -136,7 +136,7 @@ async def test_stj_acordaos_status_populated_manifest(mcp, tmp_path: Path) -> No
 
 async def test_djen_backup_status_empty_manifest(mcp, tmp_path: Path) -> None:
     fn = await _tool_fn(mcp, "djen_backup_status")
-    result = fn(manifest_file=str(tmp_path / "sync-manifest.csv"))
+    result = fn(arquivo_manifesto=str(tmp_path / "sync-manifest.csv"))
     assert result.encontrado is False
     assert result.total == 0
     assert result.enviados == 0
@@ -165,7 +165,7 @@ async def test_djen_backup_status_populated_manifest(mcp, tmp_path: Path) -> Non
     assert manifest.load_from_disk(manifest_file) == 4
 
     fn = await _tool_fn(mcp, "djen_backup_status")
-    result = fn(manifest_file=str(manifest_file))
+    result = fn(arquivo_manifesto=str(manifest_file))
 
     assert result.encontrado is True
     assert result.total == 4

--- a/tests/causaganha_mcp/test_tool_schema.py
+++ b/tests/causaganha_mcp/test_tool_schema.py
@@ -9,11 +9,14 @@ and no credential ever appears in a tool's input or output schema — not
 though — unlike the Fase 3A tools — it makes a real network call
 (`openWorldHint=True`), so it stays in the same read-only/no-credential bar.
 
-RFC 0014 M1 adds `causaganha_status` and renames every tool's output fields
-to Portuguese (`encontrado`, `ultima_atualizacao`, `fonte`, `canonica`,
-`aviso`, ...) — a deliberate schema change made before any real consumer
-exists (RFC 0014 §2), locked here with an exact-property-set test per tool
-so a future edit can't silently drop or rename an envelope field.
+RFC 0014 M1 adds `causaganha_status` and renames every tool's output *and
+input* fields to Portuguese (`encontrado`, `ultima_atualizacao`, `fonte`,
+`canonica`, `aviso`, `diretorio_dados`, `caminho_manifesto`,
+`arquivo_manifesto`, ...) — a deliberate schema change made before any real
+consumer exists (RFC 0014 §2), locked here with an exact-property-set test
+per tool (both `parameters` and `output_schema`) so a future edit can't
+silently drop or rename an envelope field, or leave an English identifier
+in the input schema while only the output gets translated.
 """
 
 from __future__ import annotations
@@ -48,6 +51,18 @@ _EXPECTED_OUTPUT_FIELDS = {
     | {"enviados", "disponiveis", "ausentes", "desconhecidos"},
     "datajud_facetas": {"tribunal", "por", "total", "grupos", "consultado_em"},
     "causaganha_status": {"pipelines"},
+}
+
+# Input parameter names are product text too (RFC 0014 review) — an English
+# `data_dir` sitting in `parameters.properties` while the output is all
+# Portuguese would be exactly the half-translated schema the review flagged.
+_EXPECTED_INPUT_FIELDS = {
+    "datajud_status": {"diretorio_dados"},
+    "tjro_juris_status": {"diretorio_dados"},
+    "stj_acordaos_status": {"caminho_manifesto"},
+    "djen_backup_status": {"arquivo_manifesto"},
+    "datajud_facetas": {"tribunal", "por", "limite"},
+    "causaganha_status": set(),
 }
 
 
@@ -101,6 +116,13 @@ async def test_tool_output_schema_has_exactly_the_expected_fields(mcp, name) -> 
     tool = await mcp.get_tool(name)
     assert tool is not None
     assert _property_names(tool.output_schema) == _EXPECTED_OUTPUT_FIELDS[name]
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+async def test_tool_input_schema_has_exactly_the_expected_fields(mcp, name) -> None:
+    tool = await mcp.get_tool(name)
+    assert tool is not None
+    assert _property_names(tool.parameters) == _EXPECTED_INPUT_FIELDS[name]
 
 
 async def test_facetas_por_enum_matches_facet_fields(mcp) -> None:

--- a/tests/causaganha_mcp/test_tool_schema.py
+++ b/tests/causaganha_mcp/test_tool_schema.py
@@ -1,4 +1,4 @@
-"""Schema-level guarantees for causaganha_mcp tools (RFC 0013 Fase 3A/3B).
+"""Schema-level guarantees for causaganha_mcp tools (RFC 0013 Fase 3A/3B, RFC 0014 M1).
 
 Fase 3A's explicit acceptance bar: every tool is read-only (`readOnlyHint`),
 and no credential ever appears in a tool's input or output schema — not
@@ -8,6 +8,12 @@ and no credential ever appears in a tool's input or output schema — not
 `datajud_facetas` is read-only too (it aggregates, never mutates) even
 though — unlike the Fase 3A tools — it makes a real network call
 (`openWorldHint=True`), so it stays in the same read-only/no-credential bar.
+
+RFC 0014 M1 adds `causaganha_status` and renames every tool's output fields
+to Portuguese (`encontrado`, `ultima_atualizacao`, `fonte`, `canonica`,
+`aviso`, ...) — a deliberate schema change made before any real consumer
+exists (RFC 0014 §2), locked here with an exact-property-set test per tool
+so a future edit can't silently drop or rename an envelope field.
 """
 
 from __future__ import annotations
@@ -24,9 +30,25 @@ TOOL_NAMES = [
     "tjro_juris_status",
     "stj_acordaos_status",
     "djen_backup_status",
+    "causaganha_status",
 ]
 
 _CREDENTIAL_SUBSTRINGS = ("key", "secret", "token", "credential", "password")
+
+# Locks the RFC 0014 M1 envelope: every local status tool exposes exactly
+# this field set, no more, no less. `causaganha_status` and `datajud_facetas`
+# have their own shapes (aggregate/live-query), asserted separately below.
+_ENVELOPE_FIELDS = {"encontrado", "total", "ultima_atualizacao", "fonte", "canonica", "aviso"}
+
+_EXPECTED_OUTPUT_FIELDS = {
+    "datajud_status": _ENVELOPE_FIELDS | {"ok", "com_docs", "sem_docs", "com_erro"},
+    "tjro_juris_status": _ENVELOPE_FIELDS | {"enviados", "pendentes"},
+    "stj_acordaos_status": _ENVELOPE_FIELDS | {"enviados", "pendentes"},
+    "djen_backup_status": _ENVELOPE_FIELDS
+    | {"enviados", "disponiveis", "ausentes", "desconhecidos"},
+    "datajud_facetas": {"tribunal", "por", "total", "grupos", "consultado_em"},
+    "causaganha_status": {"pipelines"},
+}
 
 
 def _property_names(schema: dict | None) -> set[str]:
@@ -72,6 +94,13 @@ async def test_server_exposes_exactly_the_known_tools(mcp) -> None:
     """No ingestion/upload tool exists — every tool here is read-only."""
     tools = await mcp.list_tools()
     assert {t.name for t in tools} == set(TOOL_NAMES)
+
+
+@pytest.mark.parametrize("name", TOOL_NAMES)
+async def test_tool_output_schema_has_exactly_the_expected_fields(mcp, name) -> None:
+    tool = await mcp.get_tool(name)
+    assert tool is not None
+    assert _property_names(tool.output_schema) == _EXPECTED_OUTPUT_FIELDS[name]
 
 
 async def test_facetas_por_enum_matches_facet_fields(mcp) -> None:

--- a/tests/datajud/test_datajud_manifest.py
+++ b/tests/datajud/test_datajud_manifest.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from datajud.manifest import STATUS_ERRO, STATUS_OK, ManifestDataJud
+import pytest
+
+from datajud.manifest import HEADER, STATUS_ERRO, STATUS_OK, ManifestDataJud, ManifestFormatError
 
 
 if TYPE_CHECKING:
@@ -13,6 +15,22 @@ if TYPE_CHECKING:
 
 
 CNJ = "00000010220248220001"
+
+
+def test_load_local_missing_column_raises_manifest_format_error(tmp_path: Path) -> None:
+    path = tmp_path / "datajud-manifest.csv"
+    path.write_text("tribunal,docs,consultado_em,status\ntjro,3,,ok\n", encoding="utf-8")
+
+    with pytest.raises(ManifestFormatError, match="cnj"):
+        ManifestDataJud.load_local(path)
+
+
+def test_load_local_non_numeric_docs_raises_manifest_format_error(tmp_path: Path) -> None:
+    path = tmp_path / "datajud-manifest.csv"
+    path.write_text(f"{HEADER}\n{CNJ},tjro,not-a-number,,ok\n", encoding="utf-8")
+
+    with pytest.raises(ManifestFormatError):
+        ManifestDataJud.load_local(path)
 
 
 def test_roundtrip_preserves_entries(tmp_path: Path):

--- a/tests/test_data_contract_manifest.py
+++ b/tests/test_data_contract_manifest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from djen_backup.manifest import SyncManifest, interpret_djen_raw
+from djen_backup.manifest import ManifestCounts, SyncManifest, interpret_djen_raw
 
 
 FIXTURE = Path("tests/fixtures/manifest_contract_rows.csv")
@@ -35,7 +35,14 @@ def test_manifest_fixture_load_counts_and_queries() -> None:
     loaded = manifest.load_from_csv(FIXTURE.read_text(encoding="utf-8"), overwrite=True)
 
     assert loaded == 6
-    assert manifest.counts() == (6, 1, 1, 2, 2)
+    assert manifest.counts() == ManifestCounts(
+        total=6,
+        uploaded=1,
+        available=1,
+        absent=2,
+        unknown=2,
+        ultima_atualizacao="2026-04-03T12:00:00+00:00",
+    )
     assert manifest.has_uploaded_entries("tjsp", 2026) is True
     assert manifest.entries_needing_upload()
 
@@ -79,7 +86,14 @@ TJRO,2026-04-03,,confirmed,200,2026-04-03T14:00:00+00:00"""
     applied = manifest.apply_segment_csv(segment)
 
     assert applied == 3
-    assert manifest.counts() == (6, 2, 2, 1, 1)
+    assert manifest.counts() == ManifestCounts(
+        total=6,
+        uploaded=2,
+        available=2,
+        absent=1,
+        unknown=1,
+        ultima_atualizacao="2026-04-03T14:00:00+00:00",
+    )
     assert manifest.get_status("TJSP", date(2026, 4, 3)).djen_raw == "403"  # type: ignore[union-attr]
     assert manifest.get_status("TJSP", date(2026, 4, 2)).ia_status == "uploaded"  # type: ignore[union-attr]
     assert manifest.get_status("TJRO", date(2026, 4, 3)).djen_status == "available"  # type: ignore[union-attr]

--- a/tests/tjro_juris/test_juris_manifest.py
+++ b/tests/tjro_juris/test_juris_manifest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tjro_juris.manifest import HEADER, ManifestJuris, ManifestJurisEntry
+import pytest
+
+from tjro_juris.manifest import HEADER, ManifestFormatError, ManifestJuris, ManifestJurisEntry
 
 
 if TYPE_CHECKING:
@@ -14,6 +16,22 @@ if TYPE_CHECKING:
 def test_load_local_missing_file_returns_empty_manifest(tmp_path: Path) -> None:
     m = ManifestJuris.load_local(tmp_path / "nope.csv")
     assert m.all_entries() == []
+
+
+def test_load_local_missing_column_raises_manifest_format_error(tmp_path: Path) -> None:
+    path = tmp_path / "tjro-juris-manifest.csv"
+    path.write_text("mes_ano,ia_status,n_docs,updated_at\n2024-01,uploaded,10,\n", encoding="utf-8")
+
+    with pytest.raises(ManifestFormatError, match="tipo"):
+        ManifestJuris.load_local(path)
+
+
+def test_load_local_non_numeric_n_docs_raises_manifest_format_error(tmp_path: Path) -> None:
+    path = tmp_path / "tjro-juris-manifest.csv"
+    path.write_text(f"{HEADER}\nACÓRDÃO,2024-01,uploaded,not-a-number,\n", encoding="utf-8")
+
+    with pytest.raises(ManifestFormatError):
+        ManifestJuris.load_local(path)
 
 
 def test_save_load_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

RFC 0013 (#849–#853) construiu a fundação do servidor `causaganha_mcp`: cinco tools read-only. Esta PR fecha o escopo da RFC 0013 (Fase 3 fica marcada como concluída — só a Fase 4, Typer→Cyclopts, segue pendente) e abre a **RFC 0014 — MCP como superfície de produto** com o primeiro milestone (M1): tornar o servidor descobrível e coerente, antes de qualquer tool nova de produto (`processo_consultar` fica para uma PR própria, com investigação prévia).

**O que muda:**

- **`causaganha_status`** — nova tool que dá um panorama dos quatro pipelines locais numa só chamada. Chama `service.py` de cada pacote diretamente (`datajud.service`, `tjro_juris.service`, `stj_acordaos.service`, `djen_backup.service`) — nunca as outras tools através do protocolo MCP (guardado por um teste de introspecção de source). Um pipeline sem manifest gera resultado parcial (`encontrado=false`), nunca falha a chamada inteira. Sem veredito de saúde — só fatos.
- **Envelope comum nas 4 tools locais**: `encontrado`, `ultima_atualizacao`, `fonte`, `canonica`, `aviso`. `tjro_juris_status`/`stj_acordaos_status` passam a usar `encontrado=False` para manifest ausente — antes viravam contagem zerada, indistinguível de "pipeline genuinamente vazio" (paridade com `datajud_status`, que já fazia isso). `datajud_facetas` ganha `consultado_em` e `tribunal` normalizado em minúsculas.
- **`ultima_atualizacao`** computado na camada de serviço a partir do `updated_at`/`consultado_em` já existente por entrada — proveniência documentada, nunca `mtime` de arquivo apresentado como "quando o pipeline rodou". Em `djen_backup`, o cache do tally (`_counts_tally`) foi estendido para cobrir o novo campo, evitando reintroduzir o scan O(N)-por-chamada que esse cache existe para evitar (`manifest.counts()` é chamado no loop quente do engine).
- **Título, descrição e nomes de campo de todas as 6 tools traduzidos para português** — é texto de produto (pode aparecer direto na interface do host MCP), não identificador de código.
- **README**: seção "Use o CausaGanha no seu assistente" com configuração stdio copiável, distinção entre tools locais e `datajud_facetas` (a única com chamada de rede), e cinco perguntas de exemplo. `causaganha-mcp` entra na tabela de entry points.

**Testes novos/atualizados:**

- Schema exato por tool (trava o envelope do RFC 0014 antes de existir consumidor real).
- Guard de reuso de service layer para `causaganha_status` (a fonte não pode importar `causaganha_mcp.tools` nem chamar `get_tool`/`call_tool`/`Client(`).
- Resultado parcial de `causaganha_status` quando um pipeline tem manifest quebrado (não falha a chamada).
- Ausência de campo "saúde"/"status_geral" no schema.
- Todos os testes de comportamento/schema/stdio existentes atualizados para os novos nomes de campo em português.

## Test plan

- [x] `uv run pytest -q` (suíte completa) — verde
- [x] `uv run ruff check .` — sem findings
- [x] `uv run ruff format --check .` — sem findings
- [x] Smoke test manual do servidor (`build_server()` + listagem de tools + chamada de `causaganha_status`)

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. — N/A, não toca CLI/argv, só o servidor MCP e sua camada de serviço.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_