### PR TITLE
RFC 0014 M2: processo_consultar via indice_processual.parquet (redesign)

### DIFF
--- a/docs/rfc/0005-processo-como-recurso.md
+++ b/docs/rfc/0005-processo-como-recurso.md
@@ -1,12 +1,76 @@
 # RFC 0005 — Processo como recurso unificado (reconciliação DJEN × JURIS × STJ)
 
-- **Status:** Proposto
+- **Status:** Implementado — modelo de dados redesenhado (ver Emenda abaixo,
+  RFC 0014 M2, 2026-07-22)
 - **Data:** 2026-06-26
 - **Depende de:** RFC 0002 (STJ), RFC 0003 (TJRO JURIS), RFC 0004 (embeddings)
 - **Escopo:** Modelo de dados, pipeline de reconciliação e contrato de UI para
   tratar o **processo judicial** (identificado pelo número CNJ) como o recurso
   central do causaganha, agregando contribuições das três fontes — DJEN,
   TJRO JURIS e STJ — em uma visão unificada.
+
+## Emenda (2026-07-22, RFC 0014 M2) — índice fino em vez de tabela larga
+
+**O modelo de dados descrito em §3–§5 abaixo não é o que foi implementado.**
+Esta seção documenta o que mudou e por quê; §1–§10 ficam como registro
+histórico da proposta original (a motivação do produto — processo como
+recurso unificado por CNJ — continua válida e é o que foi entregue; só o
+*schema* de armazenamento mudou).
+
+**O que mudou.** Em vez de uma tabela larga `processos_unificados.parquet`
+(uma linha por processo, colunas prefixadas por fonte, com `processo_documentos
+.parquet` como tabela auxiliar 1:n) publicada como artefato canônico, o
+sistema publica **`indice_processual.parquet`** — um índice fino, cross-fonte,
+generalizando o padrão que a própria tabela `processos` do DJEN já usava
+(`causaganha/consolidate/schema_registry.py`: `comunicacoes` guarda o
+registro completo, `processos` só aponta para ele por CNJ). Schema:
+
+```
+numero_processo  : string   — CNJ normalizado, 20 dígitos
+fonte            : string   — "djen" | "juris" | "stj" | "datajud"
+registro_id      : string   — chave do registro na fonte (natural quando
+                               existe — id_documento no JURIS, id no STJ;
+                               sintética via md5 quando não — capa DataJud)
+tribunal         : string
+data             : date     — data relevante do registro nessa fonte
+arquivo_ia_url   : string   — URL completa do parquet de origem no IA
+updated_at       : timestamp
+```
+
+Uma linha por `(processo, fonte, registro)` — nunca uma linha por processo,
+nunca uma cópia de campo de conteúdo. Consumidores (o dossiê do dashboard web,
+`causaganha.processos.service.buscar_processo`, a tool MCP `processo_consultar`
+de RFC 0014 M2) consultam o índice primeiro para descobrir quais parquets de
+origem têm registro para um CNJ, depois consultam esses parquets de origem
+diretamente — nunca uma cópia materializada dos campos de conteúdo.
+
+**Por quê.** A tabela larga original (§3.1) exigia reagregar e republicar um
+parquet de ~550k linhas a cada ciclo de reconciliação, com um schema que
+crescia a cada nova fonte (RFC 0010 já tinha acrescentado 6 colunas
+`datajud_*`/`tem_datajud` fora do desenho original desta RFC). O índice fino
+generaliza um padrão já provado (DJEN) em vez de inventar um novo, fica
+estável conforme fontes são adicionadas (uma nova fonte só precisa contribuir
+linhas com seu próprio `fonte`, nunca alterar o schema do índice), e nunca
+diverge do conteúdo de origem por construção (não há cópia para ficar
+desatualizada).
+
+**Compatibilidade com §5 (query contracts).** `processos_unificados`/
+`processo_documentos` como *nomes* sobrevivem — mas como **views DuckDB
+computadas em memória** por `scripts/render_queries.py` (agregando os
+parquets de origem com a mesma SQL descrita em §4.1 passos 1–4, só que a
+partir dos parquets registrados diretamente, não de um join pré-materializado),
+nunca mais como arquivo publicado. Isso mantém `processos_multi_fonte.qmd`
+(§5.2) funcionando sem mudança — é o único consumidor que ainda precisa da
+forma larga.
+
+**O que NÃO mudou:** normalização de CNJ (§3.3, agora em
+`causaganha/processos/cnj.py`, reexportada por `datajud.models`); a UI de
+`/processo` (§6); a decisão de CNJ como chave sem FK entre sistemas (§7.1);
+processos com CNJ inválido ficam nas fontes de origem (§7.4); cobertura
+parcial do STJ (§7.6).
+
+**Detalhes completos:** `docs/planning/manifest-source-of-truth.md` (o
+precedente do índice fino no DJEN) e o PR que implementou esta emenda.
 
 ## 1. Resumo executivo
 
@@ -351,16 +415,25 @@ como chave alternativa de join.
 
 ## 10. Critérios de aceitação
 
-- [ ] `normalizar_cnj()` é a única função de normalização no codebase; todas
-  as fontes a usam.
-- [ ] `reconcile_processos.py` produz `processos_unificados.parquet` sem erro
-  com dados reais das três fontes.
-- [ ] Nenhum `nr_processo` duplicado em `processos_unificados`.
-- [ ] `n_fontes` reflete corretamente quantas fontes contribuíram para cada
-  linha.
-- [ ] Página `/processo/{cnj}` carrega e exibe dados das fontes presentes.
-- [ ] Busca por CNJ mascarado redireciona corretamente para a página de detalhe.
-- [ ] `uv run ruff check` e `uv run pytest -q` passam.
+Ver a Emenda no topo deste documento para o que efetivamente mudou de forma
+(`indice_processual.parquet` no lugar de `processos_unificados.parquet` como
+artefato publicado) — os critérios abaixo são reafirmados contra esse schema:
+
+- [x] `normalizar_cnj()` é a única função de normalização no codebase (agora
+  `causaganha/processos/cnj.py`, reexportada por `datajud.models`); todas as
+  fontes a usam.
+- [x] `reconcile_processos.py` produz `indice_processual.parquet` sem erro com
+  dados reais das quatro fontes (DJEN, JURIS, STJ, DataJud — RFC 0010 já
+  tinha estendido para quatro).
+- [x] Nenhuma linha duplicada em `indice_processual.parquet` — chave é
+  `(numero_processo, fonte, registro_id)`, não `numero_processo` sozinho (a
+  tabela é fina, uma linha por registro de origem, não por processo).
+- [x] `fontes_presentes` (`fonte`/`fontes` conforme a camada) reflete
+  corretamente quantas/quais fontes contribuíram para cada processo.
+- [x] Página `/processo` carrega e exibe dados das fontes presentes.
+- [x] Busca por CNJ mascarado redireciona corretamente para a página de
+  detalhe.
+- [x] `uv run ruff check` e `uv run pytest -q` passam.
 
 ## 11. Referências
 

--- a/docs/rfc/0014-mcp-superficie-produto.md
+++ b/docs/rfc/0014-mcp-superficie-produto.md
@@ -1,6 +1,7 @@
 # RFC 0014 — MCP como superfície de produto
 
-- **Status:** Proposto
+- **Status:** M1 implementado; M2 implementado (com redesenho de dados —
+  ver §2 M2 e a Emenda em RFC 0005)
 - **Data:** 2026-07-22
 - **Depende de:** RFC 0013 (Fase 3A/3B — fundação `causaganha_mcp`: cinco tools
   read-only, `register(mcp)` explícito, tradução de exceções na fronteira),
@@ -36,8 +37,7 @@ Quatro lacunas concretas:
   no retorno. Um agente precisa chamar as quatro, e já saber essas
   diferenças de antemão, para montar um panorama.
 - **Ausência do produto principal.** O causaganha já tem um dossiê
-  reconciliado por CNJ (RFC 0005: `processos_unificados.parquet`,
-  `processo_documentos.parquet`, com normalização de CNJ, paginação e
+  reconciliado por CNJ (RFC 0005, com normalização de CNJ, paginação e
   apresentação já implementadas no dashboard web). O servidor MCP não expõe
   nada disso — só panoramas agregados de pipeline, que servem ao operador,
   não a quem quer saber o que está acontecendo num processo específico.
@@ -120,20 +120,45 @@ específico, não o operador do pipeline:
 processo_consultar(cnj, incluir_documentos=true, limite_documentos=10)
 ```
 
-Retorno: CNJ normalizado (e mascarado onde a apresentação web já mascara);
-quais fontes têm contribuição para esse CNJ; resumo DJEN; decisão/JURIS;
-STJ quando houver; capa oficial DataJud; timestamp de atualização do
-dataset; documentos mais recentes; `web_url` para abrir o dossiê completo no
-dashboard.
+Retorno: CNJ normalizado (e mascarado, `cnj_formatado`); `fontes_presentes`
+(quais fontes têm registro para este CNJ) separado de `cobertura_dataset`
+(estado de cada fonte na geração do dataset inteiro — distingue "fonte sem
+este CNJ" de "fonte indisponível quando o dataset foi gerado"); resumo DJEN;
+decisão/JURIS; STJ quando houver; capa oficial DataJud (RFC 0010); timestamp
+de geração do dataset (`dataset_gerado_em`); documentos mais recentes;
+`web_url` montado só quando a variável de ambiente `CAUSAGANHA_WEB_BASE_URL`
+está configurada (nunca hardcoded — a tool não deve assumir onde o dashboard
+está publicado).
 
-**Fica fora deste RFC como implementação — só como milestone.** Antes de
-escrever código, uma investigação decide a fonte de dados da tool: parquets
-canônicos/remotos do Internet Archive, cache local opcional, ou ambos com
-proveniência explícita (mesma disciplina de `fonte`/`canonica` de M1). A
-investigação também mapeia a semântica já implementada no dashboard web
-(normalização de CNJ, junção de fontes, paginação, freshness — RFC 0005) para
-reaproveitar, não portar TypeScript mecanicamente para Python. Ganha PR
-própria depois de M1.
+**Investigação (concluída) → redesenho de dados, não só uma tool nova.** A
+investigação de fonte de dados (parquets canônicos do IA vs. cache local)
+levou a uma pergunta mais fundamental: a RFC 0005 original propunha uma
+tabela larga `processos_unificados.parquet` como artefato canônico
+publicado, mas o DJEN já resolvia o mesmo problema — "que registros existem
+para este CNJ e onde estão" — de outra forma: um índice fino (`processos` em
+`causaganha/consolidate/schema_registry.py`) que só aponta para o registro
+completo, nunca copia seus campos. Generalizar esse padrão para as quatro
+fontes (`indice_processual.parquet`) em vez de repetir o desenho da tabela
+larga evita uma segunda fonte de verdade que pode divergir do conteúdo de
+origem. Ver a Emenda no topo de RFC 0005 para o schema completo e o
+raciocínio.
+
+Como o índice já existe e é publicado (o reconciliador precisava ser
+reescrito de qualquer forma), este M2 entrega o redesenho completo na mesma
+PR, não só a tool: `scripts/reconcile_processos.py` publica
+`indice_processual.parquet` (+ `indice_processual.report.json` de
+cobertura) em vez das duas tabelas largas; `scripts/render_queries.py`
+recomputa `processos_unificados`/`processo_documentos` como *views* DuckDB
+em memória a partir das fontes de origem (só para os `.qmd` que ainda
+precisam da forma larga, como `processos_multi_fonte.qmd` — nunca mais como
+arquivo publicado); `causaganha.processos.service.buscar_processo` e
+`web/src/lib/processoCnj.ts` (dashboard `/processo`) consultam o índice
+primeiro para descobrir quais parquets de origem têm registro, depois
+consultam esses parquets diretamente — a mesma consulta em duas linguagens
+(DuckDB Python / DuckDB-WASM no navegador), mesmo padrão de dois estágios;
+`datajud.service`'s descoberta de CNJs lê `indice_processual.parquet` (um
+`SELECT DISTINCT numero_processo`, sem join) em vez do antigo
+`processos_unificados.parquet`.
 
 ## 3. Regras específicas (para não abrir atalhos)
 
@@ -195,14 +220,38 @@ própria depois de M1.
   número inválido — review da #854: a primeira versão só cobria I/O).
 - `pytest`, `ruff check`, `ruff format --check` verdes.
 
-**M2 (quando a investigação e a PR acontecerem):**
-- Decisão de fonte de dados documentada (parquet IA / cache local / ambos)
-  antes do primeiro código de `processo_consultar`.
-- `processo_consultar` reaproveita a semântica de normalização/junção/
-  paginação/freshness já implementada no dashboard web (RFC 0005), sem
-  reimplementação paralela divergente.
+**M2:**
+- `scripts/reconcile_processos.py` publica `indice_processual.parquet` +
+  `indice_processual.report.json` (cobertura por fonte); não publica mais
+  `processos_unificados.parquet`/`processo_documentos.parquet` como
+  arquivos.
+- `scripts/render_queries.py` continua servindo `processos_multi_fonte.qmd`
+  e os demais `.qmd` existentes sem mudança de contrato, recomputando
+  `processos_unificados`/`processo_documentos` como views DuckDB a partir
+  das fontes de origem.
+- `causaganha.processos.cnj` é a única implementação Python de
+  normalização/máscara de CNJ; `datajud.models` reexporta em vez de manter
+  cópia própria.
+- `causaganha.processos.service.buscar_processo` consulta
+  `indice_processual.parquet` para descobrir fontes/URLs, depois os
+  parquets de origem diretamente — nunca uma tabela pré-materializada; erro
+  ao abrir o índice propaga (sem resposta possível), erro numa fonte
+  específica ou no relatório de cobertura vira lacuna vazia + aviso em
+  `avisos`, nunca exceção.
+- `processo_consultar` registrada e testada (schema exato, comportamento
+  com resultado encontrado/não-encontrado, tradução de exceção de domínio
+  para `ToolError` sem vazar detalhe interno); `web_url` só quando
+  `CAUSAGANHA_WEB_BASE_URL` está no ambiente.
+- `web/src/lib/processoCnj.ts` + `ProcessoLookup.svelte` (dashboard
+  `/processo`) migrados para o mesmo padrão de dois estágios (índice →
+  parquets de origem) via DuckDB-WASM; nenhuma referência residual a
+  `processos_unificados.parquet`/`processo_documentos.parquet` no
+  frontend.
+- `datajud.service`'s descoberta de CNJs lê `indice_processual.parquet`.
 - Mesma disciplina de M1: fatos com proveniência, não veredito; `ToolError`
   estruturado para falha real, resultado parcial para ausência de dado.
+- `pytest`, `ruff check`, `ruff format --check`, suíte de testes web
+  (`npm test`) e `astro check` verdes.
 
 ## 5. Riscos
 
@@ -218,8 +267,15 @@ própria depois de M1.
   base de usuários são brasileiros; nomes de função/módulo Python
   continuam em inglês, então o custo de reverter (se necessário) fica
   isolado nas strings de `title`/`description`/`Field(description=...)`.
-- **`processo_consultar` é a peça de maior risco de escopo.** Fica
-  deliberadamente fora da implementação deste RFC — só a investigação e o
-  contrato de dados entram aqui — para não repetir o erro que RFC 0013
-  evitou na sua própria Fase 3 (misturar fundação com escopo de
-  investigação ainda aberta).
+- **M2 acabou maior do que "uma tool nova".** A investigação de fonte de
+  dados levou a um redesenho do artefato canônico (`indice_processual
+  .parquet` no lugar de `processos_unificados.parquet`/`processo_documentos
+  .parquet`), que por sua vez toca o reconciliador, `render_queries.py`, a
+  descoberta de CNJs do `datajud` e o dashboard web — quatro superfícies
+  além da tool MCP em si. Aceito conscientemente (decisão explícita antes de
+  começar a implementação, não descoberta no meio do trabalho): adiar o
+  redesenho para depois de `processo_consultar` já existir teria criado uma
+  segunda consumidora do formato antigo, tornando a migração posterior mais
+  cara, não mais barata. `processos_unificados.parquet`/`processo_documentos
+  .parquet` descontinuados como artefatos publicados nesta mesma PR — não
+  há janela intermediária em que ambos os formatos precisam ser mantidos.

--- a/docs/rfc/0014-mcp-superficie-produto.md
+++ b/docs/rfc/0014-mcp-superficie-produto.md
@@ -244,12 +244,36 @@ consultam esses parquets diretamente — a mesma consulta em duas linguagens
   `CAUSAGANHA_WEB_BASE_URL` está no ambiente.
 - `web/src/lib/processoCnj.ts` + `ProcessoLookup.svelte` (dashboard
   `/processo`) migrados para o mesmo padrão de dois estágios (índice →
-  parquets de origem) via DuckDB-WASM; nenhuma referência residual a
-  `processos_unificados.parquet`/`processo_documentos.parquet` no
-  frontend.
+  parquets de origem) via DuckDB-WASM.
 - `datajud.service`'s descoberta de CNJs lê `indice_processual.parquet`.
 - Mesma disciplina de M1: fatos com proveniência, não veredito; `ToolError`
   estruturado para falha real, resultado parcial para ausência de dado.
+
+**Fallback de rollout (review da #856).** `deploy-web.yml` dispara direto
+no push para `main` tocando `web/**`/`render_queries.py`; `update-catalog
+.yml` só publica `indice_processual.parquet` quando `has_new_uploads ==
+true` no seu próprio gatilho (conclusão do workflow "Consolidate Parquet"
+— não o merge desta PR). Sem mitigação, `/processo` regrediria de "tem
+dado real" (lê hoje `processos_unificados.parquet`/`processo_documentos
+.parquet`) para "indisponível" durante essa janela, e
+`processos_multi_fonte.qmd` regrediria de dado real para vazio.
+`processos_unificados.parquet`/`processo_documentos.parquet` continuam no
+item IA `causaganha-dashboard` — o reconciliador para de escrevê-los, mas
+um upload com nome diferente não remove o objeto antigo — então servem de
+fallback temporário, não uma segunda fonte de verdade permanente:
+- `scripts/render_queries.py`'s `_register_comunicacoes` cai para
+  consultar o `causaganha-catalog` manifest diretamente (mesma consulta
+  que o DJEN usava antes desta PR) quando o índice está inacessível.
+- `web/src/lib/processoCnj.ts`'s `buscarProcesso`/`carregarDocumentos`
+  caem para `processos_unificados.parquet`/`processo_documentos.parquet`
+  pelo mesmo motivo, marcando o resultado com `legado: true` (a UI ajusta
+  o texto de "não encontrado" de acordo, e o aviso explica a fonte usada).
+- `processo_consultar` (MCP) fica sem fallback equivalente — é
+  funcionalidade nova, sem estado anterior para onde cair, e já degrada
+  com `ToolError` claro em vez de crashar.
+- Remover os dois fallbacks — e, quando fizer sentido, os arquivos legados
+  do IA — depois que `indice_processual.parquet` estiver confirmado
+  publicado e estável.
 - `pytest`, `ruff check`, `ruff format --check`, suíte de testes web
   (`npm test`) e `astro check` verdes.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -123,6 +123,20 @@ ignore = [
 # S310: urlopen against a fixed archive.org URL constant, not user input (inline noqa).
 "src/datajud/service.py" = ["PLC0415", "S608"]
 
+# ── causaganha.processos (RFC 0014 M2) ──────────────────────────────────────
+# S608: f-string SQL — the interpolated part is always a list of internal
+# arquivo_ia_url values (module constants or index-discovered IA URLs), never
+# user input; the CNJ itself is always a bind parameter.
+"src/causaganha/processos/service.py" = ["S608"]
+
+# ── causaganha_mcp tools ─────────────────────────────────────────────────────
+# FBT001/FBT002: incluir_documentos is a genuine on/off MCP tool parameter —
+# same idiom already accepted for CLI boolean flags (datajud/__main__.py
+# above); FastMCP calls this by keyword from the tool schema, never
+# positionally, so the usual "boolean trap" ruff is guarding against doesn't
+# apply here.
+"src/causaganha_mcp/tools/processo.py" = ["FBT001", "FBT002"]
+
 # ── Lazy / conditional imports in library modules ─────────────────────────
 # These modules defer expensive imports to avoid slowing every process start.
 "src/causaganha/pipeline/ia_s3.py" = ["E402", "S608", "S324", "D100", "E501", "PLR2004"]

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -126,22 +126,6 @@ def _expected_sources() -> tuple[str, ...]:
     return names or SOURCE_NAMES
 
 
-# ── CNJ normalisation ──────────────────────────────────────────────────────────
-
-
-def normalizar_cnj(n: str | None) -> str:
-    """Remove non-digits; return 20-digit string or '' if invalid."""
-    d = re.sub(r"\D", "", n or "")
-    return d if len(d) == 20 else ""
-
-
-def formatar_cnj(n: str) -> str:
-    """20 digits → NNNNNNN-DD.AAAA.J.TR.OOOO."""
-    if len(n) != 20:
-        return n
-    return f"{n[0:7]}-{n[7:9]}.{n[9:13]}.{n[13:14]}.{n[14:16]}.{n[16:20]}"
-
-
 # ── Data acquisition ───────────────────────────────────────────────────────────
 
 
@@ -1045,6 +1029,11 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
         upload_to_ia(_PARQUET_UNIFICADOS, "processos_unificados.parquet")
         if _PARQUET_DOCUMENTOS.exists():
             upload_to_ia(_PARQUET_DOCUMENTOS, "processo_documentos.parquet")
+        # RFC 0014 M2: processo_consultar needs the coverage report remotely
+        # too, to distinguish "source loaded but had no rows for this CNJ"
+        # from "source was unavailable when the dataset was generated" —
+        # both used to look identical (absent from `fontes`) without it.
+        upload_to_ia(report_path, _REPORT_NAME)
 
     return {
         "djen": djen_load.rows,

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -290,22 +290,29 @@ def _discover_juris_items(client: httpx.Client) -> list[str]:
     )
 
 
-def fetch_juris_from_ia() -> tuple[list[Path], bool]:
+def fetch_juris_from_ia() -> tuple[list[Path], dict[Path, str], bool]:
     """Download JURIS parquets from the tjro-juris-{year} IA items.
 
     Prefers the consolidated tjro-juris-{year}.parquet when the item has one;
-    otherwise falls back to the monthly shards the sync uploads. Returns
-    (paths, needs_dedup) — monthly shards can overlap between crawls, so they
-    must be deduplicated by id_documento before aggregation.
+    otherwise falls back to the monthly shards the sync uploads — each shard
+    keeps its own name (e.g. 2024-01-ACORDAO.parquet), never the consolidated
+    file's name, since that file is exactly what's absent in this fallback.
+    Returns (paths, urls, needs_dedup): `urls` maps each returned path to the
+    *actual* IA URL it was fetched from (item/name as fetched, not inferred
+    from any row's data later) — the ground truth for `arquivo_ia_url` in the
+    index, since a shard's filename cannot be recovered from its content.
+    Monthly shards can overlap between crawls, so they must be deduplicated
+    by id_documento before aggregation.
     """
     cache = _cache_dir() / "juris"
     paths: list[Path] = []
+    urls: dict[Path, str] = {}
     needs_dedup = False
     with httpx.Client(timeout=180, follow_redirects=True) as client:
         items = _discover_juris_items(client)
         if not items:
             print(f"  no {_JURIS_ITEM_PREFIX}-* items found on IA", file=sys.stderr)
-            return [], False
+            return [], {}, False
         for item in items:
             names = _ia_item_files(client, item)
             consolidated = f"{item}.parquet"
@@ -317,34 +324,40 @@ def fetch_juris_from_ia() -> tuple[list[Path], bool]:
                     needs_dedup = True
             if not wanted:
                 print(f"  IA item {item}: no parquet files", file=sys.stderr)
-            paths.extend(
-                _fetch_cached(
-                    client, f"{_IA_BASE}/{item}/{name}", cache / item / name, f"JURIS {item}/{name}"
-                )
-                for name in wanted
-            )
-    return paths, needs_dedup
+            for name in wanted:
+                url = f"{_IA_BASE}/{item}/{name}"
+                path = _fetch_cached(client, url, cache / item / name, f"JURIS {item}/{name}")
+                paths.append(path)
+                urls[path] = url
+    return paths, urls, needs_dedup
 
 
-def ensure_juris_parquets() -> tuple[list[Path], bool, SourceLoad]:
+def ensure_juris_parquets() -> tuple[list[Path], dict[Path, str], bool, SourceLoad]:
     """JURIS parquets: local files first, IA fallback otherwise.
 
-    Returns (paths, needs_dedup, load_status).
+    Returns (paths, urls, needs_dedup, load_status). `urls` maps each path to
+    its authoritative IA URL — for local files, the operator-placed layout
+    (`data/tjro_juris/{year}/tjro-juris-{year}.parquet`, enforced by
+    _JURIS_LOCAL_GLOBS) guarantees the filename *is* `{item}.parquet`, so the
+    URL is derived from the path itself; for IA-fetched files it comes from
+    fetch_juris_from_ia(), which already knows the real per-file URL (see its
+    docstring — never inferred from a row's own data downstream).
     """
     local = juris_parquet_files()
     if local:
         detail = f"{len(local)} local parquet file(s)"
-        return local, False, SourceLoad("juris", STATUS_LOADED_LOCAL, detail)
+        urls = {p: f"{_IA_BASE}/{p.stem}/{p.name}" for p in local}
+        return local, urls, False, SourceLoad("juris", STATUS_LOADED_LOCAL, detail)
     print(f"No local JURIS parquets — trying IA items {_JURIS_ITEM_PREFIX}-{{year}}")
     try:
-        remote, needs_dedup = fetch_juris_from_ia()
+        remote, urls, needs_dedup = fetch_juris_from_ia()
     except (httpx.HTTPError, OSError, SourceDataError) as exc:
-        return [], False, SourceLoad("juris", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
+        return [], {}, False, SourceLoad("juris", STATUS_UNAVAILABLE, f"IA fetch failed: {exc}")
     if remote:
         detail = f"{len(remote)} parquet file(s) from IA {_JURIS_ITEM_PREFIX}-* items"
-        return remote, needs_dedup, SourceLoad("juris", STATUS_LOADED_REMOTE, detail)
+        return remote, urls, needs_dedup, SourceLoad("juris", STATUS_LOADED_REMOTE, detail)
     detail = f"no local parquets and no parquets in IA {_JURIS_ITEM_PREFIX}-* items"
-    return [], False, SourceLoad("juris", STATUS_UNAVAILABLE, detail)
+    return [], {}, False, SourceLoad("juris", STATUS_UNAVAILABLE, detail)
 
 
 def datajud_parquet_files() -> list[Path]:
@@ -472,10 +485,7 @@ SELECT
     id_documento::VARCHAR AS registro_id,
     'TJRO' AS tribunal,
     TRY_CAST(data_julgamento AS DATE) AS data,
-    'https://archive.org/download/tjro-juris-' ||
-        CAST(EXTRACT(YEAR FROM TRY_CAST(data_julgamento AS DATE)) AS VARCHAR) || '/tjro-juris-' ||
-        CAST(EXTRACT(YEAR FROM TRY_CAST(data_julgamento AS DATE)) AS VARCHAR) || '.parquet'
-        AS arquivo_ia_url
+    arquivo_ia_url
 FROM tjro_juris
 WHERE length(regexp_replace(nr_processo, '[^0-9]', '', 'g')) = 20
 """
@@ -619,7 +629,7 @@ def _empty_juris_view(con: duckdb.DuckDBPyConnection) -> None:
         "NULL::VARCHAR AS tipo, NULL::DATE AS data_julgamento, "
         "NULL::VARCHAR AS orgao, NULL::VARCHAR AS relator, "
         "NULL::VARCHAR AS classe_judicial, NULL::VARCHAR AS url_portal, "
-        "NULL::VARCHAR AS texto_limpo "
+        "NULL::VARCHAR AS texto_limpo, NULL::VARCHAR AS arquivo_ia_url "
         "WHERE FALSE"
     )
 
@@ -703,9 +713,16 @@ def _register_juris(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     implicated in the failure are quarantined so the NEXT run re-fetches
     instead of hitting the same wall forever.
     """
-    juris_files, needs_dedup, load = ensure_juris_parquets()
+    juris_files, juris_urls, needs_dedup, load = ensure_juris_parquets()
     if juris_files:
         juris_list = ", ".join(f"'{p}'" for p in juris_files)
+        # filename=true stamps each row with the exact file DuckDB read it
+        # from — the ground truth for arquivo_ia_url. Never inferred from
+        # data_julgamento's year: that breaks whenever a row came from a
+        # monthly shard rather than the consolidated tjro-juris-{year}.parquet
+        # (see fetch_juris_from_ia's fallback), and NULL/unparseable dates
+        # would otherwise produce a NULL URL for a row that does have a file.
+        url_values = ", ".join(f"('{p}', '{juris_urls[p]}')" for p in juris_files)
         print(f"Registering JURIS view: {len(juris_files)} parquet file(s)")
         try:
             if needs_dedup:
@@ -716,16 +733,25 @@ def _register_juris(con: duckdb.DuckDBPyConnection) -> SourceLoad:
                 # collapsed together under a shared null key.
                 con.execute(
                     "CREATE VIEW tjro_juris AS "
-                    "SELECT * EXCLUDE (_rn) FROM ("
+                    "SELECT t.* EXCLUDE (filename, _rn), m.arquivo_ia_url FROM ("
                     "  SELECT *, ROW_NUMBER() OVER ("
                     "    PARTITION BY id_documento ORDER BY extraido_em DESC NULLS LAST"
                     "  ) AS _rn "
-                    f"  FROM read_parquet([{juris_list}], union_by_name=true) "
+                    f"  FROM read_parquet([{juris_list}], filename=true, union_by_name=true) "
                     "  WHERE id_documento IS NOT NULL"
-                    ") WHERE _rn = 1"
+                    ") AS t "
+                    f"LEFT JOIN (VALUES {url_values}) AS m(filename, arquivo_ia_url) "
+                    "  ON t.filename = m.filename "
+                    "WHERE t._rn = 1"
                 )
             else:
-                con.execute(f"CREATE VIEW tjro_juris AS SELECT * FROM read_parquet([{juris_list}])")
+                con.execute(
+                    "CREATE VIEW tjro_juris AS "
+                    "SELECT t.* EXCLUDE (filename), m.arquivo_ia_url "
+                    f"FROM read_parquet([{juris_list}], filename=true) AS t "
+                    f"LEFT JOIN (VALUES {url_values}) AS m(filename, arquivo_ia_url) "
+                    "  ON t.filename = m.filename"
+                )
             con.execute("SELECT COUNT(*) FROM tjro_juris")  # force read now, not mid-aggregation
         except duckdb.Error as exc:
             print(f"  WARNING: JURIS parquet(s) unreadable — {exc}", file=sys.stderr)
@@ -784,9 +810,11 @@ def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     """
     _datajud_required_cols = {
         "numero_processo",
+        "tribunal",
         "classe_nome",
         "assuntos",
         "orgao_julgador",
+        "orgao_julgador_codigo",
         "grau",
         "data_ajuizamento",
         "ultima_atualizacao",

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -12,6 +12,19 @@ There is deliberately no second, independently-published "wide" parquet —
 consumers (processo_consultar, web/src/lib/processoCnj.ts) join the index
 against each source's own parquet at query time.
 
+Known limitation — arquivo_ia_url provenance for local sources: DJEN's URL
+comes from `p_item_ia`, a column stamped by DJEN's own pipeline at write
+time (proven correct by construction). JURIS/STJ/DataJud have no such
+column; when loaded via IA fallback their URL is ground truth (it's
+literally where the bytes were fetched from — see fetch_juris_from_ia).
+When loaded from a *local* file (loaded_local), the URL is instead
+*presumed* from naming convention — correct only if that file has already
+been uploaded to IA under that exact name. Not exercised by CI
+(update-catalog.yml's download-state action never populates local
+JURIS/STJ/DataJud directories, so this reconciler always takes the IA-fetch
+branch there), but real for local/dev runs — see
+_warn_if_local_url_unverified.
+
 Pipeline:
   1. Load DJEN from every consolidated comunicacoes.parquet (discovered via
      the causaganha-catalog manifest) — flat, no GROUP BY.
@@ -647,6 +660,32 @@ def _empty_acordaos_view(con: duckdb.DuckDBPyConnection) -> None:
     )
 
 
+def _warn_if_local_url_unverified(fonte: str, load: SourceLoad) -> None:
+    """Warn when a source's arquivo_ia_url is presumed, not proven, for this run.
+
+    JURIS/STJ/DataJud derive arquivo_ia_url from naming convention (the item
+    each local file *would* correspond to on IA), not from where the bytes
+    were actually fetched from — that provenance only exists when the source
+    is loaded_remote (see fetch_juris_from_ia's per-file url map, ground
+    truth by construction since the URL IS where it was downloaded from).
+    A loaded_local source presumes its file already matches what's on IA at
+    that same name — true whenever this reconciler runs after that source's
+    own upload step has already completed, but never verified here (no HEAD
+    request against IA). CI never exercises this branch (update-catalog.yml's
+    download-state action only fetches sync-manifest.parquet — JURIS/STJ/
+    DataJud local directories are always empty in that job — see RFC 0014 M2
+    review), so it's a real gap only for local/dev runs of this script.
+    """
+    if load.status != STATUS_LOADED_LOCAL:
+        return
+    print(
+        f"  WARNING: {fonte} loaded from a local file — arquivo_ia_url in the index is "
+        "presumed from naming convention, not verified against IA. Correct only if this "
+        "file has already been uploaded under that exact name.",
+        file=sys.stderr,
+    )
+
+
 def _quarantine_if_cached(files: list[Path], load: SourceLoad) -> None:
     """Quarantine *files* only when they came from our own IA-fetch cache.
 
@@ -715,6 +754,7 @@ def _register_juris(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     """
     juris_files, juris_urls, needs_dedup, load = ensure_juris_parquets()
     if juris_files:
+        _warn_if_local_url_unverified("juris", load)
         juris_list = ", ".join(f"'{p}'" for p in juris_files)
         # filename=true stamps each row with the exact file DuckDB read it
         # from — the ground truth for arquivo_ia_url. Never inferred from
@@ -779,6 +819,7 @@ def _register_stj(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     """
     stj_path, load = ensure_stj_parquet()
     if stj_path is not None:
+        _warn_if_local_url_unverified("stj", load)
         print(f"Registering STJ view: {stj_path}")
         try:
             con.execute(f"CREATE VIEW acordaos AS SELECT * FROM read_parquet('{stj_path}')")
@@ -821,6 +862,7 @@ def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     }
     datajud_files, load = ensure_datajud_parquets()
     if datajud_files:
+        _warn_if_local_url_unverified("datajud", load)
         datajud_list = ", ".join(f"'{p}'" for p in datajud_files)
         print(f"  Registering DataJud capa view: {len(datajud_files)} parquet file(s)")
         try:

--- a/scripts/reconcile_processos.py
+++ b/scripts/reconcile_processos.py
@@ -1,24 +1,35 @@
 #!/usr/bin/env python3
-"""Reconcile DJEN x TJRO JURIS x STJ into processos_unificados.
+"""Reconcile DJEN x TJRO JURIS x STJ x DataJud into a cross-source index.
+
+RFC 0014 M2 design: `indice_processual.parquet` is a THIN index — one row
+per (numero_processo, fonte, registro_id), pointing at where the real
+record lives (`arquivo_ia_url`) — never a denormalized copy of each
+source's content fields. This generalizes the pattern DJEN's own
+`processos` table already used (see `causaganha/consolidate/
+schema_registry.py`'s SCHEMA_V3): each source keeps its natural schema in
+its own already-published parquet; only cross-referencing them is new.
+There is deliberately no second, independently-published "wide" parquet —
+consumers (processo_consultar, web/src/lib/processoCnj.ts) join the index
+against each source's own parquet at query time.
 
 Pipeline:
-  1. Load DJEN from every consolidated comunicacoes.parquet (discovered via the
-     causaganha-catalog manifest) — GROUP BY nr_processo
+  1. Load DJEN from every consolidated comunicacoes.parquet (discovered via
+     the causaganha-catalog manifest) — flat, no GROUP BY.
   2. Load JURIS from tjro-juris-<year>.parquet files (local, or fetched from
-     the tjro-juris-{year} IA items when absent locally) — GROUP BY nr_processo
-  3. Load STJ from stj-acordaos.parquet — filter to CNJ numbers only
-  4. Full outer join the three aggregations in DuckDB
-  5. Optional DataJud enrichment (RFC 0010): LEFT JOIN the official capa
-     (classe_oficial, assuntos, orgao_julgador, grau, data_ajuizamento,
-     ultima_atualizacao, tem_datajud) when datajud-capa-*.parquet exists
-     (local, or fetched from the datajud-{tribunal} IA items) — without it
-     the columns are NULL/false and behaviour is unchanged
-  6. Write processos_unificados.parquet + processo_documentos.parquet
-  7. Write a source-coverage report (per-source counts + load status +
-     fontes intersection matrix) next to the output as
-     processos_unificados.report.json, and fail loudly when an expected
-     source ended up with zero rows because it could not be loaded at all
-  8. Upload both parquets to IA item causaganha-dashboard
+     the tjro-juris-{year} IA items when absent locally) — flat.
+  3. Load STJ from stj-acordaos.parquet — filter to CNJ numbers only, flat.
+  4. Load DataJud capa (RFC 0010) from datajud-capa-*.parquet when present —
+     flat; registro_id is synthesized (md5 of the composite natural key
+     numero_processo+grau+orgao, since DataJud's own ES _id already encodes
+     exactly that composite — see datajud/dedup.py's capa_row_key). DataJud
+     movimentos are out of scope (no natural key at all, not indexed here).
+  5. UNION ALL the four into indice_processual — never collapsed/aggregated.
+  6. Write indice_processual.parquet.
+  7. Write a source-coverage report (per-source distinct-process counts +
+     load status + fontes intersection matrix) next to the output as
+     indice_processual.report.json, and fail loudly when an expected source
+     ended up with zero rows because it could not be loaded at all.
+  8. Upload the parquet + report to IA item causaganha-dashboard.
 
 Environment knobs:
   RECONCILE_CACHE_DIR          — where IA-fetched source parquets are cached
@@ -54,9 +65,8 @@ from datajud.archive import item_id as _datajud_item_id
 ROOT = Path(__file__).parent.parent
 DATA_DIR = ROOT / "data"
 
-_PARQUET_UNIFICADOS = DATA_DIR / "processos_unificados.parquet"
-_PARQUET_DOCUMENTOS = DATA_DIR / "processo_documentos.parquet"
-_REPORT_NAME = "processos_unificados.report.json"
+_PARQUET_INDICE = DATA_DIR / "indice_processual.parquet"
+_REPORT_NAME = "indice_processual.report.json"
 
 _IA_BASE = "https://archive.org/download"
 _IA_METADATA_BASE = "https://archive.org/metadata"
@@ -418,223 +428,98 @@ def _ia_credentials() -> str | None:
 
 # ── Aggregation SQL ────────────────────────────────────────────────────────────
 
-_DJEN_AGG_SQL = """
+# ── Cross-source index (RFC 0014 M2) ────────────────────────────────────────────
+#
+# Generalizes the pattern DJEN's own `processos` table already used (see
+# schema_registry.py's SCHEMA_V3): a thin per-record index — one row per
+# (numero_processo, fonte, registro_id) — never a collapsed/aggregated join.
+# Each source keeps its own natural schema in its own already-published
+# parquet (comunicacoes, tjro-juris-{year}, stj-acordaos, datajud-capa-
+# {tribunal}); this index only says which records exist for a CNJ and where
+# to find them (`arquivo_ia_url`). Consumers (processo_consultar,
+# web/src/lib/processoCnj.ts) join back into the source parquet themselves —
+# never a second, independently-published source of truth.
+#
+# DataJud capa has no single-column natural key (its own ES `_id` encodes a
+# composite `{TRIBUNAL}_{classe}_{grau}_{orgao}_{numero}` — see
+# datajud/dedup.py's capa_row_key) — registro_id is a deterministic md5 hash
+# of that same composite, mirroring how DJEN's own comunicacao_id is a
+# uuid5 hash of a composite key (transforms.py's djen_uuid5), just via
+# DuckDB's built-in md5() instead of a custom UDF.
+#
+# DataJud movimentos are out of scope here: reconcile_processos.py never
+# read them even in the old processos_unificados/processo_documentos shape,
+# and unlike every other source they have no natural key at all, not even a
+# composite one (ties on data_hora are real) — indexing them is a genuine
+# follow-up, not a mechanical generalization of what already existed.
+
+_INDICE_DJEN_SQL = """
 SELECT
-    regexp_replace(numero_processo, '[^0-9]', '', 'g') AS nr_processo,
-    MIN(data_disponibilizacao)::DATE  AS djen_primeira_pub,
-    MAX(data_disponibilizacao)::DATE  AS djen_ultima_pub,
-    COUNT(*)::INTEGER                 AS djen_n_publicacoes,
-    list(DISTINCT tribunal)           AS djen_tribunais
+    regexp_replace(numero_processo, '[^0-9]', '', 'g') AS numero_processo,
+    'djen' AS fonte,
+    id AS registro_id,
+    tribunal,
+    data_disponibilizacao AS data,
+    'https://archive.org/download/' || p_item_ia || '/comunicacoes.parquet' AS arquivo_ia_url
 FROM comunicacoes
 WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
-GROUP BY nr_processo
 """
 
-_JURIS_AGG_SQL = """
-WITH cleaned AS (
-    SELECT
-        regexp_replace(nr_processo, '[^0-9]', '', 'g') AS nr_processo,
-        id_documento,
-        tipo,
-        data_julgamento,
-        orgao,
-        relator,
-        classe_judicial,
-        url_portal
-    FROM tjro_juris
-    WHERE length(regexp_replace(nr_processo, '[^0-9]', '', 'g')) = 20
-),
-ranked AS (
-    SELECT
-        *,
-        ROW_NUMBER() OVER (
-            PARTITION BY nr_processo
-            ORDER BY
-                CASE tipo
-                    WHEN 'ACÓRDÃO' THEN 1
-                    WHEN 'SENTENÇA' THEN 2
-                    ELSE 9
-                END,
-                data_julgamento DESC NULLS LAST
-        ) AS rn
-    FROM cleaned
-),
-principal AS (
-    SELECT * FROM ranked WHERE rn = 1
-),
-agg AS (
-    SELECT
-        nr_processo,
-        COUNT(*)::INTEGER        AS juris_n_documentos,
-        list(DISTINCT tipo)      AS juris_tipos,
-        MAX(data_julgamento)     AS juris_data_julgamento
-    FROM cleaned
-    GROUP BY nr_processo
-)
+_INDICE_JURIS_SQL = """
 SELECT
-    agg.nr_processo,
-    agg.juris_n_documentos,
-    agg.juris_tipos,
-    agg.juris_data_julgamento::DATE AS juris_data_julgamento,
-    principal.orgao          AS juris_orgao,
-    principal.relator        AS juris_relator,
-    principal.classe_judicial AS juris_classe,
-    principal.url_portal     AS juris_url
-FROM agg
-JOIN principal USING (nr_processo)
-"""
-
-_STJ_AGG_SQL = """
-SELECT
-    regexp_replace("numeroProcesso", '[^0-9]', '', 'g') AS nr_processo,
-    FIRST(id ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS stj_id,
-    FIRST("siglaClasse" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_classe,
-    FIRST("ministroRelator" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_relator,
-    FIRST("tema" ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS stj_tema,
-    FIRST("teseJuridica" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_tese,
-    FIRST("ementa" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_ementa,
-    MAX("dataDecisao")::DATE AS stj_data_decisao,
-    MAX("dataPublicacao")::DATE AS stj_data_publicacao
-FROM acordaos
-WHERE length(regexp_replace("numeroProcesso", '[^0-9]', '', 'g')) = 20
-GROUP BY nr_processo
-"""
-
-# DataJud capa is a per-(numero, grau, orgao) table; collapse to one row per
-# CNJ preferring the most recently updated document (usually the highest grau
-# reached). data_ajuizamento takes the earliest — the original filing.
-_DATAJUD_AGG_SQL = """
-SELECT
-    numero_processo AS nr_processo,
-    FIRST(classe_nome ORDER BY ultima_atualizacao DESC NULLS LAST) AS classe_oficial,
-    FIRST(assuntos ORDER BY ultima_atualizacao DESC NULLS LAST) AS assuntos,
-    FIRST(orgao_julgador ORDER BY ultima_atualizacao DESC NULLS LAST) AS orgao_julgador,
-    FIRST(grau ORDER BY ultima_atualizacao DESC NULLS LAST) AS grau,
-    MIN(data_ajuizamento) AS data_ajuizamento,
-    MAX(ultima_atualizacao) AS ultima_atualizacao
-FROM datajud_capa
-WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
-GROUP BY numero_processo
-"""
-
-_UNIFICADOS_SQL = """
-WITH
-    base AS (
-        SELECT
-            COALESCE(d.nr_processo, j.nr_processo, s.nr_processo, dj.nr_processo) AS nr_processo,
-            d.djen_primeira_pub,
-            d.djen_ultima_pub,
-            d.djen_n_publicacoes,
-            d.djen_tribunais,
-            j.juris_n_documentos,
-            j.juris_tipos,
-            j.juris_data_julgamento,
-            j.juris_orgao,
-            j.juris_relator,
-            j.juris_classe,
-            j.juris_url,
-            s.stj_id,
-            s.stj_classe,
-            s.stj_relator,
-            s.stj_tema,
-            s.stj_tese,
-            s.stj_ementa,
-            s.stj_data_decisao,
-            s.stj_data_publicacao,
-            -- DataJud enrichment (RFC 0010) — NULL/false when the capa is absent
-            dj.classe_oficial,
-            dj.assuntos,
-            dj.orgao_julgador,
-            dj.grau,
-            dj.data_ajuizamento,
-            dj.ultima_atualizacao,
-            (dj.nr_processo IS NOT NULL) AS tem_datajud,
-            (CASE WHEN d.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
-             CASE WHEN j.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
-             CASE WHEN s.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
-             CASE WHEN dj.nr_processo IS NOT NULL THEN 1 ELSE 0 END)::INTEGER AS n_fontes,
-            list_filter(
-                ['djen', 'juris', 'stj', 'datajud'],
-                x -> (
-                    (x = 'djen'    AND d.nr_processo IS NOT NULL) OR
-                    (x = 'juris'   AND j.nr_processo IS NOT NULL) OR
-                    (x = 'stj'     AND s.nr_processo IS NOT NULL) OR
-                    (x = 'datajud' AND dj.nr_processo IS NOT NULL)
-                )
-            ) AS fontes,
-            NOW() AS updated_at
-        FROM djen_agg d
-        FULL OUTER JOIN juris_agg   j USING (nr_processo)
-        FULL OUTER JOIN stj_agg     s USING (nr_processo)
-        FULL OUTER JOIN datajud_agg dj USING (nr_processo)
-    )
-SELECT
-    base.nr_processo,
-    -- Build display mask inline (20 digits → NNNNNNN-DD.AAAA.J.TR.OOOO)
-    (base.nr_processo[1:7] || '-' || base.nr_processo[8:9] || '.' ||
-     base.nr_processo[10:13] || '.' || base.nr_processo[14:14] || '.' ||
-     base.nr_processo[15:16] || '.' || base.nr_processo[17:20]) AS nr_processo_mascara,
-    djen_primeira_pub,
-    djen_ultima_pub,
-    djen_n_publicacoes,
-    djen_tribunais,
-    juris_n_documentos,
-    juris_tipos,
-    juris_data_julgamento,
-    juris_orgao,
-    juris_relator,
-    juris_classe,
-    juris_url,
-    stj_id,
-    stj_classe,
-    stj_relator,
-    stj_tema,
-    stj_tese,
-    stj_ementa,
-    stj_data_decisao,
-    stj_data_publicacao,
-    classe_oficial,
-    assuntos,
-    orgao_julgador,
-    grau,
-    data_ajuizamento,
-    ultima_atualizacao,
-    tem_datajud,
-    fontes,
-    n_fontes,
-    updated_at
-FROM base
-ORDER BY base.nr_processo
-"""
-
-_DOCUMENTOS_SQL = """
--- JURIS documents
-SELECT
-    regexp_replace(nr_processo, '[^0-9]', '', 'g') AS nr_processo,
-    'juris'          AS fonte,
-    id_documento::VARCHAR AS id_documento,
-    tipo,
-    data_julgamento::DATE AS data,
-    url_portal       AS url,
-    left(texto_limpo, 500) AS resumo
+    regexp_replace(nr_processo, '[^0-9]', '', 'g') AS numero_processo,
+    'juris' AS fonte,
+    id_documento::VARCHAR AS registro_id,
+    'TJRO' AS tribunal,
+    TRY_CAST(data_julgamento AS DATE) AS data,
+    'https://archive.org/download/tjro-juris-' ||
+        CAST(EXTRACT(YEAR FROM TRY_CAST(data_julgamento AS DATE)) AS VARCHAR) || '/tjro-juris-' ||
+        CAST(EXTRACT(YEAR FROM TRY_CAST(data_julgamento AS DATE)) AS VARCHAR) || '.parquet'
+        AS arquivo_ia_url
 FROM tjro_juris
 WHERE length(regexp_replace(nr_processo, '[^0-9]', '', 'g')) = 20
+"""
 
-UNION ALL
-
--- STJ documents
+_INDICE_STJ_SQL = """
 SELECT
-    regexp_replace("numeroProcesso", '[^0-9]', '', 'g') AS nr_processo,
-    'stj'            AS fonte,
-    id::VARCHAR      AS id_documento,
-    "siglaClasse"    AS tipo,
-    "dataDecisao"::DATE AS data,
-    ''               AS url,
-    left("ementa", 500) AS resumo
+    regexp_replace("numeroProcesso", '[^0-9]', '', 'g') AS numero_processo,
+    'stj' AS fonte,
+    id::VARCHAR AS registro_id,
+    'STJ' AS tribunal,
+    TRY_CAST("dataDecisao" AS DATE) AS data,
+    'https://archive.org/download/stj-acordaos-primeira-secao/stj-acordaos.parquet'
+        AS arquivo_ia_url
 FROM acordaos
 WHERE length(regexp_replace("numeroProcesso", '[^0-9]', '', 'g')) = 20
+"""
 
-ORDER BY nr_processo, data DESC NULLS LAST
+_INDICE_DATAJUD_SQL = """
+SELECT
+    regexp_replace(numero_processo, '[^0-9]', '', 'g') AS numero_processo,
+    'datajud' AS fonte,
+    md5(
+        numero_processo || ':' || grau || ':' ||
+        COALESCE(orgao_julgador_codigo::VARCHAR, 'nome:' || COALESCE(orgao_julgador, ''))
+    ) AS registro_id,
+    tribunal,
+    TRY_CAST(ultima_atualizacao AS DATE) AS data,
+    'https://archive.org/download/datajud-' || lower(tribunal) || '/datajud-capa-' ||
+        lower(tribunal) || '.parquet' AS arquivo_ia_url
+FROM datajud_capa
+WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
+"""
+
+_INDICE_SQL = f"""
+SELECT *, NOW() AS updated_at FROM (
+    {_INDICE_DJEN_SQL}
+    UNION ALL
+    {_INDICE_JURIS_SQL}
+    UNION ALL
+    {_INDICE_STJ_SQL}
+    UNION ALL
+    {_INDICE_DATAJUD_SQL}
+)
+ORDER BY numero_processo, fonte
 """
 
 
@@ -721,7 +606,8 @@ def _empty_comunicacoes_view(con: duckdb.DuckDBPyConnection) -> None:
     con.execute(
         "CREATE VIEW comunicacoes AS "
         "SELECT NULL::VARCHAR AS numero_processo, NULL::DATE AS data_disponibilizacao, "
-        "NULL::VARCHAR AS tribunal WHERE FALSE"
+        "NULL::VARCHAR AS tribunal, NULL::VARCHAR AS id, NULL::VARCHAR AS p_item_ia "
+        "WHERE FALSE"
     )
 
 
@@ -887,8 +773,8 @@ def _register_stj(con: duckdb.DuckDBPyConnection) -> SourceLoad:
 def _register_datajud(con: duckdb.DuckDBPyConnection) -> SourceLoad:
     """Register datajud_capa (local parquets, IA fallback, or empty).
 
-    Joins only when the parquet has the columns _DATAJUD_AGG_SQL needs;
-    without it the datajud columns are NULL and tem_datajud is false. The
+    Joins only when the parquet has the columns _INDICE_DATAJUD_SQL needs;
+    without those columns this source contributes nothing. The
     empty fallback is derived from the producer's own pyarrow schema
     (datajud.archive.CAPA_SCHEMA) rather than hand-typed, so it can't drift
     from it — same pattern as scripts/render_queries.py's
@@ -955,69 +841,57 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
     djen_load = _register_djen(con)
     juris_load = _register_juris(con)
     stj_load = _register_stj(con)
-
-    # Build aggregation CTEs
-    print("Building DJEN aggregation…")
-    con.execute(f"CREATE TEMP TABLE djen_agg AS {_DJEN_AGG_SQL}")
-    djen_load.rows = con.execute("SELECT COUNT(*) FROM djen_agg").fetchone()[0]
-    print(f"  {djen_load.rows:,} DJEN processes")
-
-    print("Building JURIS aggregation…")
-    con.execute(f"CREATE TEMP TABLE juris_agg AS {_JURIS_AGG_SQL}")
-    juris_load.rows = con.execute("SELECT COUNT(*) FROM juris_agg").fetchone()[0]
-    print(f"  {juris_load.rows:,} JURIS processes")
-
-    print("Building STJ aggregation…")
-    con.execute(f"CREATE TEMP TABLE stj_agg AS {_STJ_AGG_SQL}")
-    stj_load.rows = con.execute("SELECT COUNT(*) FROM stj_agg").fetchone()[0]
-    print(f"  {stj_load.rows:,} STJ processes (with valid CNJ number)")
-
-    print("Building DataJud aggregation…")
     datajud_load = _register_datajud(con)
-    con.execute(f"CREATE TEMP TABLE datajud_agg AS {_DATAJUD_AGG_SQL}")
-    datajud_load.rows = con.execute("SELECT COUNT(*) FROM datajud_agg").fetchone()[0]
-    print(f"  {datajud_load.rows:,} DataJud processes")
 
-    # Full outer join → processos_unificados
-    print("Running full outer join…")
-    con.execute(f"CREATE TEMP TABLE processos_unificados AS {_UNIFICADOS_SQL}")
-    total = con.execute("SELECT COUNT(*) FROM processos_unificados").fetchone()[0]
-    multi = con.execute("SELECT COUNT(*) FROM processos_unificados WHERE n_fontes >= 2").fetchone()[
+    # Cross-source index — flat, one row per (numero_processo, fonte,
+    # registro_id), never collapsed. See _INDICE_SQL's own comment for the
+    # design rationale (RFC 0014 M2: generalizes DJEN's own `processos`
+    # table instead of introducing a second, denormalized source of truth).
+    print("Building indice_processual…")
+    con.execute(f"CREATE TEMP TABLE indice_processual AS {_INDICE_SQL}")
+
+    # rows-per-source, for the coverage report, means "distinct processes
+    # this source touched" (comparable across sources with very different
+    # records-per-process ratios), not raw index row count.
+    for load in (djen_load, juris_load, stj_load, datajud_load):
+        load.rows = con.execute(
+            "SELECT COUNT(DISTINCT numero_processo) FROM indice_processual WHERE fonte = ?",
+            [load.name],
+        ).fetchone()[0]
+        print(f"  {load.rows:,} {load.name} processes")
+
+    total = con.execute("SELECT COUNT(DISTINCT numero_processo) FROM indice_processual").fetchone()[
         0
     ]
+    multi = con.execute(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT numero_processo FROM indice_processual"
+        "  GROUP BY numero_processo HAVING COUNT(DISTINCT fonte) >= 2"
+        ")"
+    ).fetchone()[0]
     print(f"  {total:,} unified processes ({multi:,} present in 2+ sources)")
 
-    # Intersection matrix: how many processos carry each fontes combination
+    # Intersection matrix: how many processos carry each fontes combination —
+    # one row per process (not per index row), so a process with e.g. 40
+    # DJEN comunicações still counts once, not 40 times.
     combinations = dict(
         con.execute(
-            "SELECT array_to_string(fontes, '+') AS combo, COUNT(*) "
-            "FROM processos_unificados GROUP BY combo ORDER BY combo"
+            "SELECT combo, COUNT(*) FROM ("
+            "  SELECT array_to_string(list(DISTINCT fonte ORDER BY fonte), '+') AS combo "
+            "  FROM indice_processual GROUP BY numero_processo"
+            ") GROUP BY combo ORDER BY combo"
         ).fetchall()
     )
 
-    # Write processos_unificados.parquet
+    # Write indice_processual.parquet
     DATA_DIR.mkdir(parents=True, exist_ok=True)
-    print(f"Writing {_PARQUET_UNIFICADOS}")
-    con.execute(
-        f"COPY processos_unificados TO '{_PARQUET_UNIFICADOS}' (FORMAT PARQUET, COMPRESSION ZSTD)"
-    )
-
-    # Build processo_documentos (JURIS + STJ only — DJEN's per-process rollup
-    # already lives in processos_unificados via djen_agg; adding individual
-    # DJEN communications here would need a join through textos for a resumo)
-    print("Writing processo_documentos.parquet…")
-    con.execute(
-        f"COPY ({_DOCUMENTOS_SQL}) TO '{_PARQUET_DOCUMENTOS}' (FORMAT PARQUET, COMPRESSION ZSTD)"
-    )
-    doc_count = con.execute(
-        f"SELECT COUNT(*) FROM read_parquet('{_PARQUET_DOCUMENTOS}')"
-    ).fetchone()[0]
-    print(f"  {doc_count:,} document rows")
+    print(f"Writing {_PARQUET_INDICE}")
+    con.execute(f"COPY indice_processual TO '{_PARQUET_INDICE}' (FORMAT PARQUET, COMPRESSION ZSTD)")
 
     # Source coverage report — printed, and persisted next to the output
     sources = {s.name: s for s in (djen_load, juris_load, stj_load, datajud_load)}
     report = _build_report(sources, combinations, total, multi)
-    report_path = _PARQUET_UNIFICADOS.parent / _REPORT_NAME
+    report_path = _PARQUET_INDICE.parent / _REPORT_NAME
     report_path.write_text(
         json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -1026,13 +900,11 @@ def reconcile(*, upload: bool = True) -> dict[str, Any]:
     _emit_validation(report["validation"]["errors"], report["validation"]["warnings"])
 
     if upload:
-        upload_to_ia(_PARQUET_UNIFICADOS, "processos_unificados.parquet")
-        if _PARQUET_DOCUMENTOS.exists():
-            upload_to_ia(_PARQUET_DOCUMENTOS, "processo_documentos.parquet")
+        upload_to_ia(_PARQUET_INDICE, "indice_processual.parquet")
         # RFC 0014 M2: processo_consultar needs the coverage report remotely
         # too, to distinguish "source loaded but had no rows for this CNJ"
         # from "source was unavailable when the dataset was generated" —
-        # both used to look identical (absent from `fontes`) without it.
+        # both used to look identical (absent from the index) without it.
         upload_to_ia(report_path, _REPORT_NAME)
 
     return {

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -65,14 +65,6 @@ if str(ROOT) not in sys.path:
 
 from datajud.archive import CAPA_SCHEMA as _DATAJUD_CAPA_SCHEMA
 from djen_backup.manifest import HEADER as _MANIFEST_HEADER
-from scripts.reconcile_processos import (
-    _DATAJUD_AGG_SQL,
-    _DJEN_AGG_SQL,
-    _DOCUMENTOS_SQL,
-    _JURIS_AGG_SQL,
-    _STJ_AGG_SQL,
-    _UNIFICADOS_SQL,
-)
 from tjro_juris.service import _PARQUET_SCHEMA as _TJRO_JURIS_SCHEMA
 
 
@@ -94,10 +86,18 @@ _STJ_PARQUET_IA_URL = (
     "https://archive.org/download/stj-acordaos-primeira-secao/stj-acordaos.parquet"
 )
 
-_PROCESSOS_UNIFICADOS_PARQUET = ROOT / "data" / "processos_unificados.parquet"
-_PROCESSO_DOCUMENTOS_PARQUET = ROOT / "data" / "processo_documentos.parquet"
-_PROCESSOS_IA_URL = "https://archive.org/download/causaganha-dashboard/processos_unificados.parquet"
-_DOCUMENTOS_IA_URL = "https://archive.org/download/causaganha-dashboard/processo_documentos.parquet"
+# RFC 0014 M2: the reconciler no longer publishes a wide processos_unificados/
+# processo_documentos parquet — indice_processual.parquet is the sole
+# canonical cross-source artifact. `processos_unificados`/`processo_documentos`
+# survive here only as VIEW NAMES, computed on the fly by aggregating the raw
+# per-source views (comunicacoes/tjro_juris/acordaos/datajud_capa) — the exact
+# aggregation SQL scripts/reconcile_processos.py used to run, just relocated
+# here since this is now the only remaining consumer of that shape. This keeps
+# every existing .qmd contract (e.g. processos_multi_fonte.qmd) unchanged.
+_INDICE_PROCESSUAL_PARQUET = ROOT / "data" / "indice_processual.parquet"
+_INDICE_PROCESSUAL_IA_URL = (
+    "https://archive.org/download/causaganha-dashboard/indice_processual.parquet"
+)
 
 # DDL that produces the catalog tables exported as lawyer_ratings.parquet /
 # ratings_history.parquet (scripts/pipeline/export_ratings.py) — reused as the
@@ -171,6 +171,233 @@ def _try_download_parquet(url: str, dest: Path, label: str) -> Path | None:
     return dest
 
 
+# ── processos_unificados/processo_documentos aggregation (RFC 0014 M2) ─────────
+# Moved verbatim from scripts/reconcile_processos.py, which no longer computes
+# this shape — it publishes the thin indice_processual.parquet instead. This
+# is now the only place that needs the collapsed/wide view (for .qmd
+# contracts like processos_multi_fonte.qmd that predate the index), so it
+# lives here rather than duplicated across two files.
+
+_DJEN_AGG_SQL = """
+SELECT
+    regexp_replace(numero_processo, '[^0-9]', '', 'g') AS nr_processo,
+    MIN(data_disponibilizacao)::DATE  AS djen_primeira_pub,
+    MAX(data_disponibilizacao)::DATE  AS djen_ultima_pub,
+    COUNT(*)::INTEGER                 AS djen_n_publicacoes,
+    list(DISTINCT tribunal)           AS djen_tribunais
+FROM comunicacoes
+WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
+GROUP BY nr_processo
+"""
+
+_JURIS_AGG_SQL = """
+WITH cleaned AS (
+    SELECT
+        regexp_replace(nr_processo, '[^0-9]', '', 'g') AS nr_processo,
+        id_documento,
+        tipo,
+        data_julgamento,
+        orgao,
+        relator,
+        classe_judicial,
+        url_portal
+    FROM tjro_juris
+    WHERE length(regexp_replace(nr_processo, '[^0-9]', '', 'g')) = 20
+),
+ranked AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY nr_processo
+            ORDER BY
+                CASE tipo
+                    WHEN 'ACÓRDÃO' THEN 1
+                    WHEN 'SENTENÇA' THEN 2
+                    ELSE 9
+                END,
+                data_julgamento DESC NULLS LAST
+        ) AS rn
+    FROM cleaned
+),
+principal AS (
+    SELECT * FROM ranked WHERE rn = 1
+),
+agg AS (
+    SELECT
+        nr_processo,
+        COUNT(*)::INTEGER        AS juris_n_documentos,
+        list(DISTINCT tipo)      AS juris_tipos,
+        MAX(data_julgamento)     AS juris_data_julgamento
+    FROM cleaned
+    GROUP BY nr_processo
+)
+SELECT
+    agg.nr_processo,
+    agg.juris_n_documentos,
+    agg.juris_tipos,
+    agg.juris_data_julgamento::DATE AS juris_data_julgamento,
+    principal.orgao          AS juris_orgao,
+    principal.relator        AS juris_relator,
+    principal.classe_judicial AS juris_classe,
+    principal.url_portal     AS juris_url
+FROM agg
+JOIN principal USING (nr_processo)
+"""
+
+_STJ_AGG_SQL = """
+SELECT
+    regexp_replace("numeroProcesso", '[^0-9]', '', 'g') AS nr_processo,
+    FIRST(id ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS stj_id,
+    FIRST("siglaClasse" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_classe,
+    FIRST("ministroRelator" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_relator,
+    FIRST("tema" ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS stj_tema,
+    FIRST("teseJuridica" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_tese,
+    FIRST("ementa" ORDER BY "dataDecisao" DESC NULLS LAST) AS stj_ementa,
+    MAX("dataDecisao")::DATE AS stj_data_decisao,
+    MAX("dataPublicacao")::DATE AS stj_data_publicacao
+FROM acordaos
+WHERE length(regexp_replace("numeroProcesso", '[^0-9]', '', 'g')) = 20
+GROUP BY nr_processo
+"""
+
+# DataJud capa is a per-(numero, grau, orgao) table; collapse to one row per
+# CNJ preferring the most recently updated document (usually the highest grau
+# reached). data_ajuizamento takes the earliest — the original filing.
+_DATAJUD_AGG_SQL = """
+SELECT
+    numero_processo AS nr_processo,
+    FIRST(classe_nome ORDER BY ultima_atualizacao DESC NULLS LAST) AS classe_oficial,
+    FIRST(assuntos ORDER BY ultima_atualizacao DESC NULLS LAST) AS assuntos,
+    FIRST(orgao_julgador ORDER BY ultima_atualizacao DESC NULLS LAST) AS orgao_julgador,
+    FIRST(grau ORDER BY ultima_atualizacao DESC NULLS LAST) AS grau,
+    MIN(data_ajuizamento) AS data_ajuizamento,
+    MAX(ultima_atualizacao) AS ultima_atualizacao
+FROM datajud_capa
+WHERE length(regexp_replace(numero_processo, '[^0-9]', '', 'g')) = 20
+GROUP BY numero_processo
+"""
+
+_UNIFICADOS_SQL = """
+WITH
+    base AS (
+        SELECT
+            COALESCE(d.nr_processo, j.nr_processo, s.nr_processo, dj.nr_processo) AS nr_processo,
+            d.djen_primeira_pub,
+            d.djen_ultima_pub,
+            d.djen_n_publicacoes,
+            d.djen_tribunais,
+            j.juris_n_documentos,
+            j.juris_tipos,
+            j.juris_data_julgamento,
+            j.juris_orgao,
+            j.juris_relator,
+            j.juris_classe,
+            j.juris_url,
+            s.stj_id,
+            s.stj_classe,
+            s.stj_relator,
+            s.stj_tema,
+            s.stj_tese,
+            s.stj_ementa,
+            s.stj_data_decisao,
+            s.stj_data_publicacao,
+            -- DataJud enrichment (RFC 0010) — NULL/false when the capa is absent
+            dj.classe_oficial,
+            dj.assuntos,
+            dj.orgao_julgador,
+            dj.grau,
+            dj.data_ajuizamento,
+            dj.ultima_atualizacao,
+            (dj.nr_processo IS NOT NULL) AS tem_datajud,
+            (CASE WHEN d.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
+             CASE WHEN j.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
+             CASE WHEN s.nr_processo IS NOT NULL THEN 1 ELSE 0 END +
+             CASE WHEN dj.nr_processo IS NOT NULL THEN 1 ELSE 0 END)::INTEGER AS n_fontes,
+            list_filter(
+                ['djen', 'juris', 'stj', 'datajud'],
+                x -> (
+                    (x = 'djen'    AND d.nr_processo IS NOT NULL) OR
+                    (x = 'juris'   AND j.nr_processo IS NOT NULL) OR
+                    (x = 'stj'     AND s.nr_processo IS NOT NULL) OR
+                    (x = 'datajud' AND dj.nr_processo IS NOT NULL)
+                )
+            ) AS fontes,
+            NOW() AS updated_at
+        FROM djen_agg d
+        FULL OUTER JOIN juris_agg   j USING (nr_processo)
+        FULL OUTER JOIN stj_agg     s USING (nr_processo)
+        FULL OUTER JOIN datajud_agg dj USING (nr_processo)
+    )
+SELECT
+    base.nr_processo,
+    -- Build display mask inline (20 digits → NNNNNNN-DD.AAAA.J.TR.OOOO)
+    (base.nr_processo[1:7] || '-' || base.nr_processo[8:9] || '.' ||
+     base.nr_processo[10:13] || '.' || base.nr_processo[14:14] || '.' ||
+     base.nr_processo[15:16] || '.' || base.nr_processo[17:20]) AS nr_processo_mascara,
+    djen_primeira_pub,
+    djen_ultima_pub,
+    djen_n_publicacoes,
+    djen_tribunais,
+    juris_n_documentos,
+    juris_tipos,
+    juris_data_julgamento,
+    juris_orgao,
+    juris_relator,
+    juris_classe,
+    juris_url,
+    stj_id,
+    stj_classe,
+    stj_relator,
+    stj_tema,
+    stj_tese,
+    stj_ementa,
+    stj_data_decisao,
+    stj_data_publicacao,
+    classe_oficial,
+    assuntos,
+    orgao_julgador,
+    grau,
+    data_ajuizamento,
+    ultima_atualizacao,
+    tem_datajud,
+    fontes,
+    n_fontes,
+    updated_at
+FROM base
+ORDER BY base.nr_processo
+"""
+
+_DOCUMENTOS_SQL = """
+-- JURIS documents
+SELECT
+    regexp_replace(nr_processo, '[^0-9]', '', 'g') AS nr_processo,
+    'juris'          AS fonte,
+    id_documento::VARCHAR AS id_documento,
+    tipo,
+    data_julgamento::DATE AS data,
+    url_portal       AS url,
+    left(texto_limpo, 500) AS resumo
+FROM tjro_juris
+WHERE length(regexp_replace(nr_processo, '[^0-9]', '', 'g')) = 20
+
+UNION ALL
+
+-- STJ documents
+SELECT
+    regexp_replace("numeroProcesso", '[^0-9]', '', 'g') AS nr_processo,
+    'stj'            AS fonte,
+    id::VARCHAR      AS id_documento,
+    "siglaClasse"    AS tipo,
+    "dataDecisao"::DATE AS data,
+    ''               AS url,
+    left("ementa", 500) AS resumo
+FROM acordaos
+WHERE length(regexp_replace("numeroProcesso", '[^0-9]', '', 'g')) = 20
+
+ORDER BY nr_processo, data DESC NULLS LAST
+"""
+
+
 # ── View registry ──────────────────────────────────────────────────────────────
 # Single source of truth for the data sources available to .qmd SQL, in BOTH
 # modes: `register` wires the real data for rendering; `synthetic` creates an
@@ -227,23 +454,86 @@ def _register_acordaos(con: duckdb.DuckDBPyConnection) -> bool:
     return True
 
 
-def _register_processos_unificados(con: duckdb.DuckDBPyConnection) -> bool:
-    path = _try_download_parquet(
-        _PROCESSOS_IA_URL, _PROCESSOS_UNIFICADOS_PARQUET, "processos_unificados"
+def _register_comunicacoes(con: duckdb.DuckDBPyConnection) -> bool:
+    """DJEN comunicacoes, discovered via indice_processual.parquet's own arquivo_ia_url.
+
+    RFC 0014 M2: rather than re-deriving which comunicacoes.parquet files
+    exist (a second, independent lookup against the causaganha-catalog
+    manifest, duplicating scripts/reconcile_processos.py's own discovery),
+    reuse the index's own djen rows — it already recorded exactly which
+    per-date IA item each DJEN record came from.
+    """
+    indice_path = _try_download_parquet(
+        _INDICE_PROCESSUAL_IA_URL, _INDICE_PROCESSUAL_PARQUET, "indice_processual"
     )
-    if path is None:
+    if indice_path is None:
         return False
-    _register_view_from_parquet(con, "processos_unificados", path)
+    urls = [
+        row[0]
+        for row in con.execute(
+            f"SELECT DISTINCT arquivo_ia_url FROM read_parquet('{indice_path}') "
+            "WHERE fonte = 'djen'"
+        ).fetchall()
+    ]
+    if not urls:
+        return False
+    url_list = ", ".join(f"'{u}'" for u in urls)
+    print(f"Registering DJEN comunicacoes view: {len(urls)} parquet file(s) via indice_processual")
+    con.execute(
+        f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], union_by_name=true)"
+    )
+    return True
+
+
+def _ensure_view(con: duckdb.DuckDBPyConnection, name: str, synthetic: Callable) -> None:
+    """Guarantee *name* exists on *con*, falling back to its empty synthetic schema.
+
+    Used by the aggregate views below: their SQL (moved from
+    scripts/reconcile_processos.py) references comunicacoes/tjro_juris/
+    acordaos/datajud_capa unconditionally, so every one of those must exist
+    (even if empty) regardless of whether that source's own registration
+    succeeded for this run — an unavailable source is a legitimate, common
+    case (RFC 0007), not a failure of the aggregate.
+    """
+    try:
+        con.execute(f"SELECT 1 FROM {name} LIMIT 0")
+    except duckdb.Error:
+        synthetic(con)
+
+
+def _register_processos_unificados(con: duckdb.DuckDBPyConnection) -> bool:
+    """Reconstruct the processos_unificados VIEW by aggregating the raw sources.
+
+    VIEW_SPECS registers acordaos/tjro_juris/datajud_capa (and this
+    function registers comunicacoes) before this runs, so _ensure_view's
+    fallback only fires for a source that genuinely didn't load this run —
+    the aggregate always succeeds, possibly with NULLs for a missing source,
+    exactly like scripts/reconcile_processos.py's own FULL OUTER JOIN did.
+    """
+    _register_comunicacoes(con)
+    for name, synth in (
+        ("comunicacoes", _synthetic_comunicacoes),
+        ("tjro_juris", _synthetic_tjro_juris),
+        ("acordaos", _synthetic_acordaos),
+        ("datajud_capa", _synthetic_datajud_capa),
+    ):
+        _ensure_view(con, name, synth)
+    con.execute(f"CREATE OR REPLACE TEMP VIEW djen_agg AS {_DJEN_AGG_SQL}")
+    con.execute(f"CREATE OR REPLACE TEMP VIEW juris_agg AS {_JURIS_AGG_SQL}")
+    con.execute(f"CREATE OR REPLACE TEMP VIEW stj_agg AS {_STJ_AGG_SQL}")
+    con.execute(f"CREATE OR REPLACE TEMP VIEW datajud_agg AS {_DATAJUD_AGG_SQL}")
+    con.execute(f"CREATE VIEW processos_unificados AS {_UNIFICADOS_SQL}")
     return True
 
 
 def _register_processo_documentos(con: duckdb.DuckDBPyConnection) -> bool:
-    path = _try_download_parquet(
-        _DOCUMENTOS_IA_URL, _PROCESSO_DOCUMENTOS_PARQUET, "processo_documentos"
-    )
-    if path is None:
-        return False
-    _register_view_from_parquet(con, "processo_documentos", path)
+    """Reconstruct the processo_documentos VIEW (JURIS + STJ) from raw sources."""
+    for name, synth in (
+        ("tjro_juris", _synthetic_tjro_juris),
+        ("acordaos", _synthetic_acordaos),
+    ):
+        _ensure_view(con, name, synth)
+    con.execute(f"CREATE VIEW processo_documentos AS {_DOCUMENTOS_SQL}")
     return True
 
 
@@ -338,20 +628,25 @@ def _synthetic_datajud_capa(con: duckdb.DuckDBPyConnection) -> None:
     con.register("datajud_capa", _DATAJUD_CAPA_SCHEMA.empty_table())
 
 
-def _reconcile_sources_connection() -> duckdb.DuckDBPyConnection:
-    """Scratch connection with empty inputs + aggregation views of reconcile_processos.
-
-    The processos_unificados/processo_documentos schemas are derived by running
-    the producer's own SQL (scripts/reconcile_processos.py) over empty sources,
-    so --check can never drift from what the reconcile pipeline actually writes.
-    """
-    scratch = duckdb.connect()
-    # The reconcile pipeline reads every consolidated comunicacoes.parquet
-    # (one row per DJEN publication) — distinct from the sync-manifest view.
-    scratch.execute(
+def _synthetic_comunicacoes(con: duckdb.DuckDBPyConnection) -> None:
+    """Empty comunicacoes — the columns _DJEN_AGG_SQL needs (not the full DJEN schema)."""
+    con.execute(
         "CREATE TABLE comunicacoes "
         "(numero_processo VARCHAR, data_disponibilizacao DATE, tribunal VARCHAR)"
     )
+
+
+def _reconcile_sources_connection() -> duckdb.DuckDBPyConnection:
+    """Scratch connection with empty inputs + aggregation views for the moved reconcile SQL.
+
+    The processos_unificados/processo_documentos schemas are derived by
+    running this file's own aggregation SQL (moved from
+    scripts/reconcile_processos.py — see the constants above) over empty
+    sources, so --check can never drift from what render_all actually
+    computes.
+    """
+    scratch = duckdb.connect()
+    _synthetic_comunicacoes(scratch)
     _synthetic_tjro_juris(scratch)
     _synthetic_acordaos(scratch)
     _synthetic_datajud_capa(scratch)
@@ -379,17 +674,24 @@ def _synthetic_processo_documentos(con: duckdb.DuckDBPyConnection) -> None:
     _synthetic_from_reconcile_sql(con, "processo_documentos", _DOCUMENTOS_SQL)
 
 
+# acordaos/tjro_juris/datajud_capa MUST come before processos_unificados/
+# processo_documentos: those two build synthetic empty fallbacks for any
+# source not already registered (_ensure_view), which would collide with a
+# later CREATE VIEW from this same source's own spec if the order were
+# reversed. comunicacoes has no standalone spec — no .qmd queries it
+# directly, only _register_processos_unificados does (via
+# _register_comunicacoes internally).
 VIEW_SPECS: tuple[ViewSpec, ...] = (
     ViewSpec("manifest", _register_manifest, _synthetic_manifest),
     ViewSpec("lawyer_ratings", _register_lawyer_ratings, _synthetic_lawyer_ratings),
     ViewSpec("ratings_history", _register_ratings_history, _synthetic_ratings_history),
     ViewSpec("acordaos", _register_acordaos, _synthetic_acordaos),
+    ViewSpec("tjro_juris", _register_tjro_juris, _synthetic_tjro_juris),
+    ViewSpec("datajud_capa", _register_datajud_capa, _synthetic_datajud_capa),
     ViewSpec(
         "processos_unificados", _register_processos_unificados, _synthetic_processos_unificados
     ),
     ViewSpec("processo_documentos", _register_processo_documentos, _synthetic_processo_documentos),
-    ViewSpec("tjro_juris", _register_tjro_juris, _synthetic_tjro_juris),
-    ViewSpec("datajud_capa", _register_datajud_capa, _synthetic_datajud_capa),
 )
 
 

--- a/scripts/render_queries.py
+++ b/scripts/render_queries.py
@@ -99,6 +99,20 @@ _INDICE_PROCESSUAL_IA_URL = (
     "https://archive.org/download/causaganha-dashboard/indice_processual.parquet"
 )
 
+# Rollout fallback (RFC 0014 M2 review): indice_processual.parquet is a brand
+# new artifact — deploy-web.yml can build before update-catalog.yml has ever
+# published it (that step only runs when has_new_uploads==true; a plain push
+# to main touching web/**/render_queries.py deploys immediately, with no
+# ordering guarantee against the catalog pipeline). Without a fallback,
+# processos_multi_fonte.qmd would regress from "has real DJEN data" (its
+# state today, discovered via the catalog manifest) to "empty" for however
+# long that takes. _comunicacoes_urls_from_catalog reproduces the same
+# catalog-manifest lookup reconcile_processos.py's own
+# comunicacoes_parquet_urls() uses, so _register_comunicacoes only needs it
+# during that transition window — remove once indice_processual.parquet has
+# been confirmed published at least once.
+_IA_CATALOG_MANIFEST_URL = "https://archive.org/download/causaganha-catalog/manifest.parquet"
+
 # DDL that produces the catalog tables exported as lawyer_ratings.parquet /
 # ratings_history.parquet (scripts/pipeline/export_ratings.py) — reused as the
 # synthetic schema source for --check.
@@ -454,6 +468,25 @@ def _register_acordaos(con: duckdb.DuckDBPyConnection) -> bool:
     return True
 
 
+def _comunicacoes_urls_from_catalog(con: duckdb.DuckDBPyConnection) -> list[str]:
+    """DJEN comunicacoes URLs straight from the causaganha-catalog manifest.
+
+    Rollout fallback only (see _IA_CATALOG_MANIFEST_URL) — reproduces
+    scripts/reconcile_processos.py's own comunicacoes_parquet_urls(). Returns
+    [] on any read failure (unreachable/absent catalog manifest), same as an
+    absent indice_processual.parquet — the caller treats both as "try the
+    next thing, then fall back to empty" uniformly.
+    """
+    try:
+        rows = con.execute(
+            "SELECT DISTINCT ia_url FROM read_parquet(?) WHERE table_name = 'comunicacoes'",
+            [_IA_CATALOG_MANIFEST_URL],
+        ).fetchall()
+    except duckdb.Error:
+        return []
+    return sorted(r[0] for r in rows)
+
+
 def _register_comunicacoes(con: duckdb.DuckDBPyConnection) -> bool:
     """DJEN comunicacoes, discovered via indice_processual.parquet's own arquivo_ia_url.
 
@@ -462,23 +495,32 @@ def _register_comunicacoes(con: duckdb.DuckDBPyConnection) -> bool:
     manifest, duplicating scripts/reconcile_processos.py's own discovery),
     reuse the index's own djen rows — it already recorded exactly which
     per-date IA item each DJEN record came from.
+
+    Falls back to _comunicacoes_urls_from_catalog when the index itself
+    isn't available yet (or lists no djen rows) — see that function's
+    docstring for why: this is a rollout-window guard, not the steady state.
     """
+    urls: list[str] = []
     indice_path = _try_download_parquet(
         _INDICE_PROCESSUAL_IA_URL, _INDICE_PROCESSUAL_PARQUET, "indice_processual"
     )
-    if indice_path is None:
-        return False
-    urls = [
-        row[0]
-        for row in con.execute(
-            f"SELECT DISTINCT arquivo_ia_url FROM read_parquet('{indice_path}') "
-            "WHERE fonte = 'djen'"
-        ).fetchall()
-    ]
+    if indice_path is not None:
+        urls = [
+            row[0]
+            for row in con.execute(
+                f"SELECT DISTINCT arquivo_ia_url FROM read_parquet('{indice_path}') "
+                "WHERE fonte = 'djen'"
+            ).fetchall()
+        ]
+    if not urls:
+        urls = _comunicacoes_urls_from_catalog(con)
+        source = "causaganha-catalog manifest (indice_processual fallback)"
+    else:
+        source = "indice_processual"
     if not urls:
         return False
     url_list = ", ".join(f"'{u}'" for u in urls)
-    print(f"Registering DJEN comunicacoes view: {len(urls)} parquet file(s) via indice_processual")
+    print(f"Registering DJEN comunicacoes view: {len(urls)} parquet file(s) via {source}")
     con.execute(
         f"CREATE VIEW comunicacoes AS SELECT * FROM read_parquet([{url_list}], union_by_name=true)"
     )

--- a/src/causaganha/processos/__init__.py
+++ b/src/causaganha/processos/__init__.py
@@ -1,0 +1,8 @@
+"""Dossiê de processo unificado (RFC 0014 M2) — DJEN + JURIS + STJ + DataJud.
+
+Consulta os dois parquets canônicos publicados em `causaganha-dashboard`
+(Internet Archive) — a mesma fonte que o dashboard web já usa (RFC 0005) —
+sem cache local nesta primeira versão.
+"""
+
+from __future__ import annotations

--- a/src/causaganha/processos/cnj.py
+++ b/src/causaganha/processos/cnj.py
@@ -1,0 +1,41 @@
+"""Normalização de número CNJ — módulo de domínio compartilhado (RFC 0014 M2).
+
+Antes desta consolidação, a mesma regra existia em três lugares
+independentes: `datajud.models` (Python), `scripts/reconcile_processos.py`
+(Python) e `web/src/lib/processoCnj.ts` (TypeScript, cliente do dashboard).
+Este módulo é agora a única implementação Python; `datajud.models` reexporta
+estes nomes para não quebrar consumidores existentes, e
+`scripts/reconcile_processos.py` importa daqui em vez de manter sua própria
+cópia. A implementação TypeScript continua separada (runtime distinto,
+DuckDB-WASM no navegador), mas segue a mesma regra — ver os comentários em
+`processoCnj.ts`.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+CNJ_LEN = 20
+
+
+def so_digitos(value: str | None) -> str:
+    """Remove todo caractere não numérico de *value*."""
+    return re.sub(r"\D", "", value or "")
+
+
+def normalizar_cnj(value: str | None) -> str:
+    """Retorna o CNJ de 20 dígitos, ou '' quando *value* não é um CNJ válido."""
+    digits = so_digitos(value)
+    return digits if len(digits) == CNJ_LEN else ""
+
+
+def formatar_cnj(value: str) -> str:
+    """20 dígitos → NNNNNNN-DD.AAAA.J.TR.OOOO (máscara de exibição)."""
+    digits = so_digitos(value)
+    if len(digits) != CNJ_LEN:
+        return value
+    return (
+        f"{digits[0:7]}-{digits[7:9]}.{digits[9:13]}."
+        f"{digits[13:14]}.{digits[14:16]}.{digits[16:20]}"
+    )

--- a/src/causaganha/processos/cnj.py
+++ b/src/causaganha/processos/cnj.py
@@ -1,14 +1,15 @@
 """Normalização de número CNJ — módulo de domínio compartilhado (RFC 0014 M2).
 
-Antes desta consolidação, a mesma regra existia em três lugares
-independentes: `datajud.models` (Python), `scripts/reconcile_processos.py`
-(Python) e `web/src/lib/processoCnj.ts` (TypeScript, cliente do dashboard).
-Este módulo é agora a única implementação Python; `datajud.models` reexporta
-estes nomes para não quebrar consumidores existentes, e
-`scripts/reconcile_processos.py` importa daqui em vez de manter sua própria
-cópia. A implementação TypeScript continua separada (runtime distinto,
-DuckDB-WASM no navegador), mas segue a mesma regra — ver os comentários em
-`processoCnj.ts`.
+Antes desta consolidação, a mesma regra existia duplicada em `datajud.models`
+e em `web/src/lib/processoCnj.ts` (TypeScript, cliente do dashboard). Este
+módulo é agora a única implementação Python de uso geral; `datajud.models`
+reexporta estes nomes para não quebrar consumidores existentes, e
+`causaganha.processos.service` importa daqui. `scripts/reconcile_processos.py`
+normaliza inline via `regexp_replace` em SQL (o CNJ nunca sai do DuckDB
+durante a reconciliação), então não importa este módulo — mas segue a mesma
+regra de 20 dígitos. A implementação TypeScript continua separada (runtime
+distinto, DuckDB-WASM no navegador), também seguindo a mesma regra — ver os
+comentários em `processoCnj.ts`.
 """
 
 from __future__ import annotations

--- a/src/causaganha/processos/models.py
+++ b/src/causaganha/processos/models.py
@@ -1,0 +1,104 @@
+"""Modelos de domínio para o dossiê de processo unificado (RFC 0014 M2).
+
+Dataclasses puras, sem Pydantic — a mesma separação usada em
+`datajud.service`/`tjro_juris.service`/etc.: a camada de serviço não conhece
+FastMCP nem a CLI, só o domínio. `causaganha_mcp.tools.processo` converte
+este resultado para os modelos Pydantic da tool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class CnjInvalidoError(ValueError):
+    """O CNJ informado não tem 20 dígitos válidos."""
+
+
+@dataclass
+class FonteCobertura:
+    """Estado de uma fonte na geração do dataset (de `processos_unificados.report.json`)."""
+
+    fonte: str
+    status: str
+    registros: int
+
+
+@dataclass
+class DocumentoProcesso:
+    """Uma linha de `processo_documentos.parquet` (JURIS ou STJ, nunca DJEN/DataJud)."""
+
+    fonte: str
+    id_documento: str
+    tipo: str | None
+    data: str | None
+    url: str | None
+    resumo: str | None
+
+
+@dataclass
+class DjenResumo:
+    """Resumo das publicações DJEN de um processo."""
+
+    primeira_publicacao: str | None
+    ultima_publicacao: str | None
+    n_publicacoes: int | None
+    tribunais: list[str]
+
+
+@dataclass
+class JurisDecisao:
+    """Decisão(ões) do TJRO JURIS para um processo."""
+
+    n_documentos: int | None
+    tipos: list[str]
+    data_julgamento: str | None
+    orgao: str | None
+    relator: str | None
+    classe: str | None
+    url: str | None
+
+
+@dataclass
+class StjAcordao:
+    """Acórdão do STJ para um processo, quando houver."""
+
+    id: str | None
+    classe: str | None
+    relator: str | None
+    tema: str | None
+    tese: str | None
+    ementa: str | None
+    data_decisao: str | None
+    data_publicacao: str | None
+
+
+@dataclass
+class DatajudCapa:
+    """Capa oficial do DataJud (RFC 0010) para um processo."""
+
+    classe_oficial: str | None
+    assuntos: str | None
+    orgao_julgador: str | None
+    grau: str | None
+    data_ajuizamento: str | None
+    ultima_atualizacao: str | None
+
+
+@dataclass
+class ProcessoConsultaResult:
+    """Resultado de `service.buscar_processo` — encontrado ou não."""
+
+    encontrado: bool
+    nr_processo: str
+    nr_processo_mascara: str
+    fontes_presentes: list[str] = field(default_factory=list)
+    cobertura_dataset: list[FonteCobertura] = field(default_factory=list)
+    djen: DjenResumo | None = None
+    juris: JurisDecisao | None = None
+    stj: StjAcordao | None = None
+    datajud: DatajudCapa | None = None
+    documentos: list[DocumentoProcesso] = field(default_factory=list)
+    documentos_truncados: bool = False
+    dataset_gerado_em: str | None = None
+    avisos: list[str] = field(default_factory=list)

--- a/src/causaganha/processos/models.py
+++ b/src/causaganha/processos/models.py
@@ -17,7 +17,7 @@ class CnjInvalidoError(ValueError):
 
 @dataclass
 class FonteCobertura:
-    """Estado de uma fonte na geração do dataset (de `processos_unificados.report.json`)."""
+    """Estado de uma fonte na geração do dataset (de `indice_processual.report.json`)."""
 
     fonte: str
     status: str
@@ -26,7 +26,7 @@ class FonteCobertura:
 
 @dataclass
 class DocumentoProcesso:
-    """Uma linha de `processo_documentos.parquet` (JURIS ou STJ, nunca DJEN/DataJud)."""
+    """Documento JURIS ou STJ do processo (nunca DJEN/DataJud — ver `service.buscar_processo`)."""
 
     fonte: str
     id_documento: str

--- a/src/causaganha/processos/service.py
+++ b/src/causaganha/processos/service.py
@@ -365,52 +365,52 @@ def buscar_processo(
         msg = f"CNJ inválido (esperado 20 dígitos): {cnj!r}"
         raise CnjInvalidoError(msg)
 
-    con = duckdb.connect()
-    _load_httpfs(con)
+    with duckdb.connect() as con:
+        _load_httpfs(con)
 
-    rows = con.execute(_indice_sql(indice_url), [nr_processo]).fetchall()
+        rows = con.execute(_indice_sql(indice_url), [nr_processo]).fetchall()
 
-    avisos: list[str] = []
-    cobertura_result = _carregar_cobertura(report_url)
-    if cobertura_result is None:
-        cobertura: list[FonteCobertura] = []
-        dataset_gerado_em: str | None = None
-        avisos.append(_RELATORIO_INDISPONIVEL_AVISO)
-    else:
-        cobertura, dataset_gerado_em = cobertura_result
+        avisos: list[str] = []
+        cobertura_result = _carregar_cobertura(report_url)
+        if cobertura_result is None:
+            cobertura: list[FonteCobertura] = []
+            dataset_gerado_em: str | None = None
+            avisos.append(_RELATORIO_INDISPONIVEL_AVISO)
+        else:
+            cobertura, dataset_gerado_em = cobertura_result
 
-    if not rows:
-        return ProcessoConsultaResult(
-            encontrado=False,
-            nr_processo=nr_processo,
-            nr_processo_mascara=formatar_cnj(nr_processo),
-            cobertura_dataset=cobertura,
-            dataset_gerado_em=dataset_gerado_em,
-            avisos=avisos,
-        )
+        if not rows:
+            return ProcessoConsultaResult(
+                encontrado=False,
+                nr_processo=nr_processo,
+                nr_processo_mascara=formatar_cnj(nr_processo),
+                cobertura_dataset=cobertura,
+                dataset_gerado_em=dataset_gerado_em,
+                avisos=avisos,
+            )
 
-    fontes_presentes = sorted({fonte for fonte, _url in rows})
-    djen_urls = _fonte_urls(rows, "djen")
-    juris_urls = _fonte_urls(rows, "juris")
-    stj_urls = _fonte_urls(rows, "stj")
-    datajud_urls = _fonte_urls(rows, "datajud")
+        fontes_presentes = sorted({fonte for fonte, _url in rows})
+        djen_urls = _fonte_urls(rows, "djen")
+        juris_urls = _fonte_urls(rows, "juris")
+        stj_urls = _fonte_urls(rows, "stj")
+        datajud_urls = _fonte_urls(rows, "datajud")
 
-    djen = _build_djen(con, djen_urls, nr_processo, avisos)
-    juris = _build_juris(con, juris_urls, nr_processo, avisos)
-    stj = _build_stj(con, stj_urls, nr_processo, avisos)
-    datajud = _build_datajud(con, datajud_urls, nr_processo, avisos)
+        djen = _build_djen(con, djen_urls, nr_processo, avisos)
+        juris = _build_juris(con, juris_urls, nr_processo, avisos)
+        stj = _build_stj(con, stj_urls, nr_processo, avisos)
+        datajud = _build_datajud(con, datajud_urls, nr_processo, avisos)
 
-    # Sem relatório, dataset_gerado_em fica None — o índice não guarda um
-    # timestamp por linha (é fino por design), então não há fallback de
-    # "geração" possível aqui como havia na versão de tabela larga; o aviso
-    # do relatório indisponível já cobre essa lacuna.
+        # Sem relatório, dataset_gerado_em fica None — o índice não guarda um
+        # timestamp por linha (é fino por design), então não há fallback de
+        # "geração" possível aqui como havia na versão de tabela larga; o
+        # aviso do relatório indisponível já cobre essa lacuna.
 
-    documentos: list[DocumentoProcesso] = []
-    documentos_truncados = False
-    if incluir_documentos:
-        documentos, documentos_truncados = _build_documentos(
-            con, juris_urls, stj_urls, nr_processo, limite_documentos, avisos
-        )
+        documentos: list[DocumentoProcesso] = []
+        documentos_truncados = False
+        if incluir_documentos:
+            documentos, documentos_truncados = _build_documentos(
+                con, juris_urls, stj_urls, nr_processo, limite_documentos, avisos
+            )
 
     return ProcessoConsultaResult(
         encontrado=True,

--- a/src/causaganha/processos/service.py
+++ b/src/causaganha/processos/service.py
@@ -1,22 +1,28 @@
 """Consulta ao dossiê de processo unificado via DuckDB (RFC 0014 M2).
 
-Lê, por padrão, os dois parquets canônicos publicados no item IA
-`causaganha-dashboard` (`processos_unificados.parquet` +
-`processo_documentos.parquet`, produzidos por
-`scripts/reconcile_processos.py`) — a mesma fonte, com a mesma projeção de
-colunas e ordenação, que `web/src/lib/processoCnj.ts` usa para renderizar
-`/processo?cnj=...`. Nenhum cache local nesta primeira versão: a decisão
-(RFC 0014 M2) foi ler direto do Internet Archive, para que a tool funcione
-numa instalação nova e nunca divirja do que o dashboard já publica.
+Lê, por padrão, `indice_processual.parquet` — o índice fino publicado no
+item IA `causaganha-dashboard` por `scripts/reconcile_processos.py` — para
+descobrir quais fontes (DJEN/JURIS/STJ/DataJud) têm registro para um CNJ e
+em qual arquivo cada registro vive (`arquivo_ia_url`). O dossiê em si é
+montado consultando os parquets de origem (`comunicacoes.parquet`,
+`tjro-juris-{ano}.parquet`, `stj-acordaos.parquet`, `datajud-capa-
+{tribunal}.parquet`) diretamente — o índice nunca guarda cópia dos campos de
+conteúdo (generaliza o padrão que a própria tabela `processos` do DJEN já
+usava; ver `causaganha/consolidate/schema_registry.py`).
+
+Nenhum cache local nesta primeira versão: a decisão (RFC 0014 M2) foi ler
+direto do Internet Archive, para que a tool funcione numa instalação nova e
+nunca divirja do que o dashboard já publica (mesma semântica de
+`web/src/lib/processoCnj.ts`).
 
 Falhas são tratadas em duas categorias:
-  - Não conseguir abrir `processos_unificados.parquet` é fatal — propaga a
+  - Não conseguir abrir `indice_processual.parquet` é fatal — propaga a
     exceção do DuckDB/httpx para o chamador (a tool MCP a traduz em
     `ToolError`; não há resposta possível sem esse arquivo).
-  - Não conseguir carregar `processo_documentos.parquet` ou
-    `processos_unificados.report.json` é parcial — o processo já encontrado
-    ainda é retornado, com a lista/lacuna correspondente vazia e um aviso em
-    `avisos`, nunca uma exceção.
+  - Não conseguir carregar um parquet de origem específico ou o relatório de
+    cobertura (`indice_processual.report.json`) é parcial — o processo já
+    encontrado ainda é retornado, com a lacuna correspondente vazia e um
+    aviso em `avisos`, nunca uma exceção.
 """
 
 from __future__ import annotations
@@ -43,44 +49,124 @@ from causaganha.processos.models import (
 
 
 IA_DASHBOARD_BASE = "https://archive.org/download/causaganha-dashboard"
-PROCESSOS_UNIFICADOS_URL = f"{IA_DASHBOARD_BASE}/processos_unificados.parquet"
-PROCESSO_DOCUMENTOS_URL = f"{IA_DASHBOARD_BASE}/processo_documentos.parquet"
-REPORT_URL = f"{IA_DASHBOARD_BASE}/processos_unificados.report.json"
+INDICE_PROCESSUAL_URL = f"{IA_DASHBOARD_BASE}/indice_processual.parquet"
+REPORT_URL = f"{IA_DASHBOARD_BASE}/indice_processual.report.json"
 
 _RELATORIO_INDISPONIVEL_AVISO = (
-    "Relatório de cobertura (processos_unificados.report.json) indisponível; "
+    "Relatório de cobertura (indice_processual.report.json) indisponível; "
     "sem detalhamento de quais fontes estavam carregadas na geração do dataset."
 )
 
 
-def _unificado_sql(url: str) -> str:
+def _url_list_sql(urls: list[str]) -> str:
+    return ", ".join(f"'{u}'" for u in urls)
+
+
+def _indice_sql(url: str) -> str:
     # `url` é sempre uma constante do módulo (ou um override explícito de
     # teste), nunca entrada do usuário — só o CNJ, abaixo, é bind parameter.
     return f"""
-        SELECT
-            nr_processo, nr_processo_mascara, fontes,
-            djen_primeira_pub, djen_ultima_pub, djen_n_publicacoes, djen_tribunais,
-            juris_n_documentos, juris_tipos, juris_data_julgamento,
-            juris_orgao, juris_relator, juris_classe, juris_url,
-            stj_id, stj_classe, stj_relator, stj_tema, stj_tese, stj_ementa,
-            stj_data_decisao, stj_data_publicacao,
-            classe_oficial, assuntos, orgao_julgador, grau,
-            data_ajuizamento, ultima_atualizacao, tem_datajud,
-            updated_at
+        SELECT fonte, arquivo_ia_url
         FROM read_parquet('{url}')
-        WHERE nr_processo = ?
-        LIMIT 1
-    """  # noqa: S608
+        WHERE numero_processo = ?
+    """
 
 
-def _documentos_sql(url: str) -> str:
+def _djen_sql(urls: list[str]) -> str:
     return f"""
-        SELECT fonte, id_documento, tipo, data, url, resumo
-        FROM read_parquet('{url}')
-        WHERE nr_processo = ?
-        ORDER BY data DESC NULLS LAST, id_documento
-        LIMIT ?
-    """  # noqa: S608
+        SELECT
+            COUNT(*)::INTEGER AS n_publicacoes,
+            MIN(data_disponibilizacao)::DATE AS primeira_publicacao,
+            MAX(data_disponibilizacao)::DATE AS ultima_publicacao,
+            list(DISTINCT tribunal) AS tribunais
+        FROM read_parquet([{_url_list_sql(urls)}], union_by_name=true)
+        WHERE regexp_replace(numero_processo, '[^0-9]', '', 'g') = ?
+    """
+
+
+def _juris_sql(urls: list[str]) -> str:
+    return f"""
+        WITH cleaned AS (
+            SELECT id_documento, tipo, data_julgamento, orgao, relator, classe_judicial, url_portal
+            FROM read_parquet([{_url_list_sql(urls)}])
+            WHERE regexp_replace(nr_processo, '[^0-9]', '', 'g') = ?
+        ),
+        ranked AS (
+            SELECT *, ROW_NUMBER() OVER (
+                ORDER BY
+                    CASE tipo WHEN 'ACÓRDÃO' THEN 1 WHEN 'SENTENÇA' THEN 2 ELSE 9 END,
+                    data_julgamento DESC NULLS LAST
+            ) AS rn
+            FROM cleaned
+        ),
+        principal AS (SELECT * FROM ranked WHERE rn = 1),
+        agg AS (
+            SELECT
+                COUNT(*)::INTEGER AS n_documentos,
+                list(DISTINCT tipo) AS tipos,
+                MAX(data_julgamento) AS data_julgamento
+            FROM cleaned
+        )
+        SELECT
+            agg.n_documentos, agg.tipos, agg.data_julgamento::DATE AS data_julgamento,
+            principal.orgao, principal.relator,
+            principal.classe_judicial AS classe, principal.url_portal AS url
+        FROM agg, principal
+    """
+
+
+def _stj_sql(urls: list[str]) -> str:
+    return f"""
+        SELECT
+            COUNT(*)::INTEGER AS n,
+            FIRST(id ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS id,
+            FIRST("siglaClasse" ORDER BY "dataDecisao" DESC NULLS LAST) AS classe,
+            FIRST("ministroRelator" ORDER BY "dataDecisao" DESC NULLS LAST) AS relator,
+            FIRST("tema" ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS tema,
+            FIRST("teseJuridica" ORDER BY "dataDecisao" DESC NULLS LAST) AS tese,
+            FIRST("ementa" ORDER BY "dataDecisao" DESC NULLS LAST) AS ementa,
+            MAX("dataDecisao")::DATE AS data_decisao,
+            MAX("dataPublicacao")::DATE AS data_publicacao
+        FROM read_parquet([{_url_list_sql(urls)}])
+        WHERE regexp_replace("numeroProcesso", '[^0-9]', '', 'g') = ?
+    """
+
+
+def _datajud_sql(urls: list[str]) -> str:
+    return f"""
+        SELECT
+            COUNT(*)::INTEGER AS n,
+            FIRST(classe_nome ORDER BY ultima_atualizacao DESC NULLS LAST) AS classe_oficial,
+            FIRST(assuntos ORDER BY ultima_atualizacao DESC NULLS LAST) AS assuntos,
+            FIRST(orgao_julgador ORDER BY ultima_atualizacao DESC NULLS LAST) AS orgao_julgador,
+            FIRST(grau ORDER BY ultima_atualizacao DESC NULLS LAST) AS grau,
+            MIN(data_ajuizamento) AS data_ajuizamento,
+            MAX(ultima_atualizacao) AS ultima_atualizacao
+        FROM read_parquet([{_url_list_sql(urls)}])
+        WHERE numero_processo = ?
+    """
+
+
+def _documentos_sql(juris_urls: list[str], stj_urls: list[str]) -> tuple[str, int]:
+    """Returns (sql, n_cnj_params) — one `?` per source branch present, before the LIMIT `?`."""
+    parts = []
+    if juris_urls:
+        parts.append(f"""
+            SELECT 'juris' AS fonte, id_documento::VARCHAR AS id_documento, tipo,
+                data_julgamento::DATE AS data, url_portal AS url,
+                left(texto_limpo, 500) AS resumo
+            FROM read_parquet([{_url_list_sql(juris_urls)}])
+            WHERE regexp_replace(nr_processo, '[^0-9]', '', 'g') = ?
+        """)
+    if stj_urls:
+        parts.append(f"""
+            SELECT 'stj' AS fonte, id::VARCHAR AS id_documento, "siglaClasse" AS tipo,
+                "dataDecisao"::DATE AS data, '' AS url, left("ementa", 500) AS resumo
+            FROM read_parquet([{_url_list_sql(stj_urls)}])
+            WHERE regexp_replace("numeroProcesso", '[^0-9]', '', 'g') = ?
+        """)
+    union = " UNION ALL ".join(parts)
+    return f"{union} ORDER BY data DESC NULLS LAST, id_documento LIMIT ?", len(parts)
 
 
 def _iso(value: Any) -> str | None:  # noqa: ANN401 — DuckDB row values are untyped at this layer
@@ -100,7 +186,7 @@ def _fetch_text(url_or_path: str) -> str:
 
 
 def _carregar_cobertura(report_url: str) -> tuple[list[FonteCobertura], str | None] | None:
-    """Carrega `processos_unificados.report.json`; None quando indisponível/ilegível."""
+    """Carrega `indice_processual.report.json`; None quando indisponível/ilegível."""
     try:
         raw = _fetch_text(report_url)
         data = json.loads(raw)
@@ -113,126 +199,131 @@ def _carregar_cobertura(report_url: str) -> tuple[list[FonteCobertura], str | No
     return cobertura, data.get("generated_at")
 
 
-def _load_httpfs_if_remote(con: duckdb.DuckDBPyConnection, url: str) -> None:
-    if not url.startswith(("http://", "https://")):
-        return
-    # Deixa a query real abaixo falhar com um erro claro caso o httpfs seja
-    # de fato necessário — mesmo padrão não-fatal usado em
-    # scripts/reconcile_processos.py.
+def _fonte_urls(rows: list[tuple[str, str]], fonte: str) -> list[str]:
+    return sorted({url for row_fonte, url in rows if row_fonte == fonte})
+
+
+def _load_httpfs(con: duckdb.DuckDBPyConnection) -> None:
+    # INSTALL/LOAD httpfs is idempotent and cheap once already loaded, so
+    # this is always called unconditionally rather than trying to predict
+    # whether any of the URLs about to be queried are remote.
     with contextlib.suppress(duckdb.Error):
         con.execute("INSTALL httpfs; LOAD httpfs;")
 
 
-def _mapear_linha(
-    row: tuple[Any, ...],
-) -> tuple[
-    str,
-    list[str],
-    DjenResumo | None,
-    JurisDecisao | None,
-    StjAcordao | None,
-    DatajudCapa | None,
-    Any,
-]:
-    """Converte uma linha crua de `processos_unificados` nos sub-modelos por fonte."""
-    (
-        _nr_processo,
-        nr_processo_mascara,
-        fontes,
-        djen_primeira_pub,
-        djen_ultima_pub,
-        djen_n_publicacoes,
-        djen_tribunais,
-        juris_n_documentos,
-        juris_tipos,
-        juris_data_julgamento,
-        juris_orgao,
-        juris_relator,
-        juris_classe,
-        juris_url,
-        stj_id,
-        stj_classe,
-        stj_relator,
-        stj_tema,
-        stj_tese,
-        stj_ementa,
-        stj_data_decisao,
-        stj_data_publicacao,
-        classe_oficial,
-        assuntos,
-        orgao_julgador,
-        grau,
-        data_ajuizamento,
-        ultima_atualizacao,
-        tem_datajud,
-        updated_at,
-    ) = row
-
-    fontes_presentes = list(fontes or [])
-
-    djen = None
-    if "djen" in fontes_presentes:
-        djen = DjenResumo(
-            primeira_publicacao=_iso(djen_primeira_pub),
-            ultima_publicacao=_iso(djen_ultima_pub),
-            n_publicacoes=djen_n_publicacoes,
-            tribunais=list(djen_tribunais or []),
-        )
-
-    juris = None
-    if "juris" in fontes_presentes:
-        juris = JurisDecisao(
-            n_documentos=juris_n_documentos,
-            tipos=list(juris_tipos or []),
-            data_julgamento=_iso(juris_data_julgamento),
-            orgao=juris_orgao,
-            relator=juris_relator,
-            classe=juris_classe,
-            url=juris_url,
-        )
-
-    stj = None
-    if "stj" in fontes_presentes:
-        stj = StjAcordao(
-            id=stj_id,
-            classe=stj_classe,
-            relator=stj_relator,
-            tema=stj_tema,
-            tese=stj_tese,
-            ementa=stj_ementa,
-            data_decisao=_iso(stj_data_decisao),
-            data_publicacao=_iso(stj_data_publicacao),
-        )
-
-    # tem_datajud é a fonte da verdade (RFC 0010); checar os dois é
-    # redundante com a lista `fontes` mas inofensivo caso um dia divirjam —
-    # mesma cautela de `web/src/lib/processoCnj.ts:mapProcessoRow`.
-    datajud = None
-    if "datajud" in fontes_presentes and tem_datajud:
-        datajud = DatajudCapa(
-            classe_oficial=classe_oficial,
-            assuntos=assuntos,
-            orgao_julgador=orgao_julgador,
-            grau=grau,
-            data_ajuizamento=_iso(data_ajuizamento),
-            ultima_atualizacao=_iso(ultima_atualizacao),
-        )
-
-    return nr_processo_mascara, fontes_presentes, djen, juris, stj, datajud, updated_at
+def _fonte_indisponivel_aviso(fonte: str, exc: duckdb.Error) -> str:
+    return f"Fonte '{fonte}' indisponível para este processo: {exc}"
 
 
-def _carregar_documentos(
+def _build_djen(
+    con: duckdb.DuckDBPyConnection, urls: list[str], cnj: str, avisos: list[str]
+) -> DjenResumo | None:
+    if not urls:
+        return None
+    try:
+        row = con.execute(_djen_sql(urls), [cnj]).fetchone()
+    except duckdb.Error as exc:
+        avisos.append(_fonte_indisponivel_aviso("djen", exc))
+        return None
+    if row is None or row[0] == 0:
+        return None
+    n_publicacoes, primeira, ultima, tribunais = row
+    return DjenResumo(
+        primeira_publicacao=_iso(primeira),
+        ultima_publicacao=_iso(ultima),
+        n_publicacoes=n_publicacoes,
+        tribunais=list(tribunais or []),
+    )
+
+
+def _build_juris(
+    con: duckdb.DuckDBPyConnection, urls: list[str], cnj: str, avisos: list[str]
+) -> JurisDecisao | None:
+    if not urls:
+        return None
+    try:
+        row = con.execute(_juris_sql(urls), [cnj]).fetchone()
+    except duckdb.Error as exc:
+        avisos.append(_fonte_indisponivel_aviso("juris", exc))
+        return None
+    if row is None:
+        return None
+    n_documentos, tipos, data_julgamento, orgao, relator, classe, url = row
+    return JurisDecisao(
+        n_documentos=n_documentos,
+        tipos=list(tipos or []),
+        data_julgamento=_iso(data_julgamento),
+        orgao=orgao,
+        relator=relator,
+        classe=classe,
+        url=url,
+    )
+
+
+def _build_stj(
+    con: duckdb.DuckDBPyConnection, urls: list[str], cnj: str, avisos: list[str]
+) -> StjAcordao | None:
+    if not urls:
+        return None
+    try:
+        row = con.execute(_stj_sql(urls), [cnj]).fetchone()
+    except duckdb.Error as exc:
+        avisos.append(_fonte_indisponivel_aviso("stj", exc))
+        return None
+    if row is None or row[0] == 0:
+        return None
+    _n, id_, classe, relator, tema, tese, ementa, data_decisao, data_publicacao = row
+    return StjAcordao(
+        id=id_,
+        classe=classe,
+        relator=relator,
+        tema=tema,
+        tese=tese,
+        ementa=ementa,
+        data_decisao=_iso(data_decisao),
+        data_publicacao=_iso(data_publicacao),
+    )
+
+
+def _build_datajud(
+    con: duckdb.DuckDBPyConnection, urls: list[str], cnj: str, avisos: list[str]
+) -> DatajudCapa | None:
+    if not urls:
+        return None
+    try:
+        row = con.execute(_datajud_sql(urls), [cnj]).fetchone()
+    except duckdb.Error as exc:
+        avisos.append(_fonte_indisponivel_aviso("datajud", exc))
+        return None
+    if row is None or row[0] == 0:
+        return None
+    _n, classe_oficial, assuntos, orgao_julgador, grau, data_ajuizamento, ultima_atualizacao = row
+    return DatajudCapa(
+        classe_oficial=classe_oficial,
+        assuntos=assuntos,
+        orgao_julgador=orgao_julgador,
+        grau=grau,
+        data_ajuizamento=_iso(data_ajuizamento),
+        ultima_atualizacao=_iso(ultima_atualizacao),
+    )
+
+
+def _build_documentos(
     con: duckdb.DuckDBPyConnection,
-    url: str,
-    nr_processo: str,
+    juris_urls: list[str],
+    stj_urls: list[str],
+    cnj: str,
     limite: int,
     avisos: list[str],
 ) -> tuple[list[DocumentoProcesso], bool]:
-    """Busca até `limite` documentos; falha vira aviso, nunca exceção."""
+    """Busca até `limite` documentos (JURIS + STJ); falha vira aviso, nunca exceção."""
+    if not juris_urls and not stj_urls:
+        return [], False
+    sql, n_params = _documentos_sql(juris_urls, stj_urls)
     try:
         # limite+1 detecta "há mais" sem um COUNT(*) extra — mesmo padrão de
         # web/src/lib/processoCnj.ts:paginate.
-        doc_rows = con.execute(_documentos_sql(url), [nr_processo, limite + 1]).fetchall()
+        doc_rows = con.execute(sql, [cnj] * n_params + [limite + 1]).fetchall()
     except duckdb.Error as exc:
         avisos.append(f"Não foi possível carregar os documentos deste processo: {exc}")
         return [], False
@@ -257,18 +348,17 @@ def buscar_processo(
     *,
     incluir_documentos: bool = True,
     limite_documentos: int = 10,
-    processos_url: str = PROCESSOS_UNIFICADOS_URL,
-    documentos_url: str = PROCESSO_DOCUMENTOS_URL,
+    indice_url: str = INDICE_PROCESSUAL_URL,
     report_url: str = REPORT_URL,
 ) -> ProcessoConsultaResult:
-    """Busca o dossiê unificado de um CNJ nos parquets canônicos do IA.
+    """Busca o dossiê unificado de um CNJ via `indice_processual.parquet` + fontes de origem.
 
     Levanta `CnjInvalidoError` para um CNJ malformado (nunca chega a abrir
     parquet nenhum). Propaga `duckdb.Error`/`httpx.HTTPError` quando
-    `processos_unificados.parquet` em si não pode ser aberto — não há
-    resposta possível sem ele. Falha ao carregar `processo_documentos.
-    parquet` ou o relatório de cobertura vira resultado parcial (aviso +
-    lacuna vazia), nunca propaga.
+    `indice_processual.parquet` em si não pode ser aberto — não há resposta
+    possível sem ele. Falha ao carregar um parquet de origem específico ou o
+    relatório de cobertura vira resultado parcial (aviso + lacuna vazia),
+    nunca propaga.
     """
     nr_processo = normalizar_cnj(cnj)
     if not nr_processo:
@@ -276,8 +366,9 @@ def buscar_processo(
         raise CnjInvalidoError(msg)
 
     con = duckdb.connect()
-    _load_httpfs_if_remote(con, processos_url)
-    row = con.execute(_unificado_sql(processos_url), [nr_processo]).fetchone()
+    _load_httpfs(con)
+
+    rows = con.execute(_indice_sql(indice_url), [nr_processo]).fetchall()
 
     avisos: list[str] = []
     cobertura_result = _carregar_cobertura(report_url)
@@ -288,7 +379,7 @@ def buscar_processo(
     else:
         cobertura, dataset_gerado_em = cobertura_result
 
-    if row is None:
+    if not rows:
         return ProcessoConsultaResult(
             encontrado=False,
             nr_processo=nr_processo,
@@ -298,26 +389,33 @@ def buscar_processo(
             avisos=avisos,
         )
 
-    nr_processo_mascara, fontes_presentes, djen, juris, stj, datajud, updated_at = _mapear_linha(
-        row
-    )
+    fontes_presentes = sorted({fonte for fonte, _url in rows})
+    djen_urls = _fonte_urls(rows, "djen")
+    juris_urls = _fonte_urls(rows, "juris")
+    stj_urls = _fonte_urls(rows, "stj")
+    datajud_urls = _fonte_urls(rows, "datajud")
 
-    # O relatório não estava disponível (dataset_gerado_em ainda None) —
-    # cai para o timestamp de geração desta própria linha.
-    if dataset_gerado_em is None:
-        dataset_gerado_em = _iso(updated_at)
+    djen = _build_djen(con, djen_urls, nr_processo, avisos)
+    juris = _build_juris(con, juris_urls, nr_processo, avisos)
+    stj = _build_stj(con, stj_urls, nr_processo, avisos)
+    datajud = _build_datajud(con, datajud_urls, nr_processo, avisos)
+
+    # Sem relatório, dataset_gerado_em fica None — o índice não guarda um
+    # timestamp por linha (é fino por design), então não há fallback de
+    # "geração" possível aqui como havia na versão de tabela larga; o aviso
+    # do relatório indisponível já cobre essa lacuna.
 
     documentos: list[DocumentoProcesso] = []
     documentos_truncados = False
     if incluir_documentos:
-        documentos, documentos_truncados = _carregar_documentos(
-            con, documentos_url, nr_processo, limite_documentos, avisos
+        documentos, documentos_truncados = _build_documentos(
+            con, juris_urls, stj_urls, nr_processo, limite_documentos, avisos
         )
 
     return ProcessoConsultaResult(
         encontrado=True,
         nr_processo=nr_processo,
-        nr_processo_mascara=nr_processo_mascara or formatar_cnj(nr_processo),
+        nr_processo_mascara=formatar_cnj(nr_processo),
         fontes_presentes=fontes_presentes,
         cobertura_dataset=cobertura,
         djen=djen,

--- a/src/causaganha/processos/service.py
+++ b/src/causaganha/processos/service.py
@@ -1,0 +1,331 @@
+"""Consulta ao dossiê de processo unificado via DuckDB (RFC 0014 M2).
+
+Lê, por padrão, os dois parquets canônicos publicados no item IA
+`causaganha-dashboard` (`processos_unificados.parquet` +
+`processo_documentos.parquet`, produzidos por
+`scripts/reconcile_processos.py`) — a mesma fonte, com a mesma projeção de
+colunas e ordenação, que `web/src/lib/processoCnj.ts` usa para renderizar
+`/processo?cnj=...`. Nenhum cache local nesta primeira versão: a decisão
+(RFC 0014 M2) foi ler direto do Internet Archive, para que a tool funcione
+numa instalação nova e nunca divirja do que o dashboard já publica.
+
+Falhas são tratadas em duas categorias:
+  - Não conseguir abrir `processos_unificados.parquet` é fatal — propaga a
+    exceção do DuckDB/httpx para o chamador (a tool MCP a traduz em
+    `ToolError`; não há resposta possível sem esse arquivo).
+  - Não conseguir carregar `processo_documentos.parquet` ou
+    `processos_unificados.report.json` é parcial — o processo já encontrado
+    ainda é retornado, com a lista/lacuna correspondente vazia e um aviso em
+    `avisos`, nunca uma exceção.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import httpx
+
+from causaganha.processos.cnj import formatar_cnj, normalizar_cnj
+from causaganha.processos.models import (
+    CnjInvalidoError,
+    DatajudCapa,
+    DjenResumo,
+    DocumentoProcesso,
+    FonteCobertura,
+    JurisDecisao,
+    ProcessoConsultaResult,
+    StjAcordao,
+)
+
+
+IA_DASHBOARD_BASE = "https://archive.org/download/causaganha-dashboard"
+PROCESSOS_UNIFICADOS_URL = f"{IA_DASHBOARD_BASE}/processos_unificados.parquet"
+PROCESSO_DOCUMENTOS_URL = f"{IA_DASHBOARD_BASE}/processo_documentos.parquet"
+REPORT_URL = f"{IA_DASHBOARD_BASE}/processos_unificados.report.json"
+
+_RELATORIO_INDISPONIVEL_AVISO = (
+    "Relatório de cobertura (processos_unificados.report.json) indisponível; "
+    "sem detalhamento de quais fontes estavam carregadas na geração do dataset."
+)
+
+
+def _unificado_sql(url: str) -> str:
+    # `url` é sempre uma constante do módulo (ou um override explícito de
+    # teste), nunca entrada do usuário — só o CNJ, abaixo, é bind parameter.
+    return f"""
+        SELECT
+            nr_processo, nr_processo_mascara, fontes,
+            djen_primeira_pub, djen_ultima_pub, djen_n_publicacoes, djen_tribunais,
+            juris_n_documentos, juris_tipos, juris_data_julgamento,
+            juris_orgao, juris_relator, juris_classe, juris_url,
+            stj_id, stj_classe, stj_relator, stj_tema, stj_tese, stj_ementa,
+            stj_data_decisao, stj_data_publicacao,
+            classe_oficial, assuntos, orgao_julgador, grau,
+            data_ajuizamento, ultima_atualizacao, tem_datajud,
+            updated_at
+        FROM read_parquet('{url}')
+        WHERE nr_processo = ?
+        LIMIT 1
+    """  # noqa: S608
+
+
+def _documentos_sql(url: str) -> str:
+    return f"""
+        SELECT fonte, id_documento, tipo, data, url, resumo
+        FROM read_parquet('{url}')
+        WHERE nr_processo = ?
+        ORDER BY data DESC NULLS LAST, id_documento
+        LIMIT ?
+    """  # noqa: S608
+
+
+def _iso(value: Any) -> str | None:  # noqa: ANN401 — DuckDB row values are untyped at this layer
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _fetch_text(url_or_path: str) -> str:
+    if url_or_path.startswith(("http://", "https://")):
+        resp = httpx.get(url_or_path, timeout=10.0)
+        resp.raise_for_status()
+        return resp.text
+    return Path(url_or_path).read_text(encoding="utf-8")
+
+
+def _carregar_cobertura(report_url: str) -> tuple[list[FonteCobertura], str | None] | None:
+    """Carrega `processos_unificados.report.json`; None quando indisponível/ilegível."""
+    try:
+        raw = _fetch_text(report_url)
+        data = json.loads(raw)
+    except (OSError, httpx.HTTPError, json.JSONDecodeError):
+        return None
+    cobertura = [
+        FonteCobertura(fonte=nome, status=fonte["status"], registros=fonte["rows"])
+        for nome, fonte in data.get("sources", {}).items()
+    ]
+    return cobertura, data.get("generated_at")
+
+
+def _load_httpfs_if_remote(con: duckdb.DuckDBPyConnection, url: str) -> None:
+    if not url.startswith(("http://", "https://")):
+        return
+    # Deixa a query real abaixo falhar com um erro claro caso o httpfs seja
+    # de fato necessário — mesmo padrão não-fatal usado em
+    # scripts/reconcile_processos.py.
+    with contextlib.suppress(duckdb.Error):
+        con.execute("INSTALL httpfs; LOAD httpfs;")
+
+
+def _mapear_linha(
+    row: tuple[Any, ...],
+) -> tuple[
+    str,
+    list[str],
+    DjenResumo | None,
+    JurisDecisao | None,
+    StjAcordao | None,
+    DatajudCapa | None,
+    Any,
+]:
+    """Converte uma linha crua de `processos_unificados` nos sub-modelos por fonte."""
+    (
+        _nr_processo,
+        nr_processo_mascara,
+        fontes,
+        djen_primeira_pub,
+        djen_ultima_pub,
+        djen_n_publicacoes,
+        djen_tribunais,
+        juris_n_documentos,
+        juris_tipos,
+        juris_data_julgamento,
+        juris_orgao,
+        juris_relator,
+        juris_classe,
+        juris_url,
+        stj_id,
+        stj_classe,
+        stj_relator,
+        stj_tema,
+        stj_tese,
+        stj_ementa,
+        stj_data_decisao,
+        stj_data_publicacao,
+        classe_oficial,
+        assuntos,
+        orgao_julgador,
+        grau,
+        data_ajuizamento,
+        ultima_atualizacao,
+        tem_datajud,
+        updated_at,
+    ) = row
+
+    fontes_presentes = list(fontes or [])
+
+    djen = None
+    if "djen" in fontes_presentes:
+        djen = DjenResumo(
+            primeira_publicacao=_iso(djen_primeira_pub),
+            ultima_publicacao=_iso(djen_ultima_pub),
+            n_publicacoes=djen_n_publicacoes,
+            tribunais=list(djen_tribunais or []),
+        )
+
+    juris = None
+    if "juris" in fontes_presentes:
+        juris = JurisDecisao(
+            n_documentos=juris_n_documentos,
+            tipos=list(juris_tipos or []),
+            data_julgamento=_iso(juris_data_julgamento),
+            orgao=juris_orgao,
+            relator=juris_relator,
+            classe=juris_classe,
+            url=juris_url,
+        )
+
+    stj = None
+    if "stj" in fontes_presentes:
+        stj = StjAcordao(
+            id=stj_id,
+            classe=stj_classe,
+            relator=stj_relator,
+            tema=stj_tema,
+            tese=stj_tese,
+            ementa=stj_ementa,
+            data_decisao=_iso(stj_data_decisao),
+            data_publicacao=_iso(stj_data_publicacao),
+        )
+
+    # tem_datajud é a fonte da verdade (RFC 0010); checar os dois é
+    # redundante com a lista `fontes` mas inofensivo caso um dia divirjam —
+    # mesma cautela de `web/src/lib/processoCnj.ts:mapProcessoRow`.
+    datajud = None
+    if "datajud" in fontes_presentes and tem_datajud:
+        datajud = DatajudCapa(
+            classe_oficial=classe_oficial,
+            assuntos=assuntos,
+            orgao_julgador=orgao_julgador,
+            grau=grau,
+            data_ajuizamento=_iso(data_ajuizamento),
+            ultima_atualizacao=_iso(ultima_atualizacao),
+        )
+
+    return nr_processo_mascara, fontes_presentes, djen, juris, stj, datajud, updated_at
+
+
+def _carregar_documentos(
+    con: duckdb.DuckDBPyConnection,
+    url: str,
+    nr_processo: str,
+    limite: int,
+    avisos: list[str],
+) -> tuple[list[DocumentoProcesso], bool]:
+    """Busca até `limite` documentos; falha vira aviso, nunca exceção."""
+    try:
+        # limite+1 detecta "há mais" sem um COUNT(*) extra — mesmo padrão de
+        # web/src/lib/processoCnj.ts:paginate.
+        doc_rows = con.execute(_documentos_sql(url), [nr_processo, limite + 1]).fetchall()
+    except duckdb.Error as exc:
+        avisos.append(f"Não foi possível carregar os documentos deste processo: {exc}")
+        return [], False
+
+    truncados = len(doc_rows) > limite
+    documentos = [
+        DocumentoProcesso(
+            fonte=doc_fonte,
+            id_documento=str(id_documento),
+            tipo=tipo,
+            data=_iso(data),
+            url=url_doc,
+            resumo=resumo,
+        )
+        for doc_fonte, id_documento, tipo, data, url_doc, resumo in doc_rows[:limite]
+    ]
+    return documentos, truncados
+
+
+def buscar_processo(
+    cnj: str,
+    *,
+    incluir_documentos: bool = True,
+    limite_documentos: int = 10,
+    processos_url: str = PROCESSOS_UNIFICADOS_URL,
+    documentos_url: str = PROCESSO_DOCUMENTOS_URL,
+    report_url: str = REPORT_URL,
+) -> ProcessoConsultaResult:
+    """Busca o dossiê unificado de um CNJ nos parquets canônicos do IA.
+
+    Levanta `CnjInvalidoError` para um CNJ malformado (nunca chega a abrir
+    parquet nenhum). Propaga `duckdb.Error`/`httpx.HTTPError` quando
+    `processos_unificados.parquet` em si não pode ser aberto — não há
+    resposta possível sem ele. Falha ao carregar `processo_documentos.
+    parquet` ou o relatório de cobertura vira resultado parcial (aviso +
+    lacuna vazia), nunca propaga.
+    """
+    nr_processo = normalizar_cnj(cnj)
+    if not nr_processo:
+        msg = f"CNJ inválido (esperado 20 dígitos): {cnj!r}"
+        raise CnjInvalidoError(msg)
+
+    con = duckdb.connect()
+    _load_httpfs_if_remote(con, processos_url)
+    row = con.execute(_unificado_sql(processos_url), [nr_processo]).fetchone()
+
+    avisos: list[str] = []
+    cobertura_result = _carregar_cobertura(report_url)
+    if cobertura_result is None:
+        cobertura: list[FonteCobertura] = []
+        dataset_gerado_em: str | None = None
+        avisos.append(_RELATORIO_INDISPONIVEL_AVISO)
+    else:
+        cobertura, dataset_gerado_em = cobertura_result
+
+    if row is None:
+        return ProcessoConsultaResult(
+            encontrado=False,
+            nr_processo=nr_processo,
+            nr_processo_mascara=formatar_cnj(nr_processo),
+            cobertura_dataset=cobertura,
+            dataset_gerado_em=dataset_gerado_em,
+            avisos=avisos,
+        )
+
+    nr_processo_mascara, fontes_presentes, djen, juris, stj, datajud, updated_at = _mapear_linha(
+        row
+    )
+
+    # O relatório não estava disponível (dataset_gerado_em ainda None) —
+    # cai para o timestamp de geração desta própria linha.
+    if dataset_gerado_em is None:
+        dataset_gerado_em = _iso(updated_at)
+
+    documentos: list[DocumentoProcesso] = []
+    documentos_truncados = False
+    if incluir_documentos:
+        documentos, documentos_truncados = _carregar_documentos(
+            con, documentos_url, nr_processo, limite_documentos, avisos
+        )
+
+    return ProcessoConsultaResult(
+        encontrado=True,
+        nr_processo=nr_processo,
+        nr_processo_mascara=nr_processo_mascara or formatar_cnj(nr_processo),
+        fontes_presentes=fontes_presentes,
+        cobertura_dataset=cobertura,
+        djen=djen,
+        juris=juris,
+        stj=stj,
+        datajud=datajud,
+        documentos=documentos,
+        documentos_truncados=documentos_truncados,
+        dataset_gerado_em=dataset_gerado_em,
+        avisos=avisos,
+    )

--- a/src/causaganha_mcp/server.py
+++ b/src/causaganha_mcp/server.py
@@ -24,13 +24,21 @@ pipelines, calling their ``service.py`` directly — never the other tools via
 the MCP protocol itself) and translates every tool's ``title``/
 ``description``/output field names to Portuguese, since the product and its
 users are Brazilian and this text can be shown directly to a host's user.
+
+RFC 0014 M2 adds ``processo_consultar`` — the first tool that serves the
+end user directly, not the pipeline operator. It reads the canonical
+cross-source parquets published to Internet Archive (``causaganha_mcp.tools
+.processo`` → ``causaganha.processos.service``), the same artifacts the web
+dashboard's ``/processo`` page reads — not a local manifest, and not a
+second, independently-published copy of the data. Like ``datajud_facetas``,
+it is a real network call (``openWorldHint=True``).
 """
 
 from __future__ import annotations
 
 from fastmcp import FastMCP
 
-from causaganha_mcp.tools import datajud, djen_backup, status, stj_acordaos, tjro_juris
+from causaganha_mcp.tools import datajud, djen_backup, processo, status, stj_acordaos, tjro_juris
 
 
 def build_server() -> FastMCP:
@@ -38,13 +46,16 @@ def build_server() -> FastMCP:
     mcp = FastMCP(
         name="causaganha_mcp",
         instructions=(
-            "Tools somente-leitura sobre os quatro pipelines de ingestão do "
-            "CausaGanha (djen-backup, tjro-juris, stj-acordaos, datajud), "
-            "mais um panorama agregado (causaganha_status). A maioria lê só "
-            "um manifest local — sem chamada de rede, sem credencial, sem "
-            "mutação; `datajud_facetas` é a exceção, consultando a API "
-            "pública do DataJud ao vivo (ainda somente-leitura, ainda sem "
-            "credencial no schema). Para ingestão, upload ou backfill, use a "
+            "Tools sobre os quatro pipelines de ingestão do CausaGanha "
+            "(djen-backup, tjro-juris, stj-acordaos, datajud), um panorama "
+            "agregado (causaganha_status), e uma tool de produto para "
+            "consultar processos (processo_consultar). A maioria das tools "
+            "de pipeline lê só um manifest local — sem chamada de rede, sem "
+            "credencial, sem mutação. `datajud_facetas` e "
+            "`processo_consultar` são as exceções: consultam dados ao vivo "
+            "(API pública do DataJud e os parquets canônicos do Internet "
+            "Archive, respectivamente) — ainda somente-leitura, ainda sem "
+            "credencial no schema. Para ingestão, upload ou backfill, use a "
             "CLI correspondente (djen-backup, tjro-juris, stj-acordaos, "
             "datajud) ou os workflows agendados — isso não é exposto aqui "
             "por design."
@@ -55,6 +66,7 @@ def build_server() -> FastMCP:
     stj_acordaos.register(mcp)
     djen_backup.register(mcp)
     status.register(mcp)
+    processo.register(mcp)
     return mcp
 
 

--- a/src/causaganha_mcp/tools/processo.py
+++ b/src/causaganha_mcp/tools/processo.py
@@ -1,0 +1,311 @@
+"""``processo_consultar`` — dossiê unificado de um processo por CNJ (RFC 0014 M2).
+
+Primeira tool MCP que serve diretamente quem quer saber sobre um processo
+específico, não o operador do pipeline. Chama `causaganha.processos.service`
+diretamente — nunca reimplementa a consulta aqui. Lê os parquets canônicos
+do Internet Archive (`indice_processual.parquet` + os parquets de origem por
+fonte); nenhum cache local nesta primeira versão (ver o módulo de serviço
+para a justificativa completa).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Annotated
+from urllib.parse import quote
+
+import duckdb
+import httpx
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from causaganha.processos import service
+from causaganha.processos.models import CnjInvalidoError
+
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from causaganha.processos.models import ProcessoConsultaResult
+
+
+# Consulta de rede (parquets remotos via httpfs) mas de baixa latência — um
+# lookup de linha via índice + poucas leituras de parquet de origem, não uma
+# agregação de dataset inteiro (esse é o caso de datajud_facetas). O deadline
+# ainda assim fica bem abaixo de um minuto, mesma disciplina de
+# datajud_facetas: interativo, não ingestão.
+_PROCESSO_TOOL_TIMEOUT = 30.0
+
+_WEB_BASE_URL_ENV = "CAUSAGANHA_WEB_BASE_URL"
+
+
+class FonteCoberturaResult(BaseModel):
+    """Estado de uma fonte na geração do dataset."""
+
+    fonte: str = Field(description="Nome da fonte: djen, juris, stj ou datajud.")
+    status: str = Field(
+        description="Como a fonte foi carregada na geração do dataset "
+        "(ex.: loaded_local, loaded_remote, unavailable)."
+    )
+    registros: int = Field(
+        description="Quantidade de processos que essa fonte contribuiu no dataset inteiro "
+        "— não é uma contagem específica deste CNJ."
+    )
+
+
+class DocumentoResult(BaseModel):
+    """Um documento JURIS ou STJ do processo."""
+
+    fonte: str = Field(description="'juris' ou 'stj' — nunca DJEN nem DataJud.")
+    id_documento: str
+    tipo: str | None = None
+    data: str | None = Field(default=None, description="Data ISO (AAAA-MM-DD), quando houver.")
+    url: str | None = None
+    resumo: str | None = Field(
+        default=None, description="Resumo truncado em 500 caracteres na reconciliação."
+    )
+
+
+class DjenResumoResult(BaseModel):
+    """Resumo das publicações DJEN do processo."""
+
+    primeira_publicacao: str | None = None
+    ultima_publicacao: str | None = None
+    n_publicacoes: int | None = None
+    tribunais: list[str] = Field(default_factory=list)
+
+
+class JurisDecisaoResult(BaseModel):
+    """Decisão(ões) do TJRO JURIS para o processo."""
+
+    n_documentos: int | None = None
+    tipos: list[str] = Field(default_factory=list)
+    data_julgamento: str | None = None
+    orgao: str | None = None
+    relator: str | None = None
+    classe: str | None = None
+    url: str | None = None
+
+
+class StjAcordaoResult(BaseModel):
+    """Acórdão do STJ para o processo, quando houver."""
+
+    id: str | None = None
+    classe: str | None = None
+    relator: str | None = None
+    tema: str | None = None
+    tese: str | None = None
+    ementa: str | None = None
+    data_decisao: str | None = None
+    data_publicacao: str | None = None
+
+
+class DatajudCapaResult(BaseModel):
+    """Capa oficial do DataJud (RFC 0010) para o processo."""
+
+    classe_oficial: str | None = None
+    assuntos: str | None = None
+    orgao_julgador: str | None = None
+    grau: str | None = None
+    data_ajuizamento: str | None = None
+    ultima_atualizacao: str | None = None
+
+
+class ProcessoConsultarResult(BaseModel):
+    """Dossiê unificado de um processo, montado a partir das fontes canônicas do IA."""
+
+    encontrado: bool = Field(
+        description="False quando o CNJ é válido mas não aparece em nenhuma fonte."
+    )
+    cnj: str = Field(description="CNJ normalizado, 20 dígitos.")
+    cnj_formatado: str = Field(description="CNJ na máscara de exibição NNNNNNN-DD.AAAA.J.TR.OOOO.")
+    fontes_presentes: list[str] = Field(
+        default_factory=list,
+        description="Fontes que têm registro para este CNJ (subconjunto de "
+        "djen/juris/stj/datajud).",
+    )
+    cobertura_dataset: list[FonteCoberturaResult] = Field(
+        default_factory=list,
+        description="Estado de cada fonte na geração do dataset inteiro — distingue uma fonte "
+        "que não tinha este CNJ de uma fonte que estava indisponível quando o dataset foi gerado.",
+    )
+    djen: DjenResumoResult | None = None
+    juris: JurisDecisaoResult | None = None
+    stj: StjAcordaoResult | None = None
+    datajud: DatajudCapaResult | None = None
+    documentos: list[DocumentoResult] = Field(default_factory=list)
+    documentos_truncados: bool = Field(
+        default=False, description="True quando há mais documentos além de `limite_documentos`."
+    )
+    dataset_gerado_em: str | None = Field(
+        default=None,
+        description="Timestamp (ISO 8601) de quando o dataset foi gerado, do relatório de "
+        "cobertura — None quando o relatório está indisponível (ver `avisos`).",
+    )
+    consultado_em: str = Field(description="Timestamp (ISO 8601) desta própria consulta.")
+    fonte: str = Field(
+        default="parquet_ia",
+        description="Os parquets canônicos do Internet Archive são a única fonte desta tool "
+        "— não há cache local nesta primeira versão.",
+    )
+    canonica: bool = Field(
+        default=True, description="Sempre True: a fonte já é a canônica, sem cache intermediário."
+    )
+    avisos: list[str] = Field(
+        default_factory=list, description="Ressalvas relevantes (ex.: relatório indisponível)."
+    )
+    web_url: str | None = Field(
+        default=None,
+        description=f"URL completa do dossiê no dashboard web, montada apenas quando a "
+        f"variável de ambiente {_WEB_BASE_URL_ENV} está configurada — None caso contrário.",
+    )
+    web_path: str = Field(
+        description="Caminho público conhecido do dossiê: /processo?cnj=<mascarado>."
+    )
+
+
+def _web_path(cnj_formatado: str) -> str:
+    return f"/processo?cnj={quote(cnj_formatado)}"
+
+
+def _web_url(cnj_formatado: str) -> str | None:
+    base = os.environ.get(_WEB_BASE_URL_ENV, "").strip()
+    if not base:
+        return None
+    return f"{base.rstrip('/')}{_web_path(cnj_formatado)}"
+
+
+def _to_result(r: ProcessoConsultaResult) -> ProcessoConsultarResult:
+    return ProcessoConsultarResult(
+        encontrado=r.encontrado,
+        cnj=r.nr_processo,
+        cnj_formatado=r.nr_processo_mascara,
+        fontes_presentes=r.fontes_presentes,
+        cobertura_dataset=[
+            FonteCoberturaResult(fonte=c.fonte, status=c.status, registros=c.registros)
+            for c in r.cobertura_dataset
+        ],
+        djen=DjenResumoResult(
+            primeira_publicacao=r.djen.primeira_publicacao,
+            ultima_publicacao=r.djen.ultima_publicacao,
+            n_publicacoes=r.djen.n_publicacoes,
+            tribunais=r.djen.tribunais,
+        )
+        if r.djen
+        else None,
+        juris=JurisDecisaoResult(
+            n_documentos=r.juris.n_documentos,
+            tipos=r.juris.tipos,
+            data_julgamento=r.juris.data_julgamento,
+            orgao=r.juris.orgao,
+            relator=r.juris.relator,
+            classe=r.juris.classe,
+            url=r.juris.url,
+        )
+        if r.juris
+        else None,
+        stj=StjAcordaoResult(
+            id=r.stj.id,
+            classe=r.stj.classe,
+            relator=r.stj.relator,
+            tema=r.stj.tema,
+            tese=r.stj.tese,
+            ementa=r.stj.ementa,
+            data_decisao=r.stj.data_decisao,
+            data_publicacao=r.stj.data_publicacao,
+        )
+        if r.stj
+        else None,
+        datajud=DatajudCapaResult(
+            classe_oficial=r.datajud.classe_oficial,
+            assuntos=r.datajud.assuntos,
+            orgao_julgador=r.datajud.orgao_julgador,
+            grau=r.datajud.grau,
+            data_ajuizamento=r.datajud.data_ajuizamento,
+            ultima_atualizacao=r.datajud.ultima_atualizacao,
+        )
+        if r.datajud
+        else None,
+        documentos=[
+            DocumentoResult(
+                fonte=d.fonte,
+                id_documento=d.id_documento,
+                tipo=d.tipo,
+                data=d.data,
+                url=d.url,
+                resumo=d.resumo,
+            )
+            for d in r.documentos
+        ],
+        documentos_truncados=r.documentos_truncados,
+        dataset_gerado_em=r.dataset_gerado_em,
+        consultado_em=datetime.now(UTC).isoformat(timespec="seconds"),
+        avisos=r.avisos,
+        web_url=_web_url(r.nr_processo_mascara),
+        web_path=_web_path(r.nr_processo_mascara),
+    )
+
+
+def _processo_tool_error(exc: Exception) -> ToolError:
+    if isinstance(exc, CnjInvalidoError):
+        return ToolError(str(exc))
+    # duckdb.Error/httpx.HTTPError: indice_processual.parquet em si não pôde
+    # ser aberto — não há resposta possível (distinto de uma fonte de
+    # origem específica falhar, que service.buscar_processo já absorve como
+    # aviso + lacuna vazia, nunca chegando aqui).
+    return ToolError(
+        "Não foi possível abrir indice_processual.parquet no Internet Archive. "
+        "Tente de novo mais tarde; se persistir, o item causaganha-dashboard pode "
+        "estar indisponível."
+    )
+
+
+def register(mcp: FastMCP) -> None:
+    """Registra ``processo_consultar`` em *mcp*."""
+
+    @mcp.tool(
+        name="processo_consultar",
+        timeout=_PROCESSO_TOOL_TIMEOUT,
+        annotations={
+            "title": "Consulta o dossiê unificado de um processo por CNJ",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )
+    def processo_consultar(
+        cnj: str,
+        incluir_documentos: bool = True,
+        limite_documentos: Annotated[
+            int, Field(ge=1, le=50, description="Máximo de documentos a retornar.")
+        ] = 10,
+    ) -> ProcessoConsultarResult:
+        """Consulta o dossiê unificado (DJEN + JURIS + STJ + DataJud) de um processo por CNJ.
+
+        Lê os parquets canônicos publicados no Internet Archive (item
+        `causaganha-dashboard`) — a mesma fonte que o dashboard web usa para
+        `/processo?cnj=...` — sem cache local nesta primeira versão. Retorna
+        fatos com proveniência (quais fontes contribuíram, quando o dataset
+        foi gerado), nunca um veredito. Um CNJ válido mas ausente de toda
+        fonte retorna `encontrado=False`, não é um erro; um CNJ malformado
+        (não são 20 dígitos) levanta erro de uso.
+
+        Args:
+            cnj: Número do processo, com ou sem máscara (aceita ambos).
+            incluir_documentos: Se False, pula a busca de documentos
+                JURIS/STJ — mais rápido quando só o resumo por fonte importa.
+            limite_documentos: Máximo de documentos a retornar, 1-50,
+                ordenados do mais recente para o mais antigo.
+                `documentos_truncados=True` quando há mais além do limite.
+        """
+        try:
+            resultado = service.buscar_processo(
+                cnj,
+                incluir_documentos=incluir_documentos,
+                limite_documentos=limite_documentos,
+            )
+        except (CnjInvalidoError, duckdb.Error, httpx.HTTPError) as exc:
+            raise _processo_tool_error(exc) from exc
+        return _to_result(resultado)

--- a/src/datajud/__main__.py
+++ b/src/datajud/__main__.py
@@ -3,7 +3,7 @@
 Manual execution
 ----------------
 Enrich known CNJs with official capa + movimentos (CNJs come from local
-source parquets — processos_unificados, TJRO JURIS, STJ — or explicitly)::
+source parquets — indice_processual, TJRO JURIS, STJ — or explicitly)::
 
     uv run datajud enrich --tribunal tjro --limit 200 --skip-upload
     uv run datajud enrich --cnj 0000001-02.2024.8.22.0001 --skip-upload

--- a/src/datajud/models.py
+++ b/src/datajud/models.py
@@ -13,36 +13,31 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# CNJ normalization moved to causaganha.processos.cnj (RFC 0014 M2) — a
+# shared module usable by non-DataJud consumers (the process-reconciliation
+# pipeline, the processo_consultar MCP tool). Reexported here so existing
+# `from datajud.models import normalizar_cnj` call sites keep working.
+from causaganha.processos.cnj import CNJ_LEN, formatar_cnj, normalizar_cnj, so_digitos
 
-CNJ_LEN = 20
+
+__all__ = [
+    "CNJ_LEN",
+    "CodigoNome",
+    "ComplementoTabelado",
+    "Movimento",
+    "ProcessoCapa",
+    "data14_bound",
+    "formatar_cnj",
+    "normalizar_cnj",
+    "normalizar_data14",
+    "so_digitos",
+]
 
 # ``dataAjuizamento`` is a 14-digit string (AAAAMMDDHHMMSS); some records
 # truncate the time part, so hour/minute/second groups are optional.
 _DATA14_RE = re.compile(r"(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?")
 _DATE_BR_RE = re.compile(r"(\d{2})/(\d{2})/(\d{4})")
 _DATE_ISO_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
-
-
-def so_digitos(value: str | None) -> str:
-    """Strip every non-digit character from *value*."""
-    return re.sub(r"\D", "", value or "")
-
-
-def normalizar_cnj(value: str | None) -> str:
-    """Return the 20-digit CNJ number, or '' when *value* is not a valid CNJ."""
-    digits = so_digitos(value)
-    return digits if len(digits) == CNJ_LEN else ""
-
-
-def formatar_cnj(value: str) -> str:
-    """20 digits → NNNNNNN-DD.AAAA.J.TR.OOOO (display mask)."""
-    digits = so_digitos(value)
-    if len(digits) != CNJ_LEN:
-        return value
-    return (
-        f"{digits[0:7]}-{digits[7:9]}.{digits[9:13]}."
-        f"{digits[13:14]}.{digits[14:16]}.{digits[16:20]}"
-    )
 
 
 def normalizar_data14(value: str | None) -> str | None:

--- a/src/datajud/service.py
+++ b/src/datajud/service.py
@@ -37,7 +37,13 @@ DEFAULT_DATA_DIR = Path("data/datajud")
 DEFAULT_SOURCES_DIR = Path("data")
 MANIFEST_NAME = "datajud-manifest.csv"
 
-UNIFICADOS_IA_URL = "https://archive.org/download/causaganha-dashboard/processos_unificados.parquet"
+# RFC 0014 M2: processos_unificados.parquet is no longer published — the
+# reconciler's canonical cross-source artifact is now the thin
+# indice_processual.parquet, which already carries every CNJ any source
+# contributed to (no join needed just to list them).
+INDICE_PROCESSUAL_IA_URL = (
+    "https://archive.org/download/causaganha-dashboard/indice_processual.parquet"
+)
 
 
 def manifest_path(data_dir: Path) -> Path:
@@ -59,9 +65,9 @@ def _read_cnj_file(path: Path) -> list[str]:
 
 def _source_selects(sources_dir: Path) -> list[str]:
     selects: list[str] = []
-    unificados = sources_dir / "processos_unificados.parquet"
-    if unificados.exists():
-        selects.append(f"SELECT nr_processo AS cnj FROM read_parquet('{unificados}')")
+    indice = sources_dir / "indice_processual.parquet"
+    if indice.exists():
+        selects.append(f"SELECT numero_processo AS cnj FROM read_parquet('{indice}')")
     juris_files = sorted(sources_dir.glob("tjro-juris/*/tjro-juris-*.parquet"))
     if juris_files:
         juris_list = ", ".join(f"'{p}'" for p in juris_files)
@@ -72,16 +78,16 @@ def _source_selects(sources_dir: Path) -> list[str]:
     return selects
 
 
-def _try_download_unificados(sources_dir: Path) -> None:
-    """Best-effort download of processos_unificados from IA (CI cold start)."""
-    dest = sources_dir / "processos_unificados.parquet"
-    log.info("datajud_downloading_unificados", url=UNIFICADOS_IA_URL)
+def _try_download_indice(sources_dir: Path) -> None:
+    """Best-effort download of indice_processual from IA (CI cold start)."""
+    dest = sources_dir / "indice_processual.parquet"
+    log.info("datajud_downloading_indice_processual", url=INDICE_PROCESSUAL_IA_URL)
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with urllib.request.urlopen(UNIFICADOS_IA_URL, timeout=180) as resp:  # noqa: S310
+        with urllib.request.urlopen(INDICE_PROCESSUAL_IA_URL, timeout=180) as resp:  # noqa: S310
             dest.write_bytes(resp.read())
     except OSError as exc:
-        log.warning("datajud_unificados_download_failed", error=str(exc))
+        log.warning("datajud_indice_processual_download_failed", error=str(exc))
 
 
 def _collect_source_cnjs(sources_dir: Path) -> list[str]:
@@ -90,7 +96,7 @@ def _collect_source_cnjs(sources_dir: Path) -> list[str]:
 
     selects = _source_selects(sources_dir)
     if not selects:
-        _try_download_unificados(sources_dir)
+        _try_download_indice(sources_dir)
         selects = _source_selects(sources_dir)
     if not selects:
         return []

--- a/tests/causaganha/processos/test_cnj.py
+++ b/tests/causaganha/processos/test_cnj.py
@@ -1,0 +1,57 @@
+"""Tests for causaganha.processos.cnj (RFC 0014 M2) and its datajud.models reexport."""
+
+from __future__ import annotations
+
+from causaganha.processos.cnj import CNJ_LEN, formatar_cnj, normalizar_cnj, so_digitos
+
+
+CNJ_DIGITS = "00000010220248220001"
+CNJ_MASKED = "0000001-02.2024.8.22.0001"
+
+
+def test_so_digitos_strips_non_digits() -> None:
+    assert so_digitos(CNJ_MASKED) == CNJ_DIGITS
+
+
+def test_so_digitos_handles_none() -> None:
+    assert so_digitos(None) == ""
+
+
+def test_normalizar_cnj_accepts_unmasked() -> None:
+    assert normalizar_cnj(CNJ_DIGITS) == CNJ_DIGITS
+
+
+def test_normalizar_cnj_accepts_masked() -> None:
+    assert normalizar_cnj(CNJ_MASKED) == CNJ_DIGITS
+
+
+def test_normalizar_cnj_rejects_wrong_length() -> None:
+    assert normalizar_cnj("123") == ""
+    assert normalizar_cnj(CNJ_DIGITS + "9") == ""
+
+
+def test_normalizar_cnj_rejects_none_and_empty() -> None:
+    assert normalizar_cnj(None) == ""
+    assert normalizar_cnj("") == ""
+
+
+def test_formatar_cnj_masks_valid_digits() -> None:
+    assert formatar_cnj(CNJ_DIGITS) == CNJ_MASKED
+
+
+def test_formatar_cnj_returns_input_unchanged_when_invalid() -> None:
+    assert formatar_cnj("123") == "123"
+
+
+def test_cnj_len_constant() -> None:
+    assert CNJ_LEN == 20
+
+
+def test_datajud_models_reexports_match_causaganha_processos_cnj() -> None:
+    """`datajud.models` must not drift into its own copy of this rule."""
+    from datajud import models
+
+    assert models.normalizar_cnj is normalizar_cnj
+    assert models.formatar_cnj is formatar_cnj
+    assert models.so_digitos is so_digitos
+    assert models.CNJ_LEN is CNJ_LEN

--- a/tests/causaganha/processos/test_service.py
+++ b/tests/causaganha/processos/test_service.py
@@ -271,3 +271,52 @@ def test_limite_documentos_truncates_and_flags_it(fixtures: dict[str, Path]) -> 
     assert len(result.documentos) == 1
     assert result.documentos[0].fonte == "stj"  # most recent by data DESC
     assert result.documentos_truncados is True
+
+
+def _spy_on_connect(monkeypatch: pytest.MonkeyPatch) -> list[duckdb.DuckDBPyConnection]:
+    """Wraps duckdb.connect so the test can inspect the connection afterwards."""
+    captured: list[duckdb.DuckDBPyConnection] = []
+    real_connect = duckdb.connect
+
+    def _spy(*args: object, **kwargs: object) -> duckdb.DuckDBPyConnection:
+        con = real_connect(*args, **kwargs)
+        captured.append(con)
+        return con
+
+    monkeypatch.setattr(service.duckdb, "connect", _spy)
+    return captured
+
+
+def test_connection_is_closed_on_success(
+    fixtures: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A long-running MCP server calls buscar_processo repeatedly — a leaked
+    DuckDBPyConnection per call would accumulate handles/memory over time.
+    """
+    captured = _spy_on_connect(monkeypatch)
+
+    service.buscar_processo(
+        CNJ_ALL, indice_url=str(fixtures["indice"]), report_url=str(fixtures["report"])
+    )
+
+    assert len(captured) == 1
+    with pytest.raises(duckdb.Error):
+        captured[0].execute("SELECT 1")  # closed connections refuse queries
+
+
+def test_connection_is_closed_when_indice_itself_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one fatal path (index unreachable) must still close the connection."""
+    captured = _spy_on_connect(monkeypatch)
+
+    with pytest.raises(duckdb.Error):
+        service.buscar_processo(
+            CNJ_ALL,
+            indice_url="/nonexistent/indice_processual.parquet",
+            report_url="/nonexistent.report.json",
+        )
+
+    assert len(captured) == 1
+    with pytest.raises(duckdb.Error):
+        captured[0].execute("SELECT 1")

--- a/tests/causaganha/processos/test_service.py
+++ b/tests/causaganha/processos/test_service.py
@@ -1,0 +1,273 @@
+"""Tests for causaganha.processos.service.buscar_processo (RFC 0014 M2).
+
+Fixtures are hand-built local parquets wired together through a small
+indice_processual.parquet whose `arquivo_ia_url` column points at those local
+paths — DuckDB's `read_parquet()` accepts local paths exactly like it accepts
+IA URLs, so this exercises the same SQL the real service runs against remote
+parquets, without any network access.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import duckdb
+import pytest
+
+from causaganha.processos import service
+from causaganha.processos.models import CnjInvalidoError
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CNJ_ALL = "00000010220248220001"
+CNJ_DJEN_ONLY = "00000020320248220002"
+CNJ_UNKNOWN = "00000030420248220003"
+
+
+def _copy_to_parquet(path: Path, sql: str) -> Path:
+    con = duckdb.connect()
+    try:
+        con.execute(f"COPY ({sql}) TO '{path}' (FORMAT PARQUET)")
+    finally:
+        con.close()
+    return path
+
+
+@pytest.fixture
+def fixtures(tmp_path: Path) -> dict[str, Path]:
+    comunicacoes = _copy_to_parquet(
+        tmp_path / "comunicacoes.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            ('{CNJ_ALL}',       DATE '2024-03-01', 'TJRO'),
+            ('{CNJ_ALL}',       DATE '2024-03-05', 'TJRO'),
+            ('{CNJ_DJEN_ONLY}', DATE '2024-04-01', 'TJRO')
+        ) AS t(numero_processo, data_disponibilizacao, tribunal)
+        """,
+    )
+    juris = _copy_to_parquet(
+        tmp_path / "tjro-juris-2024.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            (1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A',
+             DATE '2024-01-15', 'texto um', 'https://juris/1')
+        ) AS t(id_documento, nr_processo, tipo, classe_judicial, orgao, relator,
+               data_julgamento, texto_limpo, url_portal)
+        """,
+    )
+    stj = _copy_to_parquet(
+        tmp_path / "stj-acordaos.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            ('stj-1', '{CNJ_ALL}', 'REsp', 'MIN X', 'tema', 'tese', 'ementa',
+             DATE '2024-05-01', DATE '2024-05-10')
+        ) AS t(id, "numeroProcesso", "siglaClasse", "ministroRelator", tema,
+               "teseJuridica", ementa, "dataDecisao", "dataPublicacao")
+        """,
+    )
+    datajud = _copy_to_parquet(
+        tmp_path / "datajud-capa-tjro.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            ('{CNJ_ALL}', 'Apelacao Civel', 'Contratos', '2a Camara', 'G2',
+             DATE '2024-01-10', TIMESTAMP '2024-06-01 00:00:00')
+        ) AS t(numero_processo, classe_nome, assuntos, orgao_julgador, grau,
+               data_ajuizamento, ultima_atualizacao)
+        """,
+    )
+    indice = _copy_to_parquet(
+        tmp_path / "indice_processual.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            ('{CNJ_ALL}',       'djen',    'c1',    'TJRO', DATE '2024-03-01', '{comunicacoes}'),
+            ('{CNJ_ALL}',       'djen',    'c2',    'TJRO', DATE '2024-03-05', '{comunicacoes}'),
+            ('{CNJ_ALL}',       'juris',   '1',     'TJRO', DATE '2024-01-15', '{juris}'),
+            ('{CNJ_ALL}',       'stj',     'stj-1', 'STJ',  DATE '2024-05-01', '{stj}'),
+            ('{CNJ_ALL}',       'datajud', 'dj-1',  'TJRO', DATE '2024-06-01', '{datajud}'),
+            ('{CNJ_DJEN_ONLY}', 'djen',    'c3',    'TJRO', DATE '2024-04-01', '{comunicacoes}')
+        ) AS t(numero_processo, fonte, registro_id, tribunal, data, arquivo_ia_url)
+        """,
+    )
+    report = tmp_path / "indice_processual.report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-07-12T18:00:00Z",
+                "sources": {
+                    "djen": {"status": "loaded_remote", "rows": 2},
+                    "juris": {"status": "loaded_remote", "rows": 1},
+                    "stj": {"status": "loaded_remote", "rows": 1},
+                    "datajud": {"status": "loaded_remote", "rows": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "indice": indice,
+        "report": report,
+        "comunicacoes": comunicacoes,
+        "juris": juris,
+        "stj": stj,
+        "datajud": datajud,
+    }
+
+
+def test_multi_fonte_dossier(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_ALL, indice_url=str(fixtures["indice"]), report_url=str(fixtures["report"])
+    )
+
+    assert result.encontrado is True
+    assert result.nr_processo == CNJ_ALL
+    assert result.nr_processo_mascara == "0000001-02.2024.8.22.0001"
+    assert result.fontes_presentes == ["datajud", "djen", "juris", "stj"]
+    assert result.avisos == []
+    assert result.dataset_gerado_em == "2026-07-12T18:00:00Z"
+
+    assert result.djen.n_publicacoes == 2
+    assert result.djen.primeira_publicacao == "2024-03-01"
+    assert result.djen.ultima_publicacao == "2024-03-05"
+    assert result.djen.tribunais == ["TJRO"]
+
+    assert result.juris.n_documentos == 1
+    assert result.juris.orgao == "2a Camara"
+    assert result.juris.relator == "Des. A"
+    assert result.juris.url == "https://juris/1"
+
+    assert result.stj.id == "stj-1"
+    assert result.stj.classe == "REsp"
+    assert result.stj.data_decisao == "2024-05-01"
+
+    assert result.datajud.classe_oficial == "Apelacao Civel"
+    assert result.datajud.assuntos == "Contratos"
+
+    assert [d.fonte for d in result.documentos] == ["stj", "juris"]  # data DESC
+    assert result.documentos_truncados is False
+
+
+def test_single_fonte_dossier_leaves_other_fields_none(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_DJEN_ONLY, indice_url=str(fixtures["indice"]), report_url=str(fixtures["report"])
+    )
+
+    assert result.encontrado is True
+    assert result.fontes_presentes == ["djen"]
+    assert result.djen is not None
+    assert result.juris is None
+    assert result.stj is None
+    assert result.datajud is None
+    assert result.documentos == []
+    assert result.documentos_truncados is False
+
+
+def test_not_found_still_carries_cobertura(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_UNKNOWN, indice_url=str(fixtures["indice"]), report_url=str(fixtures["report"])
+    )
+
+    assert result.encontrado is False
+    assert result.nr_processo == CNJ_UNKNOWN
+    assert result.fontes_presentes == []
+    assert result.dataset_gerado_em == "2026-07-12T18:00:00Z"
+    assert {c.fonte for c in result.cobertura_dataset} == {"djen", "juris", "stj", "datajud"}
+    assert result.avisos == []
+
+
+def test_invalid_cnj_raises_before_touching_any_parquet() -> None:
+    with pytest.raises(CnjInvalidoError):
+        service.buscar_processo(
+            "123",
+            indice_url="/nonexistent/indice_processual.parquet",
+            report_url="/nonexistent.json",
+        )
+
+
+def test_missing_report_is_partial_not_fatal(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_ALL,
+        indice_url=str(fixtures["indice"]),
+        report_url=str(fixtures["indice"].parent / "does-not-exist.report.json"),
+    )
+
+    assert result.encontrado is True  # the processo itself still resolves
+    assert result.cobertura_dataset == []
+    assert result.dataset_gerado_em is None
+    assert any("relatório de cobertura" in a.lower() for a in result.avisos)
+
+
+def test_one_source_parquet_unreachable_is_partial_not_fatal(
+    fixtures: dict[str, Path], tmp_path: Path
+) -> None:
+    """A source's own parquet failing must not take down the whole dossiê.
+
+    Mirrors reconcile_processos.py's own philosophy (a corrupted/unreachable
+    source parquet degrades to a warning, never crashes the run) — the
+    module docstring promises the same for buscar_processo, exercised here
+    against DJEN specifically (its arquivo_ia_url points nowhere).
+    """
+    missing = tmp_path / "missing.parquet"
+    broken_indice = _copy_to_parquet(
+        tmp_path / "indice_broken.parquet",
+        f"""
+        SELECT * FROM (VALUES
+            ('{CNJ_ALL}', 'djen',    'c1',    'TJRO', DATE '2024-03-01', '{missing}'),
+            ('{CNJ_ALL}', 'juris',   '1',     'TJRO', DATE '2024-01-15', '{fixtures["juris"]}'),
+            ('{CNJ_ALL}', 'stj',     'stj-1', 'STJ',  DATE '2024-05-01', '{fixtures["stj"]}'),
+            ('{CNJ_ALL}', 'datajud', 'dj-1',  'TJRO', DATE '2024-06-01', '{fixtures["datajud"]}')
+        ) AS t(numero_processo, fonte, registro_id, tribunal, data, arquivo_ia_url)
+        """,
+    )
+
+    result = service.buscar_processo(
+        CNJ_ALL, indice_url=str(broken_indice), report_url=str(fixtures["report"])
+    )
+
+    assert result.encontrado is True
+    assert result.djen is None  # the broken source's gap is empty, not a crash
+    assert any("djen" in a.lower() for a in result.avisos)
+    # unaffected sources still load normally
+    assert result.juris is not None
+    assert result.stj is not None
+    assert result.datajud is not None
+
+
+def test_indice_processual_itself_unreachable_propagates() -> None:
+    """Unlike a source parquet, the index itself failing has no partial answer."""
+    with pytest.raises(duckdb.Error):
+        service.buscar_processo(
+            CNJ_ALL,
+            indice_url="/nonexistent/indice_processual.parquet",
+            report_url="/nonexistent.report.json",
+        )
+
+
+def test_incluir_documentos_false_skips_the_documentos_query(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_ALL,
+        incluir_documentos=False,
+        indice_url=str(fixtures["indice"]),
+        report_url=str(fixtures["report"]),
+    )
+
+    assert result.documentos == []
+    assert result.documentos_truncados is False
+    # the per-fonte summaries are unaffected — only the documents list is skipped
+    assert result.juris is not None
+    assert result.stj is not None
+
+
+def test_limite_documentos_truncates_and_flags_it(fixtures: dict[str, Path]) -> None:
+    result = service.buscar_processo(
+        CNJ_ALL,
+        limite_documentos=1,
+        indice_url=str(fixtures["indice"]),
+        report_url=str(fixtures["report"]),
+    )
+
+    assert len(result.documentos) == 1
+    assert result.documentos[0].fonte == "stj"  # most recent by data DESC
+    assert result.documentos_truncados is True

--- a/tests/causaganha_mcp/test_processo_consultar.py
+++ b/tests/causaganha_mcp/test_processo_consultar.py
@@ -1,0 +1,228 @@
+"""Behavior tests for the ``processo_consultar`` MCP tool (RFC 0014 M2).
+
+`causaganha.processos.service.buscar_processo` itself is tested against real
+local-parquet fixtures in `tests/causaganha/processos/test_service.py` — what
+these tests own instead is the MCP-specific wiring layered on top of it:
+mapping a `ProcessoConsultaResult` onto the Pydantic envelope
+(`causaganha_mcp.tools.processo._to_result`), translating domain exceptions
+into `fastmcp.exceptions.ToolError` without leaking upstream detail (same
+philosophy as `test_datajud_facetas.py`), and building `web_url`/`web_path`
+from the `CAUSAGANHA_WEB_BASE_URL` env var. `service.buscar_processo` is
+monkeypatched at the tool module's own import (`causaganha_mcp.tools.processo
+.service`) so none of this touches DuckDB or the network.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from causaganha.processos.models import (
+    CnjInvalidoError,
+    DatajudCapa,
+    DjenResumo,
+    DocumentoProcesso,
+    FonteCobertura,
+    JurisDecisao,
+    ProcessoConsultaResult,
+    StjAcordao,
+)
+from causaganha_mcp import server as server_module
+from causaganha_mcp.tools import processo as processo_module
+
+
+CNJ = "00000010220248220001"
+CNJ_MASCARA = "0000001-02.2024.8.22.0001"
+
+
+@pytest.fixture
+def mcp():
+    return server_module.build_server()
+
+
+async def _processo_fn(mcp):
+    tool = await mcp.get_tool("processo_consultar")
+    return tool.fn
+
+
+def _stub_returning(resultado: ProcessoConsultaResult):
+    def _stub(*args: object, **kwargs: object) -> ProcessoConsultaResult:
+        return resultado
+
+    return _stub
+
+
+def _stub_raising(exc: Exception):
+    def _stub(*args: object, **kwargs: object) -> ProcessoConsultaResult:
+        raise exc
+
+    return _stub
+
+
+def _resultado_encontrado(**overrides: object) -> ProcessoConsultaResult:
+    base = {
+        "encontrado": True,
+        "nr_processo": CNJ,
+        "nr_processo_mascara": CNJ_MASCARA,
+        "fontes_presentes": ["datajud", "djen", "juris", "stj"],
+        "cobertura_dataset": [FonteCobertura(fonte="djen", status="loaded_remote", registros=10)],
+        "djen": DjenResumo(
+            primeira_publicacao="2024-03-01",
+            ultima_publicacao="2024-03-05",
+            n_publicacoes=2,
+            tribunais=["TJRO"],
+        ),
+        "juris": JurisDecisao(
+            n_documentos=1,
+            tipos=["ACÓRDÃO"],
+            data_julgamento="2024-01-15",
+            orgao="2a Camara",
+            relator="Des. A",
+            classe="Apelação",
+            url="https://juris/1",
+        ),
+        "stj": StjAcordao(
+            id="stj-1",
+            classe="REsp",
+            relator="MIN X",
+            tema="tema",
+            tese="tese",
+            ementa="ementa",
+            data_decisao="2024-05-01",
+            data_publicacao="2024-05-10",
+        ),
+        "datajud": DatajudCapa(
+            classe_oficial="Apelacao Civel",
+            assuntos="Contratos",
+            orgao_julgador="2a Camara",
+            grau="G2",
+            data_ajuizamento="2024-01-10",
+            ultima_atualizacao="2024-06-01",
+        ),
+        "documentos": [
+            DocumentoProcesso(
+                fonte="stj",
+                id_documento="stj-1",
+                tipo="REsp",
+                data="2024-05-01",
+                url="",
+                resumo="ementa",
+            )
+        ],
+        "documentos_truncados": False,
+        "dataset_gerado_em": "2026-07-12T18:00:00Z",
+        "avisos": [],
+    }
+    base.update(overrides)
+    return ProcessoConsultaResult(**base)
+
+
+async def test_success_maps_every_field(mcp, monkeypatch) -> None:
+    monkeypatch.delenv(processo_module._WEB_BASE_URL_ENV, raising=False)
+    monkeypatch.setattr(
+        processo_module.service, "buscar_processo", _stub_returning(_resultado_encontrado())
+    )
+
+    fn = await _processo_fn(mcp)
+    result = fn(cnj=CNJ)
+
+    assert result.encontrado is True
+    assert result.cnj == CNJ
+    assert result.cnj_formatado == CNJ_MASCARA
+    assert result.fontes_presentes == ["datajud", "djen", "juris", "stj"]
+    assert result.cobertura_dataset[0].fonte == "djen"
+    assert result.cobertura_dataset[0].registros == 10
+
+    assert result.djen.n_publicacoes == 2
+    assert result.juris.orgao == "2a Camara"
+    assert result.stj.id == "stj-1"
+    assert result.datajud.classe_oficial == "Apelacao Civel"
+
+    assert len(result.documentos) == 1
+    assert result.documentos[0].fonte == "stj"
+    assert result.documentos_truncados is False
+    assert result.dataset_gerado_em == "2026-07-12T18:00:00Z"
+    assert result.avisos == []
+
+    assert result.fonte == "parquet_ia"
+    assert result.canonica is True
+    assert result.consultado_em  # a fresh timestamp, not empty
+    assert result.web_path == f"/processo?cnj={CNJ_MASCARA}"
+    assert result.web_url is None  # no env var set
+
+
+async def test_not_found_leaves_optional_fields_empty(mcp, monkeypatch) -> None:
+    resultado = ProcessoConsultaResult(
+        encontrado=False, nr_processo=CNJ, nr_processo_mascara=CNJ_MASCARA
+    )
+    monkeypatch.setattr(processo_module.service, "buscar_processo", _stub_returning(resultado))
+
+    fn = await _processo_fn(mcp)
+    result = fn(cnj=CNJ)
+
+    assert result.encontrado is False
+    assert result.fontes_presentes == []
+    assert result.cobertura_dataset == []
+    assert result.djen is None
+    assert result.juris is None
+    assert result.stj is None
+    assert result.datajud is None
+    assert result.documentos == []
+    assert result.avisos == []
+
+
+async def test_web_url_built_from_env_var(mcp, monkeypatch) -> None:
+    monkeypatch.setenv(processo_module._WEB_BASE_URL_ENV, "https://causaganha.example/")
+    monkeypatch.setattr(
+        processo_module.service, "buscar_processo", _stub_returning(_resultado_encontrado())
+    )
+
+    fn = await _processo_fn(mcp)
+    result = fn(cnj=CNJ)
+
+    assert result.web_url == f"https://causaganha.example/processo?cnj={CNJ_MASCARA}"
+
+
+async def test_web_url_none_without_env_var(mcp, monkeypatch) -> None:
+    monkeypatch.delenv(processo_module._WEB_BASE_URL_ENV, raising=False)
+    monkeypatch.setattr(
+        processo_module.service, "buscar_processo", _stub_returning(_resultado_encontrado())
+    )
+
+    fn = await _processo_fn(mcp)
+    result = fn(cnj=CNJ)
+
+    assert result.web_url is None
+
+
+async def test_invalid_cnj_raises_tool_error_with_actionable_message(mcp, monkeypatch) -> None:
+    exc = CnjInvalidoError("CNJ inválido (esperado 20 dígitos): '123'")
+    monkeypatch.setattr(processo_module.service, "buscar_processo", _stub_raising(exc))
+
+    fn = await _processo_fn(mcp)
+    with pytest.raises(ToolError, match="CNJ inválido"):
+        fn(cnj="123")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        duckdb.Error("IO Error: could not open file /some/internal/path"),
+        httpx.HTTPError("connection reset"),
+    ],
+)
+async def test_source_failure_raises_generic_tool_error_without_leaking_detail(
+    mcp, monkeypatch, exc
+) -> None:
+    monkeypatch.setattr(processo_module.service, "buscar_processo", _stub_raising(exc))
+
+    fn = await _processo_fn(mcp)
+    with pytest.raises(ToolError) as exc_info:
+        fn(cnj=CNJ)
+
+    message = str(exc_info.value)
+    assert "indice_processual.parquet" in message
+    assert "internal/path" not in message  # never leak the raw exception detail
+    assert "connection reset" not in message

--- a/tests/causaganha_mcp/test_tool_schema.py
+++ b/tests/causaganha_mcp/test_tool_schema.py
@@ -17,6 +17,12 @@ consumer exists (RFC 0014 §2), locked here with an exact-property-set test
 per tool (both `parameters` and `output_schema`) so a future edit can't
 silently drop or rename an envelope field, or leave an English identifier
 in the input schema while only the output gets translated.
+
+RFC 0014 M2 adds `processo_consultar` — the first tool serving the end user
+directly, not the pipeline operator. It shares the read-only/no-credential
+bar and the Portuguese-schema convention with everything above; it reads the
+canonical parquets from Internet Archive (`openWorldHint=True`, same as
+`datajud_facetas`), never a local manifest.
 """
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ TOOL_NAMES = [
     "stj_acordaos_status",
     "djen_backup_status",
     "causaganha_status",
+    "processo_consultar",
 ]
 
 _CREDENTIAL_SUBSTRINGS = ("key", "secret", "token", "credential", "password")
@@ -51,6 +58,26 @@ _EXPECTED_OUTPUT_FIELDS = {
     | {"enviados", "disponiveis", "ausentes", "desconhecidos"},
     "datajud_facetas": {"tribunal", "por", "total", "grupos", "consultado_em"},
     "causaganha_status": {"pipelines"},
+    "processo_consultar": {
+        "encontrado",
+        "cnj",
+        "cnj_formatado",
+        "fontes_presentes",
+        "cobertura_dataset",
+        "djen",
+        "juris",
+        "stj",
+        "datajud",
+        "documentos",
+        "documentos_truncados",
+        "dataset_gerado_em",
+        "consultado_em",
+        "fonte",
+        "canonica",
+        "avisos",
+        "web_url",
+        "web_path",
+    },
 }
 
 # Input parameter names are product text too (RFC 0014 review) — an English
@@ -63,6 +90,7 @@ _EXPECTED_INPUT_FIELDS = {
     "djen_backup_status": {"arquivo_manifesto"},
     "datajud_facetas": {"tribunal", "por", "limite"},
     "causaganha_status": set(),
+    "processo_consultar": {"cnj", "incluir_documentos", "limite_documentos"},
 }
 
 

--- a/tests/datajud/test_datajud_enrich.py
+++ b/tests/datajud/test_datajud_enrich.py
@@ -162,7 +162,7 @@ def test_enrich_no_cnjs_and_no_sources_fails_nominally(tmp_path: Path, monkeypat
     from datajud import service
 
     # IA fallback download is a urllib call — stub it out (zero real network)
-    monkeypatch.setattr(service, "_try_download_unificados", lambda _dir: None)
+    monkeypatch.setattr(service, "_try_download_indice", lambda _dir: None)
     exit_code, _output = _invoke(
         [
             "enrich",
@@ -182,8 +182,8 @@ def test_enrich_reads_cnjs_from_source_parquets(tmp_path: Path):
     con = duckdb.connect()
     con.execute(
         f"""
-        COPY (SELECT '{CNJ}' AS nr_processo)
-        TO '{sources_dir / "processos_unificados.parquet"}' (FORMAT PARQUET)
+        COPY (SELECT '{CNJ}' AS numero_processo)
+        TO '{sources_dir / "indice_processual.parquet"}' (FORMAT PARQUET)
         """
     )
     con.close()

--- a/tests/test_reconcile_processos.py
+++ b/tests/test_reconcile_processos.py
@@ -42,10 +42,10 @@ def _comunicacoes_parquet(path: Path) -> Path:
         path,
         f"""
         SELECT * FROM (VALUES
-            ('0000001-02.2024.8.22.0001', DATE '2024-03-01', 'TJRO'),
-            ('{CNJ_ALL}',                 DATE '2024-03-05', 'TJRO'),
-            ('{CNJ_DJEN_DJ}',             DATE '2024-04-01', 'TJRO')
-        ) AS t(numero_processo, data_disponibilizacao, tribunal)
+            ('0000001-02.2024.8.22.0001', DATE '2024-03-01', 'TJRO', 'c1', 'djen-2024-03-01'),
+            ('{CNJ_ALL}',                 DATE '2024-03-05', 'TJRO', 'c2', 'djen-2024-03-05'),
+            ('{CNJ_DJEN_DJ}',             DATE '2024-04-01', 'TJRO', 'c3', 'djen-2024-04-01')
+        ) AS t(numero_processo, data_disponibilizacao, tribunal, id, p_item_ia)
         """,
     )
 
@@ -117,8 +117,7 @@ def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     data_dir.mkdir()
     monkeypatch.setattr(rp, "ROOT", tmp_path)  # JURIS local globs find nothing
     monkeypatch.setattr(rp, "DATA_DIR", data_dir)
-    monkeypatch.setattr(rp, "_PARQUET_UNIFICADOS", data_dir / "processos_unificados.parquet")
-    monkeypatch.setattr(rp, "_PARQUET_DOCUMENTOS", data_dir / "processo_documentos.parquet")
+    monkeypatch.setattr(rp, "_PARQUET_INDICE", data_dir / "indice_processual.parquet")
     monkeypatch.setattr(rp, "_STJ_PARQUET", data_dir / "stj" / "stj-acordaos.parquet")
     monkeypatch.setattr(rp, "_DATAJUD_DIR", data_dir / "datajud")
     monkeypatch.setenv("RECONCILE_CACHE_DIR", str(tmp_path / "cache"))
@@ -204,18 +203,41 @@ class TestFullReconcileWithoutLocalParquets:
         assert stats["total"] == 2
         assert stats["multi_fonte"] == 2
 
-        # Output parquet: tem_datajud/tem_juris-style flags actually populated
+        # Output parquet: one row per (processo, fonte, registro) — never a
+        # copy of content fields, only enough to say where each record lives.
         con = duckdb.connect()
         try:
-            rows = con.execute(
-                "SELECT nr_processo, tem_datajud, n_fontes, array_to_string(fontes, '+'), "
-                "juris_n_documentos "
-                f"FROM read_parquet('{rp._PARQUET_UNIFICADOS}') ORDER BY nr_processo"
+            fontes_por_processo = con.execute(
+                "SELECT numero_processo, list(DISTINCT fonte ORDER BY fonte) "
+                f"FROM read_parquet('{rp._PARQUET_INDICE}') "
+                "GROUP BY numero_processo ORDER BY numero_processo"
             ).fetchall()
+            registros_por_processo_fonte = con.execute(
+                "SELECT numero_processo, fonte, COUNT(*) "
+                f"FROM read_parquet('{rp._PARQUET_INDICE}') "
+                "GROUP BY numero_processo, fonte ORDER BY numero_processo, fonte"
+            ).fetchall()
+            nao_nulos = con.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{rp._PARQUET_INDICE}') "
+                "WHERE tribunal IS NULL OR data IS NULL OR arquivo_ia_url IS NULL"
+            ).fetchone()
         finally:
             con.close()
-        assert rows[0] == (CNJ_ALL, True, 4, "djen+juris+stj+datajud", 2)
-        assert rows[1] == (CNJ_DJEN_DJ, True, 2, "djen+datajud", None)
+        assert fontes_por_processo == [
+            (CNJ_ALL, ["datajud", "djen", "juris", "stj"]),
+            (CNJ_DJEN_DJ, ["datajud", "djen"]),
+        ]
+        # CNJ_ALL: 2 DJEN publications, 2 JURIS documents (id_documento 1+2),
+        # 1 STJ acórdão, 1 DataJud capa row (synthetic key, no natural id).
+        assert registros_por_processo_fonte == [
+            (CNJ_ALL, "datajud", 1),
+            (CNJ_ALL, "djen", 2),
+            (CNJ_ALL, "juris", 2),
+            (CNJ_ALL, "stj", 1),
+            (CNJ_DJEN_DJ, "datajud", 1),
+            (CNJ_DJEN_DJ, "djen", 1),
+        ]
+        assert nao_nulos == (0,)  # every row resolves tribunal/data/arquivo_ia_url
 
         # Coverage report next to the output
         report = json.loads((rp.DATA_DIR / rp._REPORT_NAME).read_text(encoding="utf-8"))
@@ -226,7 +248,7 @@ class TestFullReconcileWithoutLocalParquets:
             "stj": "loaded_remote",
             "datajud": "loaded_remote",
         }
-        assert report["combinations"] == {"djen+juris+stj+datajud": 1, "djen+datajud": 1}
+        assert report["combinations"] == {"datajud+djen+juris+stj": 1, "datajud+djen": 1}
         assert report["validation"]["errors"] == []
         assert report["validation"]["warnings"] == []
 

--- a/tests/test_reconcile_processos.py
+++ b/tests/test_reconcile_processos.py
@@ -221,8 +221,24 @@ class TestFullReconcileWithoutLocalParquets:
                 f"SELECT COUNT(*) FROM read_parquet('{rp._PARQUET_INDICE}') "
                 "WHERE tribunal IS NULL OR data IS NULL OR arquivo_ia_url IS NULL"
             ).fetchone()
+            juris_urls = con.execute(
+                "SELECT DISTINCT arquivo_ia_url "
+                f"FROM read_parquet('{rp._PARQUET_INDICE}') WHERE fonte = 'juris' "
+                "ORDER BY arquivo_ia_url"
+            ).fetchall()
         finally:
             con.close()
+        # _mock_juris_remote serves this CNJ from monthly shards (no
+        # consolidated tjro-juris-2024.parquet in the fake item). Both
+        # surviving rows (id_documento 1 deduped to its 2024-02 copy, id 2
+        # only in 2024-02) come from 2024-02-SENTENCA.parquet — the URL must
+        # reflect that, never the absent consolidated file inferred from
+        # data_julgamento's year (which would have pointed at
+        # tjro-juris-2024/tjro-juris-2024.parquet — a file that doesn't
+        # exist in this fallback).
+        assert juris_urls == [
+            ("https://archive.org/download/tjro-juris-2024/2024-02-SENTENCA.parquet",),
+        ]
         assert fontes_por_processo == [
             (CNJ_ALL, ["datajud", "djen", "juris", "stj"]),
             (CNJ_DJEN_DJ, ["datajud", "djen"]),
@@ -371,6 +387,51 @@ class TestCorruptedParquetHandling:
         # the corrupt download must never be promoted to the final cache path
         assert not rp._STJ_PARQUET.exists()
 
+    @pytest.mark.usefixtures("isolated_dirs")
+    def test_datajud_parquet_missing_orgao_julgador_codigo_or_tribunal_degrades_gracefully(
+        self,
+    ) -> None:
+        """A partial/old DataJud capa parquet must not crash the reconciliation.
+
+        _INDICE_DATAJUD_SQL uses both `orgao_julgador_codigo` (for the
+        synthetic registro_id) and `tribunal` — if the schema gate in
+        _register_datajud doesn't check for them, a parquet missing either
+        column passes as loaded_local, and `CREATE TEMP TABLE
+        indice_processual` then fails with a Binder Error instead of
+        DataJud degrading to unavailable.
+        """
+        rp._DATAJUD_DIR.mkdir(parents=True, exist_ok=True)
+        partial = rp._DATAJUD_DIR / rp._datajud_capa_name("tjro")
+        con = duckdb.connect()
+        try:
+            con.execute(
+                f"""
+                COPY (
+                    SELECT '{CNJ_ALL}' AS numero_processo, 'G2' AS grau,
+                        'Apelacao Civel' AS classe_nome, 'Contratos' AS assuntos,
+                        '2a Camara' AS orgao_julgador,
+                        DATE '2024-01-10' AS data_ajuizamento,
+                        DATE '2024-06-01' AS ultima_atualizacao
+                    -- deliberately missing tribunal + orgao_julgador_codigo
+                ) TO '{partial}' (FORMAT PARQUET)
+                """
+            )
+            load = rp._register_datajud(con)
+            assert load.status == rp.STATUS_UNAVAILABLE
+            assert "orgao_julgador_codigo" in load.detail
+            assert "tribunal" in load.detail
+
+            # The empty fallback view must still satisfy _INDICE_DATAJUD_SQL —
+            # this is what actually would have raised the Binder Error before
+            # the gate was fixed (a parquet missing these columns would have
+            # passed the old gate as loaded_local, and this SELECT — the one
+            # that runs inside _INDICE_SQL's UNION ALL — is exactly where it
+            # would have failed instead).
+            rows = con.execute(f"SELECT COUNT(*) FROM ({rp._INDICE_DATAJUD_SQL})").fetchone()
+            assert rows == (0,)
+        finally:
+            con.close()
+
     def test_already_corrupted_cache_file_is_not_treated_as_valid(
         self, isolated_dirs: Path
     ) -> None:
@@ -430,6 +491,50 @@ class TestCorruptedParquetHandling:
         # one for CNJ_DJEN_DJ must NOT survive by merging under a shared NULL
         # key with CNJ_ALL's null row.
         assert rows == [(CNJ_ALL, 1)]
+
+    def test_arquivo_ia_url_populated_even_with_null_data_julgamento(
+        self, isolated_dirs: Path
+    ) -> None:
+        """arquivo_ia_url comes from which file DuckDB actually read, never
+        from data_julgamento — a NULL/unparseable date must not produce a
+        NULL URL for a row that does have a real file.
+        """
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        shard = _juris_parquet(
+            fixtures / "2024-01-ACORDAO.parquet",
+            f"(1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+            " NULL, 'texto sem data', 'https://juris/1', '2024-01-31T00:00:00')",
+        )
+        with respx.mock() as router:
+            router.get(host="archive.org", path="/advancedsearch.php").respond(
+                200, json={"response": {"docs": [{"identifier": "tjro-juris-2024"}]}}
+            )
+            router.get(host="archive.org", path="/metadata/tjro-juris-2024").respond(
+                200, json={"files": [{"name": "2024-01-ACORDAO.parquet"}]}
+            )
+            router.get(
+                host="archive.org", path="/download/tjro-juris-2024/2024-01-ACORDAO.parquet"
+            ).respond(200, content=shard.read_bytes())
+
+            con = duckdb.connect()
+            try:
+                load = rp._register_juris(con)
+                rows = con.execute(
+                    "SELECT nr_processo, data_julgamento, arquivo_ia_url FROM tjro_juris"
+                ).fetchall()
+            finally:
+                con.close()
+
+        assert load.status == rp.STATUS_LOADED_REMOTE
+        assert rows == [
+            (
+                CNJ_ALL,
+                None,
+                "https://archive.org/download/tjro-juris-2024/2024-01-ACORDAO.parquet",
+            )
+        ]
 
     def test_one_invalid_source_does_not_block_other_valid_sources(
         self, isolated_dirs: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_reconcile_processos.py
+++ b/tests/test_reconcile_processos.py
@@ -574,6 +574,56 @@ class TestCorruptedParquetHandling:
         assert report["sources"]["datajud"]["status"] == rp.STATUS_LOADED_REMOTE
 
 
+class TestLocalSourceUrlProvenanceWarning:
+    """arquivo_ia_url for a loaded_local source is presumed, not proven (RFC 0014 M2 review).
+
+    CI never exercises this — update-catalog.yml's download-state action
+    only fetches sync-manifest.parquet — but a local/dev run of this script
+    can hit it, and the reconciler must say so loudly rather than silently
+    trusting the presumption.
+    """
+
+    def test_warns_when_juris_loaded_from_local_file(
+        self, isolated_dirs: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tmp_path = isolated_dirs
+        juris_dir = tmp_path / "data" / "tjro_juris" / "2024"
+        juris_dir.mkdir(parents=True)
+        _juris_parquet(
+            juris_dir / "tjro-juris-2024.parquet",
+            f"(1, '{CNJ_ALL}', 'ACÓRDÃO', 'Apelação', '2a Camara', 'Des. A', 'PJE',"
+            " '2024-01-15', 'texto um', 'https://juris/1', '2024-01-31T00:00:00')",
+        )
+        con = duckdb.connect()
+        try:
+            load = rp._register_juris(con)
+        finally:
+            con.close()
+
+        assert load.status == rp.STATUS_LOADED_LOCAL
+        err = capsys.readouterr().err
+        assert "juris" in err
+        assert "arquivo_ia_url" in err
+        assert "presumed" in err
+
+    def test_no_warning_when_juris_loaded_from_ia(
+        self, isolated_dirs: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tmp_path = isolated_dirs
+        fixtures = tmp_path / "fixtures"
+        fixtures.mkdir()
+        with respx.mock() as router:
+            _mock_juris_remote(router, fixtures)
+            con = duckdb.connect()
+            try:
+                load = rp._register_juris(con)
+            finally:
+                con.close()
+
+        assert load.status == rp.STATUS_LOADED_REMOTE
+        assert "presumed" not in capsys.readouterr().err
+
+
 class TestValidateCoverage:
     def test_zero_plus_unavailable_expected_is_error(self) -> None:
         sources = {"juris": rp.SourceLoad("juris", rp.STATUS_UNAVAILABLE, "no IA items", rows=0)}

--- a/tests/test_render_queries.py
+++ b/tests/test_render_queries.py
@@ -287,3 +287,89 @@ def test_main_strict_exit_zero_when_only_optional_missing(tmp_path, monkeypatch,
     monkeypatch.setattr(rq, "PUBLIC_DIR", tmp_path / "public")
     monkeypatch.setattr(rq, "VIEW_SPECS", _manifest_specs(manifest_parquet))
     assert rq.main(["--strict"]) == 0
+
+
+# ── _register_comunicacoes rollout fallback (RFC 0014 M2 review) ──────────────
+
+
+def _copy_sql_to_parquet(path, sql):
+    import duckdb
+
+    con = duckdb.connect()
+    try:
+        con.execute(f"COPY ({sql}) TO '{path}' (FORMAT PARQUET)")
+    finally:
+        con.close()
+    return path
+
+
+def test_register_comunicacoes_falls_back_to_catalog_manifest_when_indice_missing(
+    tmp_path, monkeypatch
+):
+    """indice_processual.parquet can 404 (deploy-web.yml can build before
+    update-catalog.yml ever publishes it — see the module-level comment on
+    _IA_CATALOG_MANIFEST_URL). Without a fallback, processos_multi_fonte.qmd
+    would regress from real DJEN data to empty for however long that takes.
+    """
+    import duckdb
+
+    comunicacoes = _copy_sql_to_parquet(
+        tmp_path / "comunicacoes.parquet",
+        """
+        SELECT * FROM (VALUES
+            ('00000010220248220001', DATE '2024-03-01', 'TJRO')
+        ) AS t(numero_processo, data_disponibilizacao, tribunal)
+        """,
+    )
+    catalog = _copy_sql_to_parquet(
+        tmp_path / "catalog.parquet",
+        f"SELECT '{comunicacoes}' AS ia_url, 'comunicacoes' AS table_name",
+    )
+    monkeypatch.setattr(rq, "_IA_CATALOG_MANIFEST_URL", str(catalog))
+    # Index unreachable: dest doesn't exist locally, and the "IA" URL refuses
+    # the connection immediately (no real network involved).
+    monkeypatch.setattr(rq, "_INDICE_PROCESSUAL_PARQUET", tmp_path / "indice_processual.parquet")
+    monkeypatch.setattr(rq, "_INDICE_PROCESSUAL_IA_URL", "http://127.0.0.1:1/unreachable")
+
+    con = duckdb.connect()
+    try:
+        registered = rq._register_comunicacoes(con)
+        assert registered is True
+        rows = con.execute("SELECT numero_processo FROM comunicacoes").fetchall()
+    finally:
+        con.close()
+    assert rows == [("00000010220248220001",)]
+
+
+def test_register_comunicacoes_prefers_indice_when_available(tmp_path, monkeypatch):
+    import duckdb
+
+    comunicacoes = _copy_sql_to_parquet(
+        tmp_path / "comunicacoes.parquet",
+        """
+        SELECT * FROM (VALUES
+            ('00000010220248220001', DATE '2024-03-01', 'TJRO')
+        ) AS t(numero_processo, data_disponibilizacao, tribunal)
+        """,
+    )
+    indice = _copy_sql_to_parquet(
+        tmp_path / "indice_processual.parquet",
+        f"""
+        SELECT '00000010220248220001' AS numero_processo, 'djen' AS fonte,
+            'c1' AS registro_id, 'TJRO' AS tribunal, DATE '2024-03-01' AS data,
+            '{comunicacoes}' AS arquivo_ia_url
+        """,
+    )
+    monkeypatch.setattr(rq, "_INDICE_PROCESSUAL_PARQUET", indice)
+    # A wrong/unreachable catalog URL proves the fallback was never touched —
+    # if it had been used, this would raise instead of quietly succeeding.
+    monkeypatch.setattr(rq, "_IA_CATALOG_MANIFEST_URL", "http://127.0.0.1:1/unreachable")
+
+    con = duckdb.connect()
+    try:
+        registered = rq._register_comunicacoes(con)
+        assert registered is True
+        rows = con.execute("SELECT numero_processo FROM comunicacoes").fetchall()
+    finally:
+        con.close()
+    assert rows == [("00000010220248220001",)]

--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -7,16 +7,13 @@
     FONTE_LABELS,
     DOCUMENTOS_PAGE_SIZE,
     buildCnjSearchParams,
-    buildProcessoDocumentosSql,
-    buildProcessoUnificadoSql,
+    buscarProcesso,
+    carregarDocumentos,
     classifyCnjInput,
     fontesPresenca,
     formatCnj,
     isDocumentosVazio,
-    mapDocumentoRow,
-    mapProcessoRow,
     normalizeCnj,
-    paginate,
     readCnjParam,
   } from '../lib/processoCnj';
 
@@ -50,7 +47,7 @@
     status === 'found' && documentosStatus === 'ready' && isDocumentosVazio(documentos, 0) && documentosOffset === 0,
   );
   const datasetGeneratedAtLabel = $derived(
-    processo?.updatedAtRaw ? (formatUtcDateTime(processo.updatedAtRaw) ?? 'desconhecido') : 'desconhecido',
+    processo?.datasetGeradoEm ? (formatUtcDateTime(processo.datasetGeradoEm) ?? 'desconhecido') : 'desconhecido',
   );
 
   async function init() {
@@ -71,12 +68,15 @@
   async function loadDocumentos(digits, offset, generation = searchGeneration) {
     documentosStatus = 'loading';
     documentosError = null;
-    let stmt;
     try {
-      stmt = await conn.prepare(buildProcessoDocumentosSql());
-      const result = await stmt.query(digits, DOCUMENTOS_PAGE_SIZE + 1, offset);
-      const rawRows = result.toArray().map((row) => row.toJSON());
-      const { items, hasMore } = paginate(rawRows.map(mapDocumentoRow), DOCUMENTOS_PAGE_SIZE);
+      const { items, hasMore } = await carregarDocumentos(
+        conn,
+        processo?.jurisUrls ?? [],
+        processo?.stjUrls ?? [],
+        digits,
+        offset,
+        DOCUMENTOS_PAGE_SIZE,
+      );
 
       if (generation !== searchGeneration) return; // a newer search superseded this one
 
@@ -88,8 +88,6 @@
       if (generation !== searchGeneration) return;
       documentosStatus = 'error';
       documentosError = err instanceof Error ? err.message : String(err);
-    } finally {
-      await stmt?.close();
     }
   }
 
@@ -145,21 +143,18 @@
       return;
     }
 
-    let stmt;
     try {
-      stmt = await conn.prepare(buildProcessoUnificadoSql());
-      const result = await stmt.query(digits);
-      const rows = result.toArray().map((row) => row.toJSON());
+      const resultado = await buscarProcesso(conn, digits);
 
       if (generation !== searchGeneration) return; // a newer search superseded this one
 
-      if (rows.length === 0) {
+      if (!resultado.encontrado) {
         status = 'not_found';
         lastQueriedCnj = digits;
         return;
       }
 
-      processo = mapProcessoRow(rows[0]);
+      processo = resultado;
       lastQueriedCnj = digits;
       status = 'found';
     } catch (err) {
@@ -167,8 +162,6 @@
       status = 'source_unavailable';
       queryError = err instanceof Error ? err.message : String(err);
       return;
-    } finally {
-      await stmt?.close();
     }
 
     // Only reached when the processo query above landed on 'found' for this
@@ -247,7 +240,7 @@
   {/if}
 
   {#if status === 'querying'}
-    <p aria-busy="true">Consultando processos_unificados.parquet e processo_documentos.parquet no Internet Archive…</p>
+    <p aria-busy="true">Consultando indice_processual.parquet e os parquets de origem (DJEN, JURIS, STJ, DataJud) no Internet Archive…</p>
   {/if}
 
   {#if status === 'not_found'}
@@ -255,7 +248,7 @@
       <h3>Processo não localizado</h3>
       <p>
         Nenhum registro para <code>{lastQueriedCnj ? formatCnj(lastQueriedCnj) : ''}</code> em
-        processos_unificados.parquet. Isso significa que o CNJ não apareceu em nenhuma das fontes
+        indice_processual.parquet. Isso significa que o CNJ não apareceu em nenhuma das fontes
         reconciliadas (DJEN, JURIS, STJ, DataJud) até a última geração do dataset — não que o
         processo não existe.
       </p>
@@ -280,6 +273,14 @@
           dataset gerado em {datasetGeneratedAtLabel}
         </p>
       </header>
+
+      {#if processo.avisos.length > 0}
+        <aside role="status" class="alert" data-level="warning">
+          {#each processo.avisos as aviso}
+            <p>{aviso}</p>
+          {/each}
+        </aside>
+      {/if}
 
       <section aria-labelledby="fontes-title">
         <h3 id="fontes-title">Fontes encontradas</h3>

--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -26,6 +26,7 @@
   let invalidMessage = $state(null);
   let queryError = $state(null);
   let processo = $state(null);
+  let notFoundLegado = $state(false);
 
   let documentosStatus = $state('idle'); // 'idle' | 'loading' | 'ready' | 'error'
   let documentosError = $state(null);
@@ -129,6 +130,7 @@
     status = 'querying';
     queryError = null;
     processo = null;
+    notFoundLegado = false;
     documentos = [];
     documentosStatus = 'idle';
     documentosOffset = 0;
@@ -151,6 +153,7 @@
 
       if (!resultado.encontrado) {
         status = 'not_found';
+        notFoundLegado = resultado.legado;
         lastQueriedCnj = digits;
         return;
       }
@@ -249,9 +252,9 @@
       <h3>Processo não localizado</h3>
       <p>
         Nenhum registro para <code>{lastQueriedCnj ? formatCnj(lastQueriedCnj) : ''}</code> em
-        indice_processual.parquet. Isso significa que o CNJ não apareceu em nenhuma das fontes
-        reconciliadas (DJEN, JURIS, STJ, DataJud) até a última geração do dataset — não que o
-        processo não existe.
+        {notFoundLegado ? 'processos_unificados.parquet' : 'indice_processual.parquet'}. Isso
+        significa que o CNJ não apareceu em nenhuma das fontes reconciliadas (DJEN, JURIS, STJ,
+        DataJud) até a última geração do dataset — não que o processo não existe.
       </p>
     </article>
   {/if}

--- a/web/src/components/ProcessoLookup.svelte
+++ b/web/src/components/ProcessoLookup.svelte
@@ -76,6 +76,7 @@
         digits,
         offset,
         DOCUMENTOS_PAGE_SIZE,
+        processo?.legado ?? false,
       );
 
       if (generation !== searchGeneration) return; // a newer search superseded this one

--- a/web/src/components/ProcessoLookup.test.ts
+++ b/web/src/components/ProcessoLookup.test.ts
@@ -2,10 +2,25 @@ import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ProcessoLookup from './ProcessoLookup.svelte';
 import { getDuckDB } from '../lib/duckdbSingleton';
+import * as processoCnj from '../lib/processoCnj';
 
 vi.mock('../lib/duckdbSingleton', () => ({
   getDuckDB: vi.fn(),
 }));
+
+// buscarProcesso/carregarDocumentos' own SQL-building and row-mapping logic
+// is unit-tested in processoCnj.test.ts against a fake DuckDB connection —
+// here only the component's orchestration (async race handling, rendering)
+// is under test, so those two functions are mocked at their natural seam;
+// everything else (formatCnj, fontesPresenca, etc.) stays real.
+vi.mock('../lib/processoCnj', async () => {
+  const actual = await vi.importActual<typeof import('../lib/processoCnj')>('../lib/processoCnj');
+  return {
+    ...actual,
+    buscarProcesso: vi.fn(),
+    carregarDocumentos: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   // Each test mounts its own component instance, but jsdom's window.location
@@ -13,6 +28,7 @@ beforeEach(() => {
   // by history.replaceState() in a previous test would auto-trigger a search
   // on the next test's mount (the component's own, intentional, feature).
   window.history.replaceState(null, '', window.location.pathname);
+  vi.mocked(getDuckDB).mockResolvedValue({ conn: {} } as never);
 });
 
 const CNJ_A = '00000010220248220001';
@@ -31,86 +47,79 @@ function makeDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
-function arrowResult(rows: Record<string, unknown>[]) {
-  return { toArray: () => rows.map((r) => ({ toJSON: () => r })) };
-}
-
-function processoRow(nrProcesso: string): Record<string, unknown> {
+function processoResultado(nrProcesso: string, overrides: Record<string, unknown> = {}) {
   return {
-    nr_processo: nrProcesso,
-    nr_processo_mascara: nrProcesso,
-    n_fontes: 1,
+    encontrado: true,
+    nrProcesso,
+    nrProcessoMascara: nrProcesso,
     fontes: ['djen'],
-    djen_primeira_pub: null,
-    djen_ultima_pub: null,
-    djen_n_publicacoes: null,
-    djen_tribunais: [],
-    juris_n_documentos: null,
-    juris_tipos: [],
-    juris_data_julgamento: null,
-    juris_orgao: null,
-    juris_relator: null,
-    juris_classe: null,
-    juris_url: null,
-    stj_id: null,
-    stj_classe: null,
-    stj_relator: null,
-    stj_tema: null,
-    stj_tese: null,
-    stj_ementa: null,
-    stj_data_decisao: null,
-    stj_data_publicacao: null,
-    classe_oficial: null,
-    assuntos: null,
-    orgao_julgador: null,
-    grau: null,
-    data_ajuizamento: null,
-    ultima_atualizacao: null,
-    tem_datajud: false,
-    updated_at: '2026-07-12T00:00:00Z',
+    djen: { present: true, primeiraPub: null, ultimaPub: null, nPublicacoes: null, tribunais: [] },
+    juris: {
+      present: false,
+      nDocumentos: null,
+      tipos: [],
+      dataJulgamento: null,
+      orgao: null,
+      relator: null,
+      classe: null,
+      url: null,
+    },
+    stj: {
+      present: false,
+      id: null,
+      classe: null,
+      relator: null,
+      tema: null,
+      tese: null,
+      ementa: null,
+      dataDecisao: null,
+      dataPublicacao: null,
+    },
+    datajud: {
+      present: false,
+      classeOficial: null,
+      assuntos: null,
+      orgaoJulgador: null,
+      grau: null,
+      dataAjuizamento: null,
+      ultimaAtualizacao: null,
+    },
+    jurisUrls: [],
+    stjUrls: [],
+    cobertura: [],
+    datasetGeradoEm: null,
+    avisos: [],
+    ...overrides,
   };
 }
 
-function documentoRow(nrProcesso: string, resumo: string): Record<string, unknown> {
-  return {
-    nr_processo: nrProcesso,
-    fonte: 'juris',
-    id_documento: `${nrProcesso}-doc`,
-    tipo: 'ACÓRDÃO',
-    data: '2024-01-15',
-    url: null,
-    resumo,
-  };
+function documentoRow(nrProcesso: string, resumo: string) {
+  return { fonte: 'juris', idDocumento: `${nrProcesso}-doc`, tipo: 'ACÓRDÃO', data: '2024-01-15', url: null, resumo };
 }
 
-/** A fake conn whose prepare()/query() resolutions are controlled per-CNJ by the test. */
-function makeControllableConn() {
+/** Controls buscarProcesso()/carregarDocumentos() resolution per-CNJ, mirroring the old per-query control. */
+function makeControllable() {
   const processoDeferreds = new Map<string, Deferred<unknown>>();
   const documentosDeferreds = new Map<string, Deferred<unknown>>();
 
-  const conn = {
-    prepare: vi.fn(async (sql: string) => {
-      const isDocumentos = sql.includes('processo_documentos');
-      return {
-        query: vi.fn((...params: unknown[]) => {
-          const digits = String(params[0]);
-          const map = isDocumentos ? documentosDeferreds : processoDeferreds;
-          const deferred = makeDeferred();
-          map.set(digits, deferred);
-          return deferred.promise;
-        }),
-        close: vi.fn(async () => {}),
-      };
-    }),
-  };
+  vi.mocked(processoCnj.buscarProcesso).mockImplementation((_conn: unknown, digits: string) => {
+    const deferred = makeDeferred();
+    processoDeferreds.set(digits, deferred);
+    return deferred.promise as ReturnType<typeof processoCnj.buscarProcesso>;
+  });
 
-  return { conn, processoDeferreds, documentosDeferreds };
+  vi.mocked(processoCnj.carregarDocumentos).mockImplementation((_conn: unknown, _jurisUrls, _stjUrls, digits: string) => {
+    const deferred = makeDeferred();
+    documentosDeferreds.set(digits, deferred);
+    return deferred.promise as ReturnType<typeof processoCnj.carregarDocumentos>;
+  });
+
+  return { processoDeferreds, documentosDeferreds };
 }
 
 describe('ProcessoLookup — race between two searches', () => {
   it('discards a stale documentos response from search A once search B has already landed', async () => {
-    const { conn, processoDeferreds, documentosDeferreds } = makeControllableConn();
-    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+    const { processoDeferreds, documentosDeferreds } = makeControllable();
 
     const { getByLabelText, getByText, queryByText } = render(ProcessoLookup);
 
@@ -123,7 +132,7 @@ describe('ProcessoLookup — race between two searches', () => {
     await fireEvent.click(getByText('Buscar'));
     await waitFor(() => expect(processoDeferreds.has(CNJ_A)).toBe(true));
 
-    processoDeferreds.get(CNJ_A)!.resolve(arrowResult([processoRow(CNJ_A)]));
+    processoDeferreds.get(CNJ_A)!.resolve(processoResultado(CNJ_A));
     await waitFor(() => expect(documentosDeferreds.has(CNJ_A)).toBe(true));
 
     // The record for A is showing, and the button is enabled again — this is
@@ -136,15 +145,15 @@ describe('ProcessoLookup — race between two searches', () => {
     await fireEvent.click(getByText('Buscar'));
     await waitFor(() => expect(processoDeferreds.has(CNJ_B)).toBe(true));
 
-    processoDeferreds.get(CNJ_B)!.resolve(arrowResult([processoRow(CNJ_B)]));
+    processoDeferreds.get(CNJ_B)!.resolve(processoResultado(CNJ_B));
     await waitFor(() => expect(documentosDeferreds.has(CNJ_B)).toBe(true));
-    documentosDeferreds.get(CNJ_B)!.resolve(arrowResult([documentoRow(CNJ_B, 'DOC-B-UNICO')]));
+    documentosDeferreds.get(CNJ_B)!.resolve({ items: [documentoRow(CNJ_B, 'DOC-B-UNICO')], hasMore: false });
 
     await waitFor(() => expect(getByText('DOC-B-UNICO')).toBeTruthy());
 
     // A's documentos response finally arrives, late — it must be discarded,
     // not overwrite B's already-displayed documents.
-    documentosDeferreds.get(CNJ_A)!.resolve(arrowResult([documentoRow(CNJ_A, 'DOC-A-UNICO')]));
+    documentosDeferreds.get(CNJ_A)!.resolve({ items: [documentoRow(CNJ_A, 'DOC-A-UNICO')], hasMore: false });
     await new Promise((r) => setTimeout(r, 0));
 
     expect(getByText(CNJ_B, { exact: false })).toBeTruthy();
@@ -154,8 +163,7 @@ describe('ProcessoLookup — race between two searches', () => {
   });
 
   it('never surfaces a stale processo response from search A once search B has already started', async () => {
-    const { conn, processoDeferreds } = makeControllableConn();
-    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+    const { processoDeferreds } = makeControllable();
 
     const { getByLabelText, getByText, queryByText } = render(ProcessoLookup);
     const input = (await waitFor(() => getByLabelText(/Número do processo/i))) as HTMLInputElement;
@@ -173,7 +181,7 @@ describe('ProcessoLookup — race between two searches', () => {
 
     // A resolves late — must be discarded entirely (never reaches 'found',
     // never issues its own documentos query).
-    processoDeferreds.get(CNJ_A)!.resolve(arrowResult([processoRow(CNJ_A)]));
+    processoDeferreds.get(CNJ_A)!.resolve(processoResultado(CNJ_A));
     await new Promise((r) => setTimeout(r, 0));
 
     expect(queryByText(CNJ_A, { exact: false })).toBeNull();
@@ -181,9 +189,12 @@ describe('ProcessoLookup — race between two searches', () => {
 });
 
 describe('ProcessoLookup — source presence copy (no false completeness score)', () => {
-  async function searchAndResolve(cnj: string, processoOverrides: Record<string, unknown>, documentoRows: Record<string, unknown>[]) {
-    const { conn, processoDeferreds, documentosDeferreds } = makeControllableConn();
-    vi.mocked(getDuckDB).mockResolvedValue({ conn } as never);
+  async function searchAndResolve(
+    cnj: string,
+    processoOverrides: Record<string, unknown>,
+    documentoRows: Record<string, unknown>[],
+  ) {
+    const { processoDeferreds, documentosDeferreds } = makeControllable();
 
     const { getByLabelText, getByText, container } = render(ProcessoLookup);
     const input = (await waitFor(() => getByLabelText(/Número do processo/i))) as HTMLInputElement;
@@ -191,9 +202,9 @@ describe('ProcessoLookup — source presence copy (no false completeness score)'
     await fireEvent.input(input, { target: { value: cnj } });
     await fireEvent.click(getByText('Buscar'));
     await waitFor(() => expect(processoDeferreds.has(cnj)).toBe(true));
-    processoDeferreds.get(cnj)!.resolve(arrowResult([{ ...processoRow(cnj), ...processoOverrides }]));
+    processoDeferreds.get(cnj)!.resolve(processoResultado(cnj, processoOverrides));
     await waitFor(() => expect(documentosDeferreds.has(cnj)).toBe(true));
-    documentosDeferreds.get(cnj)!.resolve(arrowResult(documentoRows));
+    documentosDeferreds.get(cnj)!.resolve({ items: documentoRows, hasMore: false });
 
     return container;
   }
@@ -210,7 +221,19 @@ describe('ProcessoLookup — source presence copy (no false completeness score)'
     const cnj = '00000040520248220004';
     const container = await searchAndResolve(
       cnj,
-      { fontes: ['djen', 'juris'], n_fontes: 2, juris_n_documentos: 2 },
+      {
+        fontes: ['djen', 'juris'],
+        juris: {
+          present: true,
+          nDocumentos: 2,
+          tipos: ['ACÓRDÃO'],
+          dataJulgamento: '2024-01-01',
+          orgao: null,
+          relator: null,
+          classe: null,
+          url: null,
+        },
+      },
       [documentoRow(cnj, 'DOC-MULTI')],
     );
 
@@ -227,7 +250,11 @@ describe('ProcessoLookup — source presence copy (no false completeness score)'
 
   it('explains an empty documents section without contradicting the DJEN publications shown above', async () => {
     const cnj = '00000060720248220006';
-    const container = await searchAndResolve(cnj, { djen_n_publicacoes: 3 }, []);
+    const container = await searchAndResolve(
+      cnj,
+      { djen: { present: true, primeiraPub: null, ultimaPub: null, nPublicacoes: 3, tribunais: [] } },
+      [],
+    );
 
     await waitFor(() => expect(container.textContent).toContain('Nenhum documento de decisão encontrado no JURIS ou no STJ'));
     expect(container.textContent).not.toContain('sem documentos associados');
@@ -237,7 +264,20 @@ describe('ProcessoLookup — source presence copy (no false completeness score)'
     const cnj = '00000070820248220007';
     const container = await searchAndResolve(
       cnj,
-      { fontes: ['juris'], djen_n_publicacoes: null, juris_n_documentos: 0 },
+      {
+        fontes: ['juris'],
+        djen: { present: false, primeiraPub: null, ultimaPub: null, nPublicacoes: null, tribunais: [] },
+        juris: {
+          present: true,
+          nDocumentos: 0,
+          tipos: [],
+          dataJulgamento: null,
+          orgao: null,
+          relator: null,
+          classe: null,
+          url: null,
+        },
+      },
       [],
     );
 

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -511,6 +511,97 @@ describe('buscarProcesso', () => {
   });
 });
 
+/** Like fakeConn, but any query whose SQL contains `failSubstring` throws instead of resolving. */
+function fakeConnWithFailure(
+  failSubstring: string,
+  bySqlSubstring: Array<[string, Record<string, unknown>[]]>,
+) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  return {
+    calls,
+    prepare: async (sql: string) => ({
+      query: async (...params: unknown[]) => {
+        calls.push({ sql, params });
+        if (sql.includes(failSubstring)) {
+          throw new Error('IO Error: could not open causaganha-dashboard/indice_processual.parquet');
+        }
+        const match = bySqlSubstring.find(([needle]) => sql.includes(needle));
+        const rows = match ? match[1] : [];
+        return { toArray: () => rows.map((row) => ({ toJSON: () => row })) };
+      },
+      close: async () => {},
+    }),
+  };
+}
+
+describe('buscarProcesso — rollout fallback (indice_processual.parquet unreachable)', () => {
+  const INDICE_SUBSTRING = "FROM read_parquet('https://archive.org/download/causaganha-dashboard/indice_processual.parquet')";
+  const LEGADO_UNIFICADO_SUBSTRING =
+    "FROM read_parquet('https://archive.org/download/causaganha-dashboard/processos_unificados.parquet')";
+
+  it('falls back to processos_unificados.parquet and marks the result legado', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    try {
+      const conn = fakeConnWithFailure(INDICE_SUBSTRING, [
+        [
+          LEGADO_UNIFICADO_SUBSTRING,
+          [
+            {
+              nr_processo: CNJ_ALL,
+              nr_processo_mascara: '0000001-02.2024.8.22.0001',
+              n_fontes: 2,
+              fontes: ['djen', 'juris'],
+              djen_primeira_pub: '2024-03-01',
+              djen_ultima_pub: '2024-03-05',
+              djen_n_publicacoes: 2,
+              djen_tribunais: ['TJRO'],
+              juris_n_documentos: 1,
+              juris_tipos: ['ACÓRDÃO'],
+              juris_data_julgamento: '2024-02-28',
+              juris_orgao: '2a Camara',
+              juris_relator: 'Des. A',
+              juris_classe: 'Apelação',
+              juris_url: 'https://juris/1',
+              tem_datajud: false,
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+        ],
+      ]);
+      const result = await buscarProcesso(conn as any, CNJ_ALL);
+
+      expect(result.legado).toBe(true);
+      expect(result.encontrado).toBe(true);
+      expect(result.nrProcesso).toBe(CNJ_ALL);
+      expect(result.fontes).toEqual(['djen', 'juris']);
+      expect(result.djen).toMatchObject({ present: true, nPublicacoes: 2 });
+      expect(result.juris).toMatchObject({ present: true, orgao: '2a Camara' });
+      expect(result.jurisUrls).toEqual([]);
+      expect(result.stjUrls).toEqual([]);
+      expect(result.cobertura).toEqual([]);
+      expect(result.datasetGeradoEm).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.avisos.some((a) => a.includes('indice_processual.parquet'))).toBe(true);
+      expect(result.avisos.some((a) => a.includes('processos_unificados.parquet'))).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('falls back and reports not found when the legacy parquet has no row either', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    try {
+      const conn = fakeConnWithFailure(INDICE_SUBSTRING, []);
+      const result = await buscarProcesso(conn as any, CNJ_ALL);
+
+      expect(result.legado).toBe(true);
+      expect(result.encontrado).toBe(false);
+      expect(result.fontes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
 describe('carregarDocumentos', () => {
   it('skips the query entirely when neither juris nor stj has a URL', async () => {
     const conn = fakeConn([]);
@@ -533,6 +624,22 @@ describe('carregarDocumentos', () => {
       { fonte: 'juris', idDocumento: '1', tipo: 'ACÓRDÃO', data: '2024-01-15', url: 'https://juris/1', resumo: 'r1' },
     ]);
     expect(result.hasMore).toBe(false);
+    expect(conn.calls[0].params).toEqual([CNJ_ALL, 21, 0]);
+  });
+
+  it('queries processo_documentos.parquet directly when legado=true, ignoring jurisUrls/stjUrls', async () => {
+    const conn = fakeConn([
+      [
+        "FROM read_parquet('https://archive.org/download/causaganha-dashboard/processo_documentos.parquet')",
+        [
+          { fonte: 'juris', id_documento: '1', tipo: 'ACÓRDÃO', data: '2024-01-15', url: 'https://juris/1', resumo: 'r1' },
+        ],
+      ],
+    ]);
+    const result = await carregarDocumentos(conn as any, [], [], CNJ_ALL, 0, 20, true);
+    expect(result.items).toEqual([
+      { fonte: 'juris', idDocumento: '1', tipo: 'ACÓRDÃO', data: '2024-01-15', url: 'https://juris/1', resumo: 'r1' },
+    ]);
     expect(conn.calls[0].params).toEqual([CNJ_ALL, 21, 0]);
   });
 });

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -509,6 +509,41 @@ describe('buscarProcesso', () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it('isolates a single source failure — JURIS erroring must not discard DJEN/DataJud (RFC 0014 M2 review)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    try {
+      const conn = fakeConnWithFailure('FROM agg, principal', [
+        [
+          'FROM read_parquet(\'https://archive.org/download/causaganha-dashboard/indice_processual.parquet\')',
+          [
+            { fonte: 'djen', arquivo_ia_url: 'https://ia/djen-2024.parquet' },
+            { fonte: 'juris', arquivo_ia_url: 'https://ia/tjro-juris-2024.parquet' },
+            { fonte: 'datajud', arquivo_ia_url: 'https://ia/datajud-capa-tjro.parquet' },
+          ],
+        ],
+        [
+          'COUNT(*)::INTEGER AS n_publicacoes',
+          [{ n_publicacoes: 1, primeira_publicacao: '2024-01-01', ultima_publicacao: '2024-01-01', tribunais: ['TJRO'] }],
+        ],
+        [
+          'FROM read_parquet([\'https://ia/datajud-capa-tjro.parquet\'])',
+          [{ n: 1, classe_oficial: 'Apelacao', assuntos: 'X', orgao_julgador: 'Y', grau: 'G1', data_ajuizamento: '2024-01-01', ultima_atualizacao: '2024-02-01' }],
+        ],
+      ]);
+
+      // buscarProcesso must resolve (not reject) even though the JURIS query throws.
+      const result = await buscarProcesso(conn as any, CNJ_ALL);
+
+      expect(result.encontrado).toBe(true);
+      expect(result.djen.present).toBe(true); // unaffected by JURIS failing
+      expect(result.datajud.present).toBe(true); // unaffected by JURIS failing
+      expect(result.juris.present).toBe(false); // the failed source degrades to absent
+      expect(result.avisos.some((a) => a.includes('juris') && a.includes('indisponível'))).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 /** Like fakeConn, but any query whose SQL contains `failSubstring` throws instead of resolving. */

--- a/web/src/lib/processoCnj.test.ts
+++ b/web/src/lib/processoCnj.test.ts
@@ -1,17 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   ALL_FONTES,
   buildCnjSearchParams,
+  buildDatajudSql,
+  buildDjenSql,
+  buildDocumentosSql,
   buildHeroSearchRedirect,
-  buildProcessoDocumentosSql,
-  buildProcessoUnificadoSql,
+  buildIndiceSql,
+  buildJurisSql,
+  buildStjSql,
+  buscarProcesso,
+  carregarDocumentos,
   classifyCnjInput,
+  fetchCobertura,
   fontesPresenca,
+  fonteUrls,
   formatCnj,
   isDocumentosVazio,
   isValidCnj,
+  mapDatajudRow,
+  mapDjenRow,
   mapDocumentoRow,
-  mapProcessoRow,
+  mapJurisRow,
+  mapStjRow,
   normalizeCnj,
   paginate,
   readCnjParam,
@@ -139,20 +150,50 @@ describe('readCnjParam / buildCnjSearchParams', () => {
 });
 
 describe('SQL builders never use SELECT * and filter by parameter', () => {
-  it('processos_unificados query lists explicit columns and filters nr_processo via placeholder', () => {
-    const sql = buildProcessoUnificadoSql();
+  it('indice query filters numero_processo via placeholder and reads indice_processual.parquet', () => {
+    const sql = buildIndiceSql();
     expect(sql).not.toMatch(/select\s+\*/i);
-    expect(sql).toContain('WHERE nr_processo = ?');
-    expect(sql).toContain('nr_processo_mascara');
-    expect(sql).toContain("read_parquet('https://archive.org/download/causaganha-dashboard/processos_unificados.parquet')");
+    expect(sql).toContain('WHERE numero_processo = ?');
+    expect(sql).toContain(
+      "read_parquet('https://archive.org/download/causaganha-dashboard/indice_processual.parquet')",
+    );
   });
 
-  it('processo_documentos query lists explicit columns, filters by parameter and paginates', () => {
-    const sql = buildProcessoDocumentosSql();
+  it('djen query unions the discovered URLs and filters by placeholder', () => {
+    const sql = buildDjenSql(['https://a/comunicacoes.parquet', "https://b/comunicacoes.parquet"]);
     expect(sql).not.toMatch(/select\s+\*/i);
-    expect(sql).toContain('WHERE nr_processo = ?');
+    expect(sql).toContain("read_parquet(['https://a/comunicacoes.parquet', 'https://b/comunicacoes.parquet']");
+    expect(sql).toContain('= ?');
+  });
+
+  it('juris query cross-joins agg and principal over the discovered URLs', () => {
+    const sql = buildJurisSql(['https://a/tjro-juris-2024.parquet']);
+    expect(sql).toContain('FROM agg, principal');
+    expect(sql).toContain("read_parquet(['https://a/tjro-juris-2024.parquet']");
+  });
+
+  it('stj query filters by placeholder over the discovered URLs', () => {
+    const sql = buildStjSql(['https://a/stj-acordaos.parquet']);
+    expect(sql).toContain('regexp_replace("numeroProcesso"');
+  });
+
+  it('datajud query filters by placeholder over the discovered URLs', () => {
+    const sql = buildDatajudSql(['https://a/datajud-capa-tjro.parquet']);
+    expect(sql).toContain('WHERE numero_processo = ?');
+  });
+
+  it('documentos query unions only the branches with URLs present, and paginates', () => {
+    const { sql, nParams } = buildDocumentosSql(['https://a/juris.parquet'], []);
+    expect(sql).not.toMatch(/union all.*union all/is);
     expect(sql).toContain('LIMIT ? OFFSET ?');
-    expect(sql).toContain('ORDER BY data DESC NULLS LAST');
+    expect(nParams).toBe(1);
+
+    const both = buildDocumentosSql(['https://a/juris.parquet'], ['https://a/stj.parquet']);
+    expect(both.sql).toMatch(/union all/i);
+    expect(both.nParams).toBe(2);
+
+    const none = buildDocumentosSql([], []);
+    expect(none.nParams).toBe(0);
   });
 });
 
@@ -194,126 +235,89 @@ describe('toIsoDate', () => {
   });
 });
 
-const CNJ_ALL = '00000010220248220001';
+describe('mapDjenRow', () => {
+  it('marks present with n_publicacoes > 0', () => {
+    const view = mapDjenRow({
+      n_publicacoes: 2,
+      primeira_publicacao: '2024-03-01',
+      ultima_publicacao: '2024-03-05',
+      tribunais: ['TJRO'],
+    });
+    expect(view).toMatchObject({ present: true, nPublicacoes: 2, primeiraPub: '2024-03-01', ultimaPub: '2024-03-05' });
+    expect(view.tribunais).toEqual(['TJRO']);
+  });
 
-function baseRawProcesso(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    nr_processo: CNJ_ALL,
-    nr_processo_mascara: '0000001-02.2024.8.22.0001',
-    n_fontes: 4,
-    fontes: ['djen', 'juris', 'stj', 'datajud'],
-    djen_primeira_pub: '2024-03-01',
-    djen_ultima_pub: '2024-03-05',
-    djen_n_publicacoes: 2,
-    djen_tribunais: ['TJRO'],
-    juris_n_documentos: 2,
-    juris_tipos: ['ACÓRDÃO', 'SENTENÇA'],
-    juris_data_julgamento: '2024-02-28',
-    juris_orgao: '2a Camara',
-    juris_relator: 'Des. A',
-    juris_classe: 'Apelação',
-    juris_url: 'https://juris/1',
-    stj_id: 'stj-1',
-    stj_classe: 'REsp',
-    stj_relator: 'MIN X',
-    stj_tema: 'tema',
-    stj_tese: 'tese',
-    stj_ementa: 'ementa',
-    stj_data_decisao: '2024-05-01',
-    stj_data_publicacao: '2024-05-10',
-    classe_oficial: 'Apelacao Civel',
-    assuntos: 'Contratos',
-    orgao_julgador: '2a Camara',
-    grau: 'G2',
-    data_ajuizamento: '2024-01-10',
-    ultima_atualizacao: '2024-06-01',
-    tem_datajud: true,
-    updated_at: '2026-07-12T18:00:00Z',
-    ...overrides,
-  };
-}
-
-describe('mapProcessoRow — multi-fonte row', () => {
-  it('marks every source present and surfaces every field with the right provenance', () => {
-    const row = mapProcessoRow(baseRawProcesso());
-    expect(row.nrProcesso).toBe(CNJ_ALL);
-    expect(row.nrProcessoMascara).toBe('0000001-02.2024.8.22.0001');
-    expect(row.nFontes).toBe(4);
-    expect(row.fontes).toEqual(['djen', 'juris', 'stj', 'datajud']);
-
-    expect(row.djen).toMatchObject({ present: true, nPublicacoes: 2, primeiraPub: '2024-03-01', ultimaPub: '2024-03-05' });
-    expect(row.djen.tribunais).toEqual(['TJRO']);
-
-    expect(row.juris).toMatchObject({ present: true, nDocumentos: 2, orgao: '2a Camara', relator: 'Des. A' });
-    expect(row.juris.tipos).toEqual(['ACÓRDÃO', 'SENTENÇA']);
-
-    expect(row.stj).toMatchObject({ present: true, id: 'stj-1', classe: 'REsp' });
-
-    expect(row.datajud).toMatchObject({ present: true, classeOficial: 'Apelacao Civel', assuntos: 'Contratos' });
+  it('marks absent for a null row or n_publicacoes=0, without fabricating zeros', () => {
+    expect(mapDjenRow(null)).toMatchObject({ present: false, nPublicacoes: null });
+    expect(mapDjenRow({ n_publicacoes: 0, tribunais: [] })).toMatchObject({ present: false });
   });
 });
 
-describe('mapProcessoRow — DataJud absent (tem_datajud=false)', () => {
-  it('marks datajud not present and nulls its fields even if fontes lists it (defensive)', () => {
-    const row = mapProcessoRow(
-      baseRawProcesso({
-        fontes: ['djen', 'juris', 'stj'],
-        tem_datajud: false,
-        classe_oficial: null,
-        assuntos: null,
-        orgao_julgador: null,
-        grau: null,
-        data_ajuizamento: null,
-        ultima_atualizacao: null,
-      }),
-    );
-    expect(row.datajud.present).toBe(false);
-    expect(row.datajud.classeOficial).toBeNull();
+describe('mapJurisRow', () => {
+  it('marks present when a row comes back', () => {
+    const view = mapJurisRow({
+      n_documentos: 2,
+      tipos: ['ACÓRDÃO', 'SENTENÇA'],
+      data_julgamento: '2024-02-28',
+      orgao: '2a Camara',
+      relator: 'Des. A',
+      classe: 'Apelação',
+      url: 'https://juris/1',
+    });
+    expect(view).toMatchObject({ present: true, nDocumentos: 2, orgao: '2a Camara', relator: 'Des. A' });
+    expect(view.tipos).toEqual(['ACÓRDÃO', 'SENTENÇA']);
+  });
+
+  it('marks absent for a null row (no cross-join match)', () => {
+    expect(mapJurisRow(null)).toMatchObject({ present: false, nDocumentos: null });
   });
 });
 
-describe('mapProcessoRow — single-source (DJEN only)', () => {
-  it('marks juris/stj/datajud absent and leaves their fields null, without fabricating zeros', () => {
-    const row = mapProcessoRow(
-      baseRawProcesso({
-        fontes: ['djen'],
-        n_fontes: 1,
-        juris_n_documentos: null,
-        juris_tipos: null,
-        juris_data_julgamento: null,
-        juris_orgao: null,
-        juris_relator: null,
-        juris_classe: null,
-        juris_url: null,
-        stj_id: null,
-        stj_classe: null,
-        stj_relator: null,
-        stj_tema: null,
-        stj_tese: null,
-        stj_ementa: null,
-        stj_data_decisao: null,
-        stj_data_publicacao: null,
-        tem_datajud: false,
-        classe_oficial: null,
-        assuntos: null,
-        orgao_julgador: null,
-        grau: null,
-        data_ajuizamento: null,
-        ultima_atualizacao: null,
-      }),
-    );
-    expect(row.djen.present).toBe(true);
-    expect(row.juris.present).toBe(false);
-    expect(row.juris.nDocumentos).toBeNull();
-    expect(row.stj.present).toBe(false);
-    expect(row.datajud.present).toBe(false);
+describe('mapStjRow', () => {
+  it('marks present with n > 0', () => {
+    const view = mapStjRow({
+      n: 1,
+      id: 'stj-1',
+      classe: 'REsp',
+      relator: 'MIN X',
+      tema: 'tema',
+      tese: 'tese',
+      ementa: 'ementa',
+      data_decisao: '2024-05-01',
+      data_publicacao: '2024-05-10',
+    });
+    expect(view).toMatchObject({ present: true, id: 'stj-1', classe: 'REsp' });
+  });
+
+  it('marks absent for a null row or n=0', () => {
+    expect(mapStjRow(null)).toMatchObject({ present: false, id: null });
+    expect(mapStjRow({ n: 0 })).toMatchObject({ present: false });
+  });
+});
+
+describe('mapDatajudRow', () => {
+  it('marks present with n > 0', () => {
+    const view = mapDatajudRow({
+      n: 1,
+      classe_oficial: 'Apelacao Civel',
+      assuntos: 'Contratos',
+      orgao_julgador: '2a Camara',
+      grau: 'G2',
+      data_ajuizamento: '2024-01-10',
+      ultima_atualizacao: '2024-06-01',
+    });
+    expect(view).toMatchObject({ present: true, classeOficial: 'Apelacao Civel', assuntos: 'Contratos' });
+  });
+
+  it('marks absent for a null row or n=0', () => {
+    expect(mapDatajudRow(null)).toMatchObject({ present: false, classeOficial: null });
+    expect(mapDatajudRow({ n: 0 })).toMatchObject({ present: false });
   });
 });
 
 describe('mapDocumentoRow', () => {
   it('maps a JURIS document row', () => {
     const doc = mapDocumentoRow({
-      nr_processo: CNJ_ALL,
       fonte: 'juris',
       id_documento: '1',
       tipo: 'ACÓRDÃO',
@@ -333,7 +337,6 @@ describe('mapDocumentoRow', () => {
 
   it('maps an STJ document row with an empty url as null', () => {
     const doc = mapDocumentoRow({
-      nr_processo: CNJ_ALL,
       fonte: 'stj',
       id_documento: 'stj-1',
       tipo: 'REsp',
@@ -367,6 +370,19 @@ describe('fontesPresenca', () => {
   });
 });
 
+describe('fonteUrls', () => {
+  it('dedupes and sorts URLs for the requested fonte', () => {
+    const rows = [
+      { fonte: 'djen', url: 'https://b' },
+      { fonte: 'djen', url: 'https://a' },
+      { fonte: 'djen', url: 'https://a' },
+      { fonte: 'juris', url: 'https://c' },
+    ];
+    expect(fonteUrls(rows, 'djen')).toEqual(['https://a', 'https://b']);
+    expect(fonteUrls(rows, 'stj')).toEqual([]);
+  });
+});
+
 describe('isDocumentosVazio', () => {
   it('is true only on the first page with zero items (processo found, no documents)', () => {
     expect(isDocumentosVazio([], 0)).toBe(true);
@@ -378,5 +394,145 @@ describe('isDocumentosVazio', () => {
 
   it('is false on a later page even if that page is empty (already proven non-empty overall)', () => {
     expect(isDocumentosVazio([], 20)).toBe(false);
+  });
+});
+
+describe('fetchCobertura', () => {
+  it('returns cobertura + datasetGeradoEm on a healthy report', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        generated_at: '2026-07-12T18:00:00Z',
+        sources: { djen: { status: 'loaded_remote', rows: 10 }, stj: { status: 'unavailable', rows: 0 } },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const result = await fetchCobertura('https://example/report.json');
+      expect(result?.datasetGeradoEm).toBe('2026-07-12T18:00:00Z');
+      expect(result?.cobertura).toEqual([
+        { fonte: 'djen', status: 'loaded_remote', registros: 10 },
+        { fonte: 'stj', status: 'unavailable', registros: 0 },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('returns null on a non-ok response, without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    try {
+      expect(await fetchCobertura('https://example/report.json')).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('returns null when fetch itself rejects, without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    try {
+      expect(await fetchCobertura('https://example/report.json')).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+const CNJ_ALL = '00000010220248220001';
+
+/** Fake DuckDB-WASM connection: routes each prepare()d SQL to a canned row set by matching a SQL substring. */
+function fakeConn(bySqlSubstring: Array<[string, Record<string, unknown>[]]>) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  return {
+    calls,
+    prepare: async (sql: string) => ({
+      query: async (...params: unknown[]) => {
+        calls.push({ sql, params });
+        const match = bySqlSubstring.find(([needle]) => sql.includes(needle));
+        const rows = match ? match[1] : [];
+        return { toArray: () => rows.map((row) => ({ toJSON: () => row })) };
+      },
+      close: async () => {},
+    }),
+  };
+}
+
+describe('buscarProcesso', () => {
+  it('returns encontrado=false when the index has no rows for the CNJ, still surfacing cobertura', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ generated_at: 'X', sources: {} }) }),
+    );
+    try {
+      const conn = fakeConn([]);
+      const result = await buscarProcesso(conn as any, CNJ_ALL);
+      expect(result.encontrado).toBe(false);
+      expect(result.nrProcessoMascara).toBe('0000001-02.2024.8.22.0001');
+      expect(result.datasetGeradoEm).toBe('X');
+      expect(result.avisos).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('assembles the dossie from per-fonte queries when the index has rows, and warns when the report is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    try {
+      const conn = fakeConn([
+        [
+          'FROM read_parquet(\'https://archive.org/download/causaganha-dashboard/indice_processual.parquet\')',
+          [
+            { fonte: 'djen', arquivo_ia_url: 'https://ia/djen-2024.parquet' },
+            { fonte: 'datajud', arquivo_ia_url: 'https://ia/datajud-capa-tjro.parquet' },
+          ],
+        ],
+        ['COUNT(*)::INTEGER AS n_publicacoes', [{ n_publicacoes: 1, primeira_publicacao: '2024-01-01', ultima_publicacao: '2024-01-01', tribunais: ['TJRO'] }]],
+        ['FROM agg, principal', []],
+        [
+          'FROM read_parquet([\'https://ia/datajud-capa-tjro.parquet\'])',
+          [{ n: 1, classe_oficial: 'Apelacao', assuntos: 'X', orgao_julgador: 'Y', grau: 'G1', data_ajuizamento: '2024-01-01', ultima_atualizacao: '2024-02-01' }],
+        ],
+      ]);
+      const result = await buscarProcesso(conn as any, CNJ_ALL);
+      expect(result.encontrado).toBe(true);
+      expect(result.fontes).toEqual(['datajud', 'djen']);
+      expect(result.djen.present).toBe(true);
+      expect(result.juris.present).toBe(false);
+      expect(result.stj.present).toBe(false);
+      expect(result.datajud).toMatchObject({ present: true, classeOficial: 'Apelacao' });
+      expect(result.jurisUrls).toEqual([]);
+      expect(result.avisos).toEqual([
+        'Relatório de cobertura (indice_processual.report.json) indisponível; sem detalhamento de ' +
+          'quais fontes estavam carregadas na geração do dataset.',
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe('carregarDocumentos', () => {
+  it('skips the query entirely when neither juris nor stj has a URL', async () => {
+    const conn = fakeConn([]);
+    const result = await carregarDocumentos(conn as any, [], [], CNJ_ALL, 0, 20);
+    expect(result).toEqual({ items: [], hasMore: false });
+    expect(conn.calls).toHaveLength(0);
+  });
+
+  it('queries and paginates over the discovered URLs', async () => {
+    const conn = fakeConn([
+      [
+        "'juris' AS fonte",
+        [
+          { fonte: 'juris', id_documento: '1', tipo: 'ACÓRDÃO', data: '2024-01-15', url: 'https://juris/1', resumo: 'r1' },
+        ],
+      ],
+    ]);
+    const result = await carregarDocumentos(conn as any, ['https://ia/juris.parquet'], [], CNJ_ALL, 0, 20);
+    expect(result.items).toEqual([
+      { fonte: 'juris', idDocumento: '1', tipo: 'ACÓRDÃO', data: '2024-01-15', url: 'https://juris/1', resumo: 'r1' },
+    ]);
+    expect(result.hasMore).toBe(false);
+    expect(conn.calls[0].params).toEqual([CNJ_ALL, 21, 0]);
   });
 });

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -669,13 +669,30 @@ async function queryRows(
   }
 }
 
-async function queryRow(
+/**
+ * Como queryRows, mas isolada por fonte: uma falha (404, CORS, parquet
+ * corrompido, erro transitório) vira aviso identificando `fonte` e resolve
+ * para null em vez de propagar — a mesma fronteira que
+ * causaganha.processos.service.py's `_build_djen`/`_build_juris`/etc. já
+ * aplicam no lado Python (RFC 0014 M2 review: sem isso, uma única fonte
+ * fora do ar derrubava o dossiê inteiro para 'source_unavailable' no
+ * componente, descartando as demais fontes que carregaram normalmente).
+ */
+async function queryRowSafe(
   conn: DuckDBConnectionLike,
+  fonte: Fonte,
   sql: string,
   params: unknown[],
+  avisos: string[],
 ): Promise<Record<string, unknown> | null> {
-  const rows = await queryRows(conn, sql, params);
-  return rows[0] ?? null;
+  try {
+    const rows = await queryRows(conn, sql, params);
+    return rows[0] ?? null;
+  } catch (err) {
+    const detalhe = err instanceof Error ? err.message : String(err);
+    avisos.push(`Fonte '${fonte}' indisponível para este processo: ${detalhe}`);
+    return null;
+  }
 }
 
 export interface ProcessoResultado {
@@ -757,10 +774,14 @@ export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string)
   const stjUrls = fonteUrls(rowPairs, 'stj');
   const datajudUrls = fonteUrls(rowPairs, 'datajud');
 
-  const djenRaw = djenUrls.length ? await queryRow(conn, buildDjenSql(djenUrls), [digits]) : null;
-  const jurisRaw = jurisUrls.length ? await queryRow(conn, buildJurisSql(jurisUrls), [digits]) : null;
-  const stjRaw = stjUrls.length ? await queryRow(conn, buildStjSql(stjUrls), [digits]) : null;
-  const datajudRaw = datajudUrls.length ? await queryRow(conn, buildDatajudSql(datajudUrls), [digits]) : null;
+  const djenRaw = djenUrls.length ? await queryRowSafe(conn, 'djen', buildDjenSql(djenUrls), [digits], avisos) : null;
+  const jurisRaw = jurisUrls.length
+    ? await queryRowSafe(conn, 'juris', buildJurisSql(jurisUrls), [digits], avisos)
+    : null;
+  const stjRaw = stjUrls.length ? await queryRowSafe(conn, 'stj', buildStjSql(stjUrls), [digits], avisos) : null;
+  const datajudRaw = datajudUrls.length
+    ? await queryRowSafe(conn, 'datajud', buildDatajudSql(datajudUrls), [digits], avisos)
+    : null;
 
   return {
     encontrado: true,

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -1,18 +1,24 @@
 /**
- * Helpers puros para a página /processo — dossiê unificado de um número CNJ,
- * consultado inteiramente client-side via DuckDB-WASM contra os parquets
- * `processos_unificados.parquet` e `processo_documentos.parquet` do item IA
- * `causaganha-dashboard` (produzidos por scripts/reconcile_processos.py).
+ * Helpers para a página /processo — dossiê unificado de um número CNJ,
+ * consultado inteiramente client-side via DuckDB-WASM.
  *
- * Mantidos fora do componente Svelte para serem testáveis sem montar UI —
- * normalização de CNJ, parsing/serialização da URL compartilhável, geração
- * de SQL parametrizado e conversão de linhas cruas (Arrow → objeto simples)
- * em modelos de visualização tipados.
+ * Mesmo desenho de `causaganha/processos/service.py`: `indice_processual.parquet`
+ * (item IA `causaganha-dashboard`, produzido por scripts/reconcile_processos.py)
+ * só diz quais fontes (DJEN/JURIS/STJ/DataJud) têm registro para um CNJ e em
+ * qual parquet cada registro vive — o dossiê em si é montado consultando os
+ * parquets de origem diretamente. O índice nunca guarda cópia dos campos de
+ * conteúdo.
+ *
+ * Funções puras (normalização de CNJ, parsing/serialização da URL
+ * compartilhável, geração de SQL parametrizado, conversão de linhas cruas) e
+ * a orquestração assíncrona (`buscarProcesso`/`carregarDocumentos`, que
+ * recebem a conexão DuckDB-WASM já aberta) ficam aqui, fora do componente
+ * Svelte, para serem testáveis sem montar UI.
  */
 
 export const IA_DASHBOARD_BASE = 'https://archive.org/download/causaganha-dashboard';
-export const PROCESSOS_UNIFICADOS_URL = `${IA_DASHBOARD_BASE}/processos_unificados.parquet`;
-export const PROCESSO_DOCUMENTOS_URL = `${IA_DASHBOARD_BASE}/processo_documentos.parquet`;
+export const INDICE_PROCESSUAL_URL = `${IA_DASHBOARD_BASE}/indice_processual.parquet`;
+export const REPORT_URL = `${IA_DASHBOARD_BASE}/indice_processual.report.json`;
 
 export const DOCUMENTOS_PAGE_SIZE = 20;
 
@@ -26,6 +32,10 @@ export const FONTE_LABELS: Record<Fonte, string> = {
   datajud: 'DataJud',
 };
 
+const RELATORIO_INDISPONIVEL_AVISO =
+  'Relatório de cobertura (indice_processual.report.json) indisponível; sem detalhamento de ' +
+  'quais fontes estavam carregadas na geração do dataset.';
+
 // ── Normalização de CNJ ─────────────────────────────────────────────────────
 
 /** Remove tudo que não for dígito. Não valida o comprimento — use isValidCnj. */
@@ -33,7 +43,7 @@ export function stripCnjMask(input: string): string {
   return (input ?? '').replace(/\D/g, '');
 }
 
-/** 20 dígitos exatos — mesma regra de scripts/reconcile_processos.py:normalizar_cnj. */
+/** 20 dígitos exatos — mesma regra de causaganha/processos/cnj.py:normalizar_cnj. */
 export function isValidCnj(digits: string): boolean {
   return /^\d{20}$/.test(digits);
 }
@@ -44,7 +54,7 @@ export function normalizeCnj(input: string): string {
   return isValidCnj(digits) ? digits : '';
 }
 
-/** 20 dígitos → NNNNNNN-DD.AAAA.J.TR.OOOO — mesma máscara de scripts/reconcile_processos.py:formatar_cnj. */
+/** 20 dígitos → NNNNNNN-DD.AAAA.J.TR.OOOO — mesma máscara de causaganha/processos/cnj.py:formatar_cnj. */
 export function formatCnj(digits: string): string {
   if (!isValidCnj(digits)) return digits;
   return `${digits.slice(0, 7)}-${digits.slice(7, 9)}.${digits.slice(9, 13)}.${digits.slice(13, 14)}.${digits.slice(14, 16)}.${digits.slice(16, 20)}`;
@@ -99,39 +109,127 @@ export function buildCnjSearchParams(search: string, digits: string): string {
 }
 
 // ── SQL parametrizado ───────────────────────────────────────────────────────
-// Somente as colunas exibidas (nunca SELECT *); nr_processo filtrado via
-// prepared statement, nunca por interpolação de string.
+// Somente as colunas exibidas (nunca SELECT *); nr_processo/numero_processo
+// filtrado via prepared statement, nunca por interpolação de string. As URLs
+// interpoladas em read_parquet([...]) vêm sempre de INDICE_PROCESSUAL_URL (um
+// módulo constante) ou de arquivo_ia_url descoberto no próprio índice — nunca
+// de entrada do usuário.
 
-export function buildProcessoUnificadoSql(): string {
+function urlListSql(urls: string[]): string {
+  return urls.map((u) => `'${u}'`).join(', ');
+}
+
+/** Descobre, para um CNJ, quais fontes têm registro e em qual parquet cada uma vive. */
+export function buildIndiceSql(): string {
+  return `
+    SELECT fonte, arquivo_ia_url
+    FROM read_parquet('${INDICE_PROCESSUAL_URL}')
+    WHERE numero_processo = ?
+  `;
+}
+
+export function buildDjenSql(urls: string[]): string {
   return `
     SELECT
-      nr_processo, nr_processo_mascara, n_fontes, fontes,
-      djen_primeira_pub, djen_ultima_pub, djen_n_publicacoes, djen_tribunais,
-      juris_n_documentos, juris_tipos, juris_data_julgamento,
-      juris_orgao, juris_relator, juris_classe, juris_url,
-      stj_id, stj_classe, stj_relator, stj_tema, stj_tese, stj_ementa,
-      stj_data_decisao, stj_data_publicacao,
-      classe_oficial, assuntos, orgao_julgador, grau,
-      data_ajuizamento, ultima_atualizacao, tem_datajud,
-      updated_at
-    FROM read_parquet('${PROCESSOS_UNIFICADOS_URL}')
-    WHERE nr_processo = ?
-    LIMIT 1
+      COUNT(*)::INTEGER AS n_publicacoes,
+      MIN(data_disponibilizacao)::VARCHAR AS primeira_publicacao,
+      MAX(data_disponibilizacao)::VARCHAR AS ultima_publicacao,
+      list(DISTINCT tribunal) AS tribunais
+    FROM read_parquet([${urlListSql(urls)}], union_by_name=true)
+    WHERE regexp_replace(numero_processo, '[^0-9]', '', 'g') = ?
+  `;
+}
+
+export function buildJurisSql(urls: string[]): string {
+  return `
+    WITH cleaned AS (
+      SELECT id_documento, tipo, data_julgamento, orgao, relator, classe_judicial, url_portal
+      FROM read_parquet([${urlListSql(urls)}])
+      WHERE regexp_replace(nr_processo, '[^0-9]', '', 'g') = ?
+    ),
+    ranked AS (
+      SELECT *, ROW_NUMBER() OVER (
+        ORDER BY
+          CASE tipo WHEN 'ACÓRDÃO' THEN 1 WHEN 'SENTENÇA' THEN 2 ELSE 9 END,
+          data_julgamento DESC NULLS LAST
+      ) AS rn
+      FROM cleaned
+    ),
+    principal AS (SELECT * FROM ranked WHERE rn = 1),
+    agg AS (
+      SELECT
+        COUNT(*)::INTEGER AS n_documentos,
+        list(DISTINCT tipo) AS tipos,
+        MAX(data_julgamento)::VARCHAR AS data_julgamento
+      FROM cleaned
+    )
+    SELECT
+      agg.n_documentos, agg.tipos, agg.data_julgamento,
+      principal.orgao, principal.relator,
+      principal.classe_judicial AS classe, principal.url_portal AS url
+    FROM agg, principal
+  `;
+}
+
+export function buildStjSql(urls: string[]): string {
+  return `
+    SELECT
+      COUNT(*)::INTEGER AS n,
+      FIRST(id ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS id,
+      FIRST("siglaClasse" ORDER BY "dataDecisao" DESC NULLS LAST) AS classe,
+      FIRST("ministroRelator" ORDER BY "dataDecisao" DESC NULLS LAST) AS relator,
+      FIRST("tema" ORDER BY "dataDecisao" DESC NULLS LAST)::VARCHAR AS tema,
+      FIRST("teseJuridica" ORDER BY "dataDecisao" DESC NULLS LAST) AS tese,
+      FIRST("ementa" ORDER BY "dataDecisao" DESC NULLS LAST) AS ementa,
+      MAX("dataDecisao")::VARCHAR AS data_decisao,
+      MAX("dataPublicacao")::VARCHAR AS data_publicacao
+    FROM read_parquet([${urlListSql(urls)}])
+    WHERE regexp_replace("numeroProcesso", '[^0-9]', '', 'g') = ?
+  `;
+}
+
+export function buildDatajudSql(urls: string[]): string {
+  return `
+    SELECT
+      COUNT(*)::INTEGER AS n,
+      FIRST(classe_nome ORDER BY ultima_atualizacao DESC NULLS LAST) AS classe_oficial,
+      FIRST(assuntos ORDER BY ultima_atualizacao DESC NULLS LAST) AS assuntos,
+      FIRST(orgao_julgador ORDER BY ultima_atualizacao DESC NULLS LAST) AS orgao_julgador,
+      FIRST(grau ORDER BY ultima_atualizacao DESC NULLS LAST) AS grau,
+      MIN(data_ajuizamento)::VARCHAR AS data_ajuizamento,
+      MAX(ultima_atualizacao)::VARCHAR AS ultima_atualizacao
+    FROM read_parquet([${urlListSql(urls)}])
+    WHERE numero_processo = ?
   `;
 }
 
 /**
  * Busca `pageSize + 1` linhas a partir de `offset` — o "+1" permite detectar
- * "há mais" sem uma segunda consulta de contagem (ver paginate()).
+ * "há mais" sem uma segunda consulta de contagem (ver paginate()). Um branch
+ * UNION ALL por fonte presente; `nParams` é quantos `?` de CNJ vêm antes do
+ * `LIMIT ? OFFSET ?` final — um por branch.
  */
-export function buildProcessoDocumentosSql(): string {
-  return `
-    SELECT nr_processo, fonte, id_documento, tipo, data, url, resumo
-    FROM read_parquet('${PROCESSO_DOCUMENTOS_URL}')
-    WHERE nr_processo = ?
-    ORDER BY data DESC NULLS LAST, id_documento
-    LIMIT ? OFFSET ?
-  `;
+export function buildDocumentosSql(jurisUrls: string[], stjUrls: string[]): { sql: string; nParams: number } {
+  const parts: string[] = [];
+  if (jurisUrls.length > 0) {
+    parts.push(`
+      SELECT 'juris' AS fonte, id_documento::VARCHAR AS id_documento, tipo,
+        data_julgamento::VARCHAR AS data, url_portal AS url,
+        left(texto_limpo, 500) AS resumo
+      FROM read_parquet([${urlListSql(jurisUrls)}])
+      WHERE regexp_replace(nr_processo, '[^0-9]', '', 'g') = ?
+    `);
+  }
+  if (stjUrls.length > 0) {
+    parts.push(`
+      SELECT 'stj' AS fonte, id::VARCHAR AS id_documento, "siglaClasse" AS tipo,
+        "dataDecisao"::VARCHAR AS data, '' AS url, left("ementa", 500) AS resumo
+      FROM read_parquet([${urlListSql(stjUrls)}])
+      WHERE regexp_replace("numeroProcesso", '[^0-9]', '', 'g') = ?
+    `);
+  }
+  const union = parts.join(' UNION ALL ');
+  return { sql: `${union} ORDER BY data DESC NULLS LAST, id_documento LIMIT ? OFFSET ?`, nParams: parts.length };
 }
 
 export interface PageResult<T> {
@@ -139,7 +237,7 @@ export interface PageResult<T> {
   hasMore: boolean;
 }
 
-/** rows deve ter sido buscado com LIMIT pageSize+1 (ver buildProcessoDocumentosSql). */
+/** rows deve ter sido buscado com LIMIT pageSize+1 (ver buildDocumentosSql). */
 export function paginate<T>(rows: T[], pageSize: number): PageResult<T> {
   const hasMore = rows.length > pageSize;
   return { items: hasMore ? rows.slice(0, pageSize) : rows, hasMore };
@@ -194,118 +292,147 @@ export function toIsoDate(value: unknown): string | null {
   return null;
 }
 
-/** TIMESTAMP arbitrário → rótulo pt-BR/UTC via formatUtcDateTime, ou null. */
-export function toIsoTimestampString(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'bigint') {
-    const parsed = new Date(typeof value === 'bigint' ? Number(value) : value);
-    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-  }
-  return null;
+// ── Modelos de visualização por fonte ──────────────────────────────────────
+
+export interface DjenResumoView {
+  present: boolean;
+  primeiraPub: string | null;
+  ultimaPub: string | null;
+  nPublicacoes: number | null;
+  tribunais: string[];
 }
 
-// ── Modelos de visualização ────────────────────────────────────────────────
-
-export interface ProcessoUnificadoRow {
-  nrProcesso: string;
-  nrProcessoMascara: string;
-  nFontes: number;
-  fontes: Fonte[];
-  djen: {
-    present: boolean;
-    primeiraPub: string | null;
-    ultimaPub: string | null;
-    nPublicacoes: number | null;
-    tribunais: string[];
-  };
-  juris: {
-    present: boolean;
-    nDocumentos: number | null;
-    tipos: string[];
-    dataJulgamento: string | null;
-    orgao: string | null;
-    relator: string | null;
-    classe: string | null;
-    url: string | null;
-  };
-  stj: {
-    present: boolean;
-    id: string | null;
-    classe: string | null;
-    relator: string | null;
-    tema: string | null;
-    tese: string | null;
-    ementa: string | null;
-    dataDecisao: string | null;
-    dataPublicacao: string | null;
-  };
-  datajud: {
-    present: boolean;
-    classeOficial: string | null;
-    assuntos: string | null;
-    orgaoJulgador: string | null;
-    grau: string | null;
-    dataAjuizamento: string | null;
-    ultimaAtualizacao: string | null;
-  };
-  /** ISO cru (para testes/derivações); use datasetGeneratedAtLabel() para exibir. */
-  updatedAtRaw: string | null;
+export interface JurisDecisaoView {
+  present: boolean;
+  nDocumentos: number | null;
+  tipos: string[];
+  dataJulgamento: string | null;
+  orgao: string | null;
+  relator: string | null;
+  classe: string | null;
+  url: string | null;
 }
 
-/** Converte uma linha crua (raw.<coluna> de processos_unificados) no modelo de visualização. */
-export function mapProcessoRow(raw: Record<string, unknown>): ProcessoUnificadoRow {
-  const fontes = toStringArray(raw.fontes) as Fonte[];
-  const has = (f: Fonte) => fontes.includes(f);
-  const nrProcesso = String(raw.nr_processo ?? '');
+export interface StjAcordaoView {
+  present: boolean;
+  id: string | null;
+  classe: string | null;
+  relator: string | null;
+  tema: string | null;
+  tese: string | null;
+  ementa: string | null;
+  dataDecisao: string | null;
+  dataPublicacao: string | null;
+}
 
+export interface DatajudCapaView {
+  present: boolean;
+  classeOficial: string | null;
+  assuntos: string | null;
+  orgaoJulgador: string | null;
+  grau: string | null;
+  dataAjuizamento: string | null;
+  ultimaAtualizacao: string | null;
+}
+
+const AUSENTE_DJEN: DjenResumoView = {
+  present: false,
+  primeiraPub: null,
+  ultimaPub: null,
+  nPublicacoes: null,
+  tribunais: [],
+};
+
+const AUSENTE_JURIS: JurisDecisaoView = {
+  present: false,
+  nDocumentos: null,
+  tipos: [],
+  dataJulgamento: null,
+  orgao: null,
+  relator: null,
+  classe: null,
+  url: null,
+};
+
+const AUSENTE_STJ: StjAcordaoView = {
+  present: false,
+  id: null,
+  classe: null,
+  relator: null,
+  tema: null,
+  tese: null,
+  ementa: null,
+  dataDecisao: null,
+  dataPublicacao: null,
+};
+
+const AUSENTE_DATAJUD: DatajudCapaView = {
+  present: false,
+  classeOficial: null,
+  assuntos: null,
+  orgaoJulgador: null,
+  grau: null,
+  dataAjuizamento: null,
+  ultimaAtualizacao: null,
+};
+
+/** raw vem de buildDjenSql — sempre 1 linha (COUNT agregado), n_publicacoes=0 quando ausente. */
+export function mapDjenRow(raw: Record<string, unknown> | null): DjenResumoView {
+  const n = raw ? toNumber(raw.n_publicacoes) : null;
+  if (!raw || !n) return AUSENTE_DJEN;
   return {
-    nrProcesso,
-    nrProcessoMascara: toNullableString(raw.nr_processo_mascara) ?? formatCnj(nrProcesso),
-    nFontes: toNumber(raw.n_fontes) ?? fontes.length,
-    fontes,
-    djen: {
-      present: has('djen'),
-      primeiraPub: toIsoDate(raw.djen_primeira_pub),
-      ultimaPub: toIsoDate(raw.djen_ultima_pub),
-      nPublicacoes: toNumber(raw.djen_n_publicacoes),
-      tribunais: toStringArray(raw.djen_tribunais),
-    },
-    juris: {
-      present: has('juris'),
-      nDocumentos: toNumber(raw.juris_n_documentos),
-      tipos: toStringArray(raw.juris_tipos),
-      dataJulgamento: toIsoDate(raw.juris_data_julgamento),
-      orgao: toNullableString(raw.juris_orgao),
-      relator: toNullableString(raw.juris_relator),
-      classe: toNullableString(raw.juris_classe),
-      url: toNullableString(raw.juris_url),
-    },
-    stj: {
-      present: has('stj'),
-      id: toNullableString(raw.stj_id),
-      classe: toNullableString(raw.stj_classe),
-      relator: toNullableString(raw.stj_relator),
-      tema: toNullableString(raw.stj_tema),
-      tese: toNullableString(raw.stj_tese),
-      ementa: toNullableString(raw.stj_ementa),
-      dataDecisao: toIsoDate(raw.stj_data_decisao),
-      dataPublicacao: toIsoDate(raw.stj_data_publicacao),
-    },
-    datajud: {
-      // tem_datajud é a fonte da verdade (RFC 0010) — 'datajud' em fontes
-      // acompanha o mesmo booleano, então checar os dois é redundante mas
-      // inofensivo caso um dia divirjam.
-      present: has('datajud') && Boolean(raw.tem_datajud),
-      classeOficial: toNullableString(raw.classe_oficial),
-      assuntos: toNullableString(raw.assuntos),
-      orgaoJulgador: toNullableString(raw.orgao_julgador),
-      grau: toNullableString(raw.grau),
-      dataAjuizamento: toIsoDate(raw.data_ajuizamento),
-      ultimaAtualizacao: toIsoDate(raw.ultima_atualizacao),
-    },
-    updatedAtRaw: toIsoTimestampString(raw.updated_at),
+    present: true,
+    primeiraPub: toIsoDate(raw.primeira_publicacao),
+    ultimaPub: toIsoDate(raw.ultima_publicacao),
+    nPublicacoes: n,
+    tribunais: toStringArray(raw.tribunais),
+  };
+}
+
+/** raw vem de buildJurisSql — 0 linhas quando ausente (cross join agg×principal vazio). */
+export function mapJurisRow(raw: Record<string, unknown> | null): JurisDecisaoView {
+  if (!raw) return AUSENTE_JURIS;
+  return {
+    present: true,
+    nDocumentos: toNumber(raw.n_documentos),
+    tipos: toStringArray(raw.tipos),
+    dataJulgamento: toIsoDate(raw.data_julgamento),
+    orgao: toNullableString(raw.orgao),
+    relator: toNullableString(raw.relator),
+    classe: toNullableString(raw.classe),
+    url: toNullableString(raw.url),
+  };
+}
+
+/** raw vem de buildStjSql — sempre 1 linha (COUNT agregado), n=0 quando ausente. */
+export function mapStjRow(raw: Record<string, unknown> | null): StjAcordaoView {
+  const n = raw ? toNumber(raw.n) : null;
+  if (!raw || !n) return AUSENTE_STJ;
+  return {
+    present: true,
+    id: toNullableString(raw.id),
+    classe: toNullableString(raw.classe),
+    relator: toNullableString(raw.relator),
+    tema: toNullableString(raw.tema),
+    tese: toNullableString(raw.tese),
+    ementa: toNullableString(raw.ementa),
+    dataDecisao: toIsoDate(raw.data_decisao),
+    dataPublicacao: toIsoDate(raw.data_publicacao),
+  };
+}
+
+/** raw vem de buildDatajudSql — sempre 1 linha (COUNT agregado), n=0 quando ausente. */
+export function mapDatajudRow(raw: Record<string, unknown> | null): DatajudCapaView {
+  const n = raw ? toNumber(raw.n) : null;
+  if (!raw || !n) return AUSENTE_DATAJUD;
+  return {
+    present: true,
+    classeOficial: toNullableString(raw.classe_oficial),
+    assuntos: toNullableString(raw.assuntos),
+    orgaoJulgador: toNullableString(raw.orgao_julgador),
+    grau: toNullableString(raw.grau),
+    dataAjuizamento: toIsoDate(raw.data_ajuizamento),
+    ultimaAtualizacao: toIsoDate(raw.ultima_atualizacao),
   };
 }
 
@@ -318,7 +445,7 @@ export interface ProcessoDocumentoRow {
   resumo: string | null;
 }
 
-/** Converte uma linha crua de processo_documentos no modelo de visualização. */
+/** Converte uma linha crua de buildDocumentosSql no modelo de visualização. */
 export function mapDocumentoRow(raw: Record<string, unknown>): ProcessoDocumentoRow {
   return {
     fonte: String(raw.fonte ?? ''),
@@ -351,4 +478,181 @@ export function fontesPresenca(fontes: Fonte[]): FontesPresenca {
 /** Processo localizado, mas sem documentos JURIS/STJ — distinto de CNJ não encontrado. */
 export function isDocumentosVazio(items: unknown[], offset: number): boolean {
   return offset === 0 && items.length === 0;
+}
+
+/** Agrupa as URLs de arquivo_ia_url do índice por fonte, sem repetição, ordenadas. */
+export function fonteUrls(rows: Array<{ fonte: string; url: string }>, fonte: Fonte): string[] {
+  return Array.from(new Set(rows.filter((r) => r.fonte === fonte).map((r) => r.url))).sort();
+}
+
+// ── Cobertura do dataset (indice_processual.report.json) ──────────────────
+
+export interface FonteCobertura {
+  fonte: string;
+  status: string;
+  registros: number;
+}
+
+export interface CoberturaResult {
+  cobertura: FonteCobertura[];
+  datasetGeradoEm: string | null;
+}
+
+/** Carrega indice_processual.report.json; null quando indisponível/ilegível — nunca lança. */
+export async function fetchCobertura(reportUrl: string = REPORT_URL): Promise<CoberturaResult | null> {
+  try {
+    const res = await fetch(reportUrl);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const sources = (data?.sources ?? {}) as Record<string, { status?: string; rows?: number }>;
+    const cobertura: FonteCobertura[] = Object.entries(sources).map(([fonte, info]) => ({
+      fonte,
+      status: info?.status ?? 'unknown',
+      registros: Number(info?.rows ?? 0),
+    }));
+    return { cobertura, datasetGeradoEm: typeof data?.generated_at === 'string' ? data.generated_at : null };
+  } catch {
+    return null;
+  }
+}
+
+// ── Orquestração (DuckDB-WASM) ─────────────────────────────────────────────
+// Mesma conexão AsyncDuckDB do resto do dashboard (getDuckDB()) é passada
+// pelo chamador — este módulo não abre conexão nenhuma, só a usa.
+
+interface DuckDBConnectionLike {
+  prepare: (sql: string) => Promise<{
+    query: (...params: unknown[]) => Promise<{ toArray: () => Array<{ toJSON: () => Record<string, unknown> }> }>;
+    close: () => Promise<void>;
+  }>;
+}
+
+async function queryRows(
+  conn: DuckDBConnectionLike,
+  sql: string,
+  params: unknown[],
+): Promise<Record<string, unknown>[]> {
+  const stmt = await conn.prepare(sql);
+  try {
+    const result = await stmt.query(...params);
+    return result.toArray().map((row) => row.toJSON());
+  } finally {
+    await stmt.close();
+  }
+}
+
+async function queryRow(
+  conn: DuckDBConnectionLike,
+  sql: string,
+  params: unknown[],
+): Promise<Record<string, unknown> | null> {
+  const rows = await queryRows(conn, sql, params);
+  return rows[0] ?? null;
+}
+
+export interface ProcessoResultado {
+  encontrado: boolean;
+  nrProcesso: string;
+  nrProcessoMascara: string;
+  fontes: Fonte[];
+  djen: DjenResumoView;
+  juris: JurisDecisaoView;
+  stj: StjAcordaoView;
+  datajud: DatajudCapaView;
+  /** URLs de origem descobertas no índice — reusadas por carregarDocumentos() sem nova consulta ao índice. */
+  jurisUrls: string[];
+  stjUrls: string[];
+  cobertura: FonteCobertura[];
+  datasetGeradoEm: string | null;
+  avisos: string[];
+}
+
+/**
+ * Busca o dossiê unificado de um CNJ (20 dígitos) via indice_processual.parquet
+ * + parquets de origem. Espelha causaganha/processos/service.py:buscar_processo
+ * — não conhece FastMCP/Svelte, só DuckDB. Deixa propagar erros de
+ * indice_processual.parquet em si (não há resposta possível sem ele); uma
+ * fonte de origem específica ou o relatório de cobertura falhando vira lacuna
+ * vazia + aviso, nunca lança.
+ */
+export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string): Promise<ProcessoResultado> {
+  const avisos: string[] = [];
+  const coberturaResult = await fetchCobertura();
+  const cobertura = coberturaResult?.cobertura ?? [];
+  const datasetGeradoEm = coberturaResult?.datasetGeradoEm ?? null;
+  if (!coberturaResult) avisos.push(RELATORIO_INDISPONIVEL_AVISO);
+
+  const nrProcessoMascara = formatCnj(digits);
+  const indiceRows = await queryRows(conn, buildIndiceSql(), [digits]);
+
+  if (indiceRows.length === 0) {
+    return {
+      encontrado: false,
+      nrProcesso: digits,
+      nrProcessoMascara,
+      fontes: [],
+      djen: AUSENTE_DJEN,
+      juris: AUSENTE_JURIS,
+      stj: AUSENTE_STJ,
+      datajud: AUSENTE_DATAJUD,
+      jurisUrls: [],
+      stjUrls: [],
+      cobertura,
+      datasetGeradoEm,
+      avisos,
+    };
+  }
+
+  const rowPairs = indiceRows.map((r) => ({ fonte: String(r.fonte), url: String(r.arquivo_ia_url) }));
+  const fontes = (Array.from(new Set(rowPairs.map((r) => r.fonte))).sort() as Fonte[]).filter((f) =>
+    ALL_FONTES.includes(f),
+  );
+  const djenUrls = fonteUrls(rowPairs, 'djen');
+  const jurisUrls = fonteUrls(rowPairs, 'juris');
+  const stjUrls = fonteUrls(rowPairs, 'stj');
+  const datajudUrls = fonteUrls(rowPairs, 'datajud');
+
+  const djenRaw = djenUrls.length ? await queryRow(conn, buildDjenSql(djenUrls), [digits]) : null;
+  const jurisRaw = jurisUrls.length ? await queryRow(conn, buildJurisSql(jurisUrls), [digits]) : null;
+  const stjRaw = stjUrls.length ? await queryRow(conn, buildStjSql(stjUrls), [digits]) : null;
+  const datajudRaw = datajudUrls.length ? await queryRow(conn, buildDatajudSql(datajudUrls), [digits]) : null;
+
+  return {
+    encontrado: true,
+    nrProcesso: digits,
+    nrProcessoMascara,
+    fontes,
+    djen: mapDjenRow(djenRaw),
+    juris: mapJurisRow(jurisRaw),
+    stj: mapStjRow(stjRaw),
+    datajud: mapDatajudRow(datajudRaw),
+    jurisUrls,
+    stjUrls,
+    cobertura,
+    datasetGeradoEm,
+    avisos,
+  };
+}
+
+/**
+ * Busca uma página de documentos JURIS/STJ para um CNJ já resolvido por
+ * buscarProcesso() — reusa `jurisUrls`/`stjUrls` descobertas ali, sem
+ * reconsultar o índice. Retorna vazio sem consultar nada quando nenhuma das
+ * duas fontes tem registro.
+ */
+export async function carregarDocumentos(
+  conn: DuckDBConnectionLike,
+  jurisUrls: string[],
+  stjUrls: string[],
+  digits: string,
+  offset: number,
+  pageSize: number = DOCUMENTOS_PAGE_SIZE,
+): Promise<PageResult<ProcessoDocumentoRow>> {
+  if (jurisUrls.length === 0 && stjUrls.length === 0) {
+    return { items: [], hasMore: false };
+  }
+  const { sql, nParams } = buildDocumentosSql(jurisUrls, stjUrls);
+  const params = [...Array(nParams).fill(digits), pageSize + 1, offset];
+  const rawRows = await queryRows(conn, sql, params);
+  return paginate(rawRows.map(mapDocumentoRow), pageSize);
 }

--- a/web/src/lib/processoCnj.ts
+++ b/web/src/lib/processoCnj.ts
@@ -20,6 +20,22 @@ export const IA_DASHBOARD_BASE = 'https://archive.org/download/causaganha-dashbo
 export const INDICE_PROCESSUAL_URL = `${IA_DASHBOARD_BASE}/indice_processual.parquet`;
 export const REPORT_URL = `${IA_DASHBOARD_BASE}/indice_processual.report.json`;
 
+// Rollout fallback (RFC 0014 M2 review): indice_processual.parquet is a brand
+// new artifact — deploy-web.yml can build/deploy before update-catalog.yml
+// has ever published it (that step only runs when has_new_uploads==true; a
+// plain push to main touching web/**/render_queries.py deploys immediately,
+// with no ordering guarantee against the catalog pipeline). Without a
+// fallback, /processo would regress from "has real reconciled data" (its
+// state today, reading these two files) to "indisponível" for however long
+// that takes. These files are frozen (the reconciler stopped writing to
+// them, but nothing deletes them from IA), so they remain a valid — if
+// increasingly stale — source until the index is confirmed published.
+// Mirrors scripts/render_queries.py's own _comunicacoes_urls_from_catalog
+// fallback. Remove once indice_processual.parquet has been confirmed
+// published at least once.
+export const PROCESSOS_UNIFICADOS_URL_LEGADO = `${IA_DASHBOARD_BASE}/processos_unificados.parquet`;
+export const PROCESSO_DOCUMENTOS_URL_LEGADO = `${IA_DASHBOARD_BASE}/processo_documentos.parquet`;
+
 export const DOCUMENTOS_PAGE_SIZE = 20;
 
 export type Fonte = 'djen' | 'juris' | 'stj' | 'datajud';
@@ -232,6 +248,36 @@ export function buildDocumentosSql(jurisUrls: string[], stjUrls: string[]): { sq
   return { sql: `${union} ORDER BY data DESC NULLS LAST, id_documento LIMIT ? OFFSET ?`, nParams: parts.length };
 }
 
+// ── Consultas legadas (fallback de rollout, ver PROCESSOS_UNIFICADOS_URL_LEGADO) ──
+
+export function buildProcessoUnificadoSqlLegado(): string {
+  return `
+    SELECT
+      nr_processo, nr_processo_mascara, n_fontes, fontes,
+      djen_primeira_pub, djen_ultima_pub, djen_n_publicacoes, djen_tribunais,
+      juris_n_documentos, juris_tipos, juris_data_julgamento,
+      juris_orgao, juris_relator, juris_classe, juris_url,
+      stj_id, stj_classe, stj_relator, stj_tema, stj_tese, stj_ementa,
+      stj_data_decisao, stj_data_publicacao,
+      classe_oficial, assuntos, orgao_julgador, grau,
+      data_ajuizamento, ultima_atualizacao, tem_datajud,
+      updated_at
+    FROM read_parquet('${PROCESSOS_UNIFICADOS_URL_LEGADO}')
+    WHERE nr_processo = ?
+    LIMIT 1
+  `;
+}
+
+export function buildProcessoDocumentosSqlLegado(): string {
+  return `
+    SELECT fonte, id_documento, tipo, data, url, resumo
+    FROM read_parquet('${PROCESSO_DOCUMENTOS_URL_LEGADO}')
+    WHERE nr_processo = ?
+    ORDER BY data DESC NULLS LAST, id_documento
+    LIMIT ? OFFSET ?
+  `;
+}
+
 export interface PageResult<T> {
   items: T[];
   hasMore: boolean;
@@ -277,6 +323,17 @@ function toNullableString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   const s = String(value);
   return s.length > 0 ? s : null;
+}
+
+/** TIMESTAMP arbitrário (Date, string ISO, epoch numérico) → string ISO completa, ou null. */
+function toIsoTimestamp(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+    const parsed = new Date(typeof value === 'bigint' ? Number(value) : value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  return null;
 }
 
 /** DATE/TIMESTAMP arbitrário (Date, string ISO, epoch numérico) → 'YYYY-MM-DD', ou null. */
@@ -436,6 +493,77 @@ export function mapDatajudRow(raw: Record<string, unknown> | null): DatajudCapaV
   };
 }
 
+export interface ProcessoLegadoRow {
+  nrProcesso: string;
+  nrProcessoMascara: string;
+  fontes: Fonte[];
+  djen: DjenResumoView;
+  juris: JurisDecisaoView;
+  stj: StjAcordaoView;
+  datajud: DatajudCapaView;
+  updatedAtRaw: string | null;
+}
+
+/**
+ * Converte uma linha crua de buildProcessoUnificadoSqlLegado (o schema largo
+ * pré-índice) para as mesmas interfaces de visualização por fonte usadas
+ * pelo caminho novo — os nomes de campo já coincidem exatamente (herdados
+ * do mesmo componente antes da migração), então é uma reestruturação, não
+ * uma tradução de schema.
+ */
+export function mapProcessoRowLegado(raw: Record<string, unknown>): ProcessoLegadoRow {
+  const fontes = toStringArray(raw.fontes) as Fonte[];
+  const has = (f: Fonte) => fontes.includes(f);
+  const nrProcesso = String(raw.nr_processo ?? '');
+
+  return {
+    nrProcesso,
+    nrProcessoMascara: toNullableString(raw.nr_processo_mascara) ?? formatCnj(nrProcesso),
+    fontes,
+    djen: {
+      present: has('djen'),
+      primeiraPub: toIsoDate(raw.djen_primeira_pub),
+      ultimaPub: toIsoDate(raw.djen_ultima_pub),
+      nPublicacoes: toNumber(raw.djen_n_publicacoes),
+      tribunais: toStringArray(raw.djen_tribunais),
+    },
+    juris: {
+      present: has('juris'),
+      nDocumentos: toNumber(raw.juris_n_documentos),
+      tipos: toStringArray(raw.juris_tipos),
+      dataJulgamento: toIsoDate(raw.juris_data_julgamento),
+      orgao: toNullableString(raw.juris_orgao),
+      relator: toNullableString(raw.juris_relator),
+      classe: toNullableString(raw.juris_classe),
+      url: toNullableString(raw.juris_url),
+    },
+    stj: {
+      present: has('stj'),
+      id: toNullableString(raw.stj_id),
+      classe: toNullableString(raw.stj_classe),
+      relator: toNullableString(raw.stj_relator),
+      tema: toNullableString(raw.stj_tema),
+      tese: toNullableString(raw.stj_tese),
+      ementa: toNullableString(raw.stj_ementa),
+      dataDecisao: toIsoDate(raw.stj_data_decisao),
+      dataPublicacao: toIsoDate(raw.stj_data_publicacao),
+    },
+    datajud: {
+      // tem_datajud é a fonte da verdade (RFC 0010) — 'datajud' em fontes
+      // acompanha o mesmo booleano, checar os dois é redundante mas
+      // inofensivo caso um dia divirjam.
+      present: has('datajud') && Boolean(raw.tem_datajud),
+      classeOficial: toNullableString(raw.classe_oficial),
+      assuntos: toNullableString(raw.assuntos),
+      orgaoJulgador: toNullableString(raw.orgao_julgador),
+      grau: toNullableString(raw.grau),
+      dataAjuizamento: toIsoDate(raw.data_ajuizamento),
+      ultimaAtualizacao: toIsoDate(raw.ultima_atualizacao),
+    },
+    updatedAtRaw: toIsoTimestamp(raw.updated_at),
+  };
+}
+
 export interface ProcessoDocumentoRow {
   fonte: Fonte | string;
   idDocumento: string;
@@ -565,15 +693,26 @@ export interface ProcessoResultado {
   cobertura: FonteCobertura[];
   datasetGeradoEm: string | null;
   avisos: string[];
+  /** True quando este resultado veio do fallback pré-migração (ver PROCESSOS_UNIFICADOS_URL_LEGADO). */
+  legado: boolean;
 }
+
+const INDICE_INDISPONIVEL_AVISO =
+  'Não foi possível abrir indice_processual.parquet no Internet Archive. Mostrando dados de ' +
+  'processos_unificados.parquet (versão anterior à migração para o índice fino) — podem estar ' +
+  'desatualizados.';
 
 /**
  * Busca o dossiê unificado de um CNJ (20 dígitos) via indice_processual.parquet
  * + parquets de origem. Espelha causaganha/processos/service.py:buscar_processo
- * — não conhece FastMCP/Svelte, só DuckDB. Deixa propagar erros de
- * indice_processual.parquet em si (não há resposta possível sem ele); uma
- * fonte de origem específica ou o relatório de cobertura falhando vira lacuna
- * vazia + aviso, nunca lança.
+ * — não conhece FastMCP/Svelte, só DuckDB. Uma fonte de origem específica ou o
+ * relatório de cobertura falhando vira lacuna vazia + aviso, nunca lança.
+ *
+ * indice_processual.parquet em si sendo inacessível (não apenas uma fonte
+ * específica) não propaga como erro aqui — ao contrário do serviço Python,
+ * que não tem alternativa e por isso deixa a exceção subir — porque há um
+ * fallback real disponível no navegador: processos_unificados.parquet
+ * (RFC 0014 M2 review). Ver buscarProcessoLegado.
  */
 export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string): Promise<ProcessoResultado> {
   const avisos: string[] = [];
@@ -583,7 +722,12 @@ export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string)
   if (!coberturaResult) avisos.push(RELATORIO_INDISPONIVEL_AVISO);
 
   const nrProcessoMascara = formatCnj(digits);
-  const indiceRows = await queryRows(conn, buildIndiceSql(), [digits]);
+  let indiceRows: Record<string, unknown>[];
+  try {
+    indiceRows = await queryRows(conn, buildIndiceSql(), [digits]);
+  } catch {
+    return buscarProcessoLegado(conn, digits, nrProcessoMascara, avisos);
+  }
 
   if (indiceRows.length === 0) {
     return {
@@ -600,6 +744,7 @@ export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string)
       cobertura,
       datasetGeradoEm,
       avisos,
+      legado: false,
     };
   }
 
@@ -631,6 +776,61 @@ export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string)
     cobertura,
     datasetGeradoEm,
     avisos,
+    legado: false,
+  };
+}
+
+/**
+ * Fallback de rollout: indice_processual.parquet está inacessível — tenta o
+ * schema largo pré-migração (ainda no IA, congelado). Se ele também falhar,
+ * não há fonte de dados nenhuma disponível — deixa a exceção subir para o
+ * chamador tratar como "fonte indisponível" (mesmo comportamento de antes
+ * desta fallback existir).
+ */
+async function buscarProcessoLegado(
+  conn: DuckDBConnectionLike,
+  digits: string,
+  nrProcessoMascara: string,
+  avisosBase: string[],
+): Promise<ProcessoResultado> {
+  const avisos = [...avisosBase, INDICE_INDISPONIVEL_AVISO];
+  const rows = await queryRows(conn, buildProcessoUnificadoSqlLegado(), [digits]);
+
+  if (rows.length === 0) {
+    return {
+      encontrado: false,
+      nrProcesso: digits,
+      nrProcessoMascara,
+      fontes: [],
+      djen: AUSENTE_DJEN,
+      juris: AUSENTE_JURIS,
+      stj: AUSENTE_STJ,
+      datajud: AUSENTE_DATAJUD,
+      jurisUrls: [],
+      stjUrls: [],
+      cobertura: [],
+      datasetGeradoEm: null,
+      avisos,
+      legado: true,
+    };
+  }
+
+  const legado = mapProcessoRowLegado(rows[0]);
+  return {
+    encontrado: true,
+    nrProcesso: legado.nrProcesso,
+    nrProcessoMascara: legado.nrProcessoMascara,
+    fontes: legado.fontes,
+    djen: legado.djen,
+    juris: legado.juris,
+    stj: legado.stj,
+    datajud: legado.datajud,
+    jurisUrls: [],
+    stjUrls: [],
+    cobertura: [],
+    datasetGeradoEm: legado.updatedAtRaw,
+    avisos,
+    legado: true,
   };
 }
 
@@ -638,7 +838,10 @@ export async function buscarProcesso(conn: DuckDBConnectionLike, digits: string)
  * Busca uma página de documentos JURIS/STJ para um CNJ já resolvido por
  * buscarProcesso() — reusa `jurisUrls`/`stjUrls` descobertas ali, sem
  * reconsultar o índice. Retorna vazio sem consultar nada quando nenhuma das
- * duas fontes tem registro.
+ * duas fontes tem registro (também o caso quando `legado=true`, já que o
+ * fallback não descobre URLs de origem — carregarDocumentos precisa do
+ * parâmetro `legado` nesse caso para consultar processo_documentos.parquet
+ * em vez do UNION dinâmico por fonte).
  */
 export async function carregarDocumentos(
   conn: DuckDBConnectionLike,
@@ -647,7 +850,16 @@ export async function carregarDocumentos(
   digits: string,
   offset: number,
   pageSize: number = DOCUMENTOS_PAGE_SIZE,
+  legado = false,
 ): Promise<PageResult<ProcessoDocumentoRow>> {
+  if (legado) {
+    const rawRows = await queryRows(conn, buildProcessoDocumentosSqlLegado(), [
+      digits,
+      pageSize + 1,
+      offset,
+    ]);
+    return paginate(rawRows.map(mapDocumentoRow), pageSize);
+  }
   if (jurisUrls.length === 0 && stjUrls.length === 0) {
     return { items: [], hasMore: false };
   }


### PR DESCRIPTION
## Description

RFC 0014 M2: adds `processo_consultar`, the first `causaganha_mcp` tool serving the end user directly (not the pipeline operator). Answering "what's the canonical data source for this tool" led to a redesign of the cross-source data model itself, shipped in this same PR rather than after the tool existed against the old shape.

**The redesign.** The original plan (RFC 0005) published a wide `processos_unificados.parquet`/`processo_documentos.parquet` — one row per processo, columns prefixed by source. Instead, `scripts/reconcile_processos.py` now publishes **`indice_processual.parquet`** — a thin cross-source index (`numero_processo | fonte | registro_id | tribunal | data | arquivo_ia_url`), generalizing the pattern DJEN's own `comunicacoes`/`processos` tables already used (full record + a thin pointer table, never a copy of content fields). Consumers query the index to discover which source parquets have a record for a CNJ, then query those source parquets directly.

**What changed:**
- `scripts/reconcile_processos.py` — publishes `indice_processual.parquet` + `indice_processual.report.json` (per-source coverage) instead of the two wide tables.
- `scripts/render_queries.py` — recomputes `processos_unificados`/`processo_documentos` as in-memory DuckDB views from the raw source parquets, so `processos_multi_fonte.qmd` and the rest of the existing `.qmd` contracts keep working unchanged.
- `causaganha.processos` (new package) — `cnj.py` (CNJ normalization, single implementation now reexported by `datajud.models`), `models.py` (framework-neutral dataclasses), `service.py` (`buscar_processo()`: queries the index then the per-source parquets; a source or the coverage report failing degrades to a warning, never a crash; the index itself being unreachable is the only fatal path).
- `causaganha_mcp/tools/processo.py` — registers `processo_consultar`, mapping the service result onto a Portuguese Pydantic envelope. `fontes_presentes` (which sources have this CNJ) is kept separate from `cobertura_dataset` (which sources were loaded when the dataset was generated). `web_url` is built only from the `CAUSAGANHA_WEB_BASE_URL` env var, never hardcoded.
- `datajud.service`'s CNJ discovery now reads `indice_processual.parquet` directly (a `SELECT DISTINCT`, no join needed).
- `web/src/lib/processoCnj.ts` + `ProcessoLookup.svelte` (the dashboard's `/processo` page) migrate to the same two-stage query via DuckDB-WASM — index lookup, then per-source parquet queries, including a dynamic multi-URL union for DJEN (a CNJ's comunicações can span many per-date IA items).
- `docs/rfc/0005-processo-como-recurso.md` and `docs/rfc/0014-mcp-superficie-produto.md` updated to document the redesign and why it landed in this PR.

## Test plan

- [x] `uv run pytest -q` — full suite green (Python)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `npx vitest run` (web) — 227 tests green, including rewritten `processoCnj.test.ts` and `ProcessoLookup.test.ts`
- [x] `npx astro check` — 0 errors
- [x] New tests: `causaganha.processos.cnj`, `causaganha.processos.service` (against local parquet fixtures — multi-source, single-source, not-found, invalid CNJ, missing report, one source unreachable, index itself unreachable, document pagination/truncation), MCP tool schema + behavior (envelope mapping, `web_url` env-var gating, `ToolError` translation without leaking upstream detail), `reconcile_processos.py` (index shape, dedup, coverage report), `datajud` CNJ-discovery fixture.

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. — N/A, doesn't touch CLI/argv, only the MCP server, the reconciler's published artifact, and the web dashboard.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_