### PR TITLE
ops: add force_reconcile input to bootstrap indice_processual.parquet

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -2,6 +2,11 @@ name: Update Catalog
 
 on:
   workflow_dispatch:
+    inputs:
+      force_reconcile:
+        description: 'Gerar e publicar indice_processual.parquet mesmo sem novos uploads'
+        type: boolean
+        default: false
   workflow_run:
     workflows: ["Consolidate Parquet"]
     types: [completed]
@@ -57,7 +62,7 @@ jobs:
           echo "Catalog updated."
 
       - name: Reconcile processos (DJEN x JURIS x STJ x DataJud)
-        if: steps.append.outputs.has_new_uploads == 'true'
+        if: steps.append.outputs.has_new_uploads == 'true' || github.event.inputs.force_reconcile == 'true'
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
@@ -70,18 +75,18 @@ jobs:
           # soon as those uploads produce real IA items.
           RECONCILE_EXPECTED_SOURCES: djen,stj
         run: |
-          echo "Reconciling processos_unificados..."
+          echo "Reconciling indice_processual..."
           uv run python scripts/reconcile_processos.py
-          echo "processos_unificados.parquet uploaded."
+          echo "indice_processual.parquet uploaded."
 
       - name: Render query contracts and generate cache
-        if: steps.append.outputs.has_new_uploads == 'true'
+        if: steps.append.outputs.has_new_uploads == 'true' || github.event.inputs.force_reconcile == 'true'
         run: |
           uv run python scripts/render_queries.py
           uv run python scripts/generate_cache_from_manifest.py --upload
 
       - name: Trigger dashboard deploy
-        if: steps.append.outputs.has_new_uploads == 'true'
+        if: steps.append.outputs.has_new_uploads == 'true' || github.event.inputs.force_reconcile == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |


### PR DESCRIPTION
## Description

Operational follow-up to #856 (merged in `daeb6332`). The reconciler code that publishes `indice_processual.parquet`/`indice_processual.report.json` is on `main`, but `update-catalog.yml` only runs the reconcile/render/deploy-trigger steps when `has_new_uploads == true`. A plain `workflow_dispatch` skips those steps too when there's no new upload — so nothing actually bootstraps the first publish of the new index. Until that happens, `/processo` and `processo_consultar` stay on the rollout fallback (`processos_unificados.parquet`/`processo_documentos.parquet`) indefinitely.

**What changed:**
- `workflow_dispatch` gains a `force_reconcile` boolean input.
- The three steps that produce/publish the new index — "Reconcile processos", "Render query contracts and generate cache", "Trigger dashboard deploy" — now run when `has_new_uploads == true` **or** `force_reconcile == true`. "Validate manifest" and "Generate and upload catalog" (the unrelated `causaganha-catalog` manifest) stay gated on `has_new_uploads` only.
- Two stale log lines ("Reconciling processos_unificados...", "processos_unificados.parquet uploaded.") updated to say `indice_processual` — leftover from before the M2 redesign.

**Next step after this merges:** dispatch `Update Catalog` once with `force_reconcile=true` to publish the first `indice_processual.parquet`/`indice_processual.report.json`, then validate (known CNJs across DJEN-only/multi-source/not-found, `/processo` no longer showing the legacy-fallback warning, `processo_consultar`, and the coverage report) before considering the rollout fallbacks for removal in a separate PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [x] Reviewed the `if:` conditions don't touch the two catalog-only steps (still gated on `has_new_uploads` alone, since they're unrelated to `indice_processual.parquet`)
- [ ] After merge: dispatch with `force_reconcile=true`, confirm the two new files land on IA, confirm `/processo` drops the legacy-fallback warning

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] If this PR modifies workflow CLI flags, confirm the flag exists in the Python CLI in main. — N/A, this is a GitHub Actions workflow input, not a CLI flag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BfEgjxG9hwSfHg479MJqYw)_