### PR TITLE
ci: isolate trusted-bot lint autofixes and keep main CI read-only

### DIFF
--- a/.github/workflows/fixtures/trusted-bot-autofix-events.json
+++ b/.github/workflows/fixtures/trusted-bot-autofix-events.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "same-repository Dependabot pull request",
+    "repository": "causaganha/causaganha",
+    "head_repository": "causaganha/causaganha",
+    "pull_request_author": "dependabot[bot]",
+    "actor": "dependabot[bot]",
+    "allowed": true
+  },
+  {
+    "name": "forked Dependabot pull request",
+    "repository": "causaganha/causaganha",
+    "head_repository": "forker/causaganha",
+    "pull_request_author": "dependabot[bot]",
+    "actor": "dependabot[bot]",
+    "allowed": false
+  },
+  {
+    "name": "unapproved bot",
+    "repository": "causaganha/causaganha",
+    "head_repository": "causaganha/causaganha",
+    "pull_request_author": "renovate[bot]",
+    "actor": "renovate[bot]",
+    "allowed": false
+  },
+  {
+    "name": "maintainer rerun of Dependabot pull request",
+    "repository": "causaganha/causaganha",
+    "head_repository": "causaganha/causaganha",
+    "pull_request_author": "dependabot[bot]",
+    "actor": "maintainer",
+    "allowed": false
+  }
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
 
-# Default to read-only; jobs that need more declare it themselves.
+# Every normal CI job is intentionally read-only, including lint and validation.
 permissions:
   contents: read
 
@@ -13,11 +13,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      # The "Auto-fix linting issues" step commits and pushes lint fixes back
-      # to bot PRs, which requires write access to repo contents. No other
-      # job needs more than read.
-      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup
@@ -29,7 +24,7 @@ jobs:
         # a non-blocking advisory lint pass.
         run: uv run ruff check
       - name: Check dead code
-        run: uvx vulture src/ scripts/ vulture_whitelist.py --min-confidence 100
+        run: uv run vulture src/ scripts/ vulture_whitelist.py --min-confidence 100
       - name: Check notebooks synced
         # Notebooks are authored as marimo notebooks (notebooks/*.py); the
         # committed *.ipynb must match `marimo export ipynb`. Fails if a
@@ -40,21 +35,6 @@ jobs:
         # frontmatter fields + SQL executed against synthetic schemas derived
         # from the same view registry the render uses. No network needed.
         run: uv run python scripts/render_queries.py --check
-      - name: Auto-fix linting issues
-        if: failure() && github.event_name == 'pull_request' && endsWith(github.actor, '[bot]')
-        run: |
-          uvx ruff format . || true
-          uvx ruff check --fix . || true
-          uv run python scripts/check_notebooks_synced.py --fix || true
-          npx prettier --write . || true
-
-          if [ -n "$(git status --porcelain)" ]; then
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add .
-            git commit -m "style: auto-fix lint violations [bot]"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
 
   tests:
     runs-on: ubuntu-latest
@@ -83,8 +63,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
           cache-dependency-path: web/package-lock.json
       - run: npm ci
       - name: Stub pipeline-generated data files
@@ -112,4 +92,3 @@ jobs:
         run: npm test
       - name: Build
         run: npm run build
-

--- a/.github/workflows/trusted-bot-autofix.yml
+++ b/.github/workflows/trusted-bot-autofix.yml
@@ -1,0 +1,54 @@
+name: Trusted bot lint auto-fix
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+# This is intentionally the only write-capable CI workflow. It is guarded below
+# before it checks out or executes PR-controlled code, and references no secrets.
+permissions:
+  contents: write
+
+jobs:
+  auto-fix:
+    # Approved bots must be listed explicitly. Keep this expression synchronized
+    # with fixtures/trusted-bot-autofix-events.json and its workflow test.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+      - name: Install locked frontend tools
+        run: npm ci --prefix web
+      - name: Auto-fix linting issues
+        env:
+          # checkout deliberately does not persist credentials; use this token
+          # only for the final, same-repository branch push.
+          PUSH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          uv run ruff format .
+          uv run ruff check --fix .
+          uv run python scripts/check_notebooks_synced.py --fix
+          npm --prefix web exec prettier -- --write .
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git add .
+            git commit -m "style: auto-fix lint violations [bot]"
+            git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
+            git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          fi

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Common local commands:
 uv run pytest -q
 uv run ruff format --check
 uv run ruff check
-uvx vulture src/ scripts/ vulture_whitelist.py --min-confidence 100
+uv run vulture src/ scripts/ vulture_whitelist.py --min-confidence 100
 cd web && npm ci && npm run lint && npm test && npm run build
 ```
 
@@ -278,6 +278,13 @@ The main CI workflow is [test.yml](.github/workflows/test.yml). It currently run
 3. Notebook sync check (`scripts/check_notebooks_synced.py`)
 4. Python tests
 5. Frontend lint, test, and build
+
+Normal CI always uses read-only repository permissions. The separate
+[trusted bot auto-fix workflow](.github/workflows/trusted-bot-autofix.yml) is
+the only workflow that can push formatting fixes. Its allowlist currently
+contains only `dependabot[bot]`; a pull request must also originate from a
+branch in this repository (forks are never eligible). Add another bot only by
+updating the workflow condition and its event-condition fixture together.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "pytest-cov>=6.2.1",
     "respx>=0.22.0",
     "ruff>=0.12.0",
+    "vulture>=2.14",
     # Runtime of deployment/relay/function/main.py (Cloud Run relay) — needed
     # to import and unit-test it; not used anywhere else in the repo.
     "functions-framework>=3.0.0",

--- a/tests/test_trusted_bot_autofix_workflow.py
+++ b/tests/test_trusted_bot_autofix_workflow.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 CausaGanha Team
+"""Contract tests for the write-capable trusted-bot workflow guard."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/trusted-bot-autofix.yml"
+FIXTURES = ROOT / ".github/workflows/fixtures/trusted-bot-autofix-events.json"
+EXPECTED_CONDITION = (
+    "github.event.pull_request.head.repo.full_name == github.repository && "
+    "github.event.pull_request.user.login == 'dependabot[bot]' && "
+    "github.actor == 'dependabot[bot]'"
+)
+
+
+def auto_fix_is_allowed(event: dict[str, object]) -> bool:
+    """Mirror the documented GitHub Actions condition for fixture coverage."""
+    return (
+        event["head_repository"] == event["repository"]
+        and event["pull_request_author"] == "dependabot[bot]"
+        and event["actor"] == "dependabot[bot]"
+    )
+
+
+def test_trusted_bot_auto_fix_guard_matches_event_fixture() -> None:
+    events = json.loads(FIXTURES.read_text())
+
+    assert [auto_fix_is_allowed(event) for event in events] == [
+        event["allowed"] for event in events
+    ]
+
+
+def test_write_workflow_uses_the_explicit_trusted_bot_guard() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert "pull_request_target:" in workflow
+    assert "permissions:\n  contents: write" in workflow
+    assert EXPECTED_CONDITION in " ".join(workflow.split())
+    assert "persist-credentials: false" in workflow

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,7 @@
         "jsdom": "^26.0.0",
         "openapi-typescript": "^7.13.0",
         "orval": "^8.21.0",
+        "prettier": "3.8.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^8.1.4",

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "jsdom": "^26.0.0",
     "openapi-typescript": "^7.13.0",
     "orval": "^8.21.0",
+    "prettier": "3.8.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^8.1.4",


### PR DESCRIPTION
### Motivation

- Ensure normal CI (lint, notebook-sync, and `.qmd` validation) always runs with `contents: read` and cannot push changes.
- Move any write-capable auto-fix behavior into a separate, narrowly-scoped workflow that can only run for explicitly trusted bot PRs from the same repository.
- Avoid transient tool resolution for write-capable steps by using lockfile-managed frontend tooling and an explicit `vulture` dev dependency.

### Description

- Updated `.github/workflows/test.yml` to make the workflow-level `permissions` `contents: read`, remove the in-line auto-fix push step, and use the project-managed `uv run vulture` invocation for dead-code checks.
- Added a new write-capable workflow `.github/workflows/trusted-bot-autofix.yml` that runs on `pull_request_target`, requires `permissions: contents: write`, and is guarded by a strict `if` expression that requires the PR to originate in the same repository and be authored/acted-by `dependabot[bot]` while using `persist-credentials: false` before checkout.
- The trusted-bot workflow installs lockfile-managed frontend tools (`npm ci --prefix web`) and runs fixes with `uv run ruff` and `npm --prefix web exec prettier -- --write .`, and only pushes back to the same-repository branch after explicit guarded checks using the injected `github.token`.
- Documented the allowlist and added a fixture file `.github/workflows/fixtures/trusted-bot-autofix-events.json` plus a contract test `tests/test_trusted_bot_autofix_workflow.py` that mirrors the workflow condition and validates allowed/denied event cases; also added `vulture` to `dev` deps and pinned `prettier` in `web/package.json`/`package-lock.json`.

### Testing

- Ran action linting with `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/test.yml .github/workflows/trusted-bot-autofix.yml` and it passed.
- Ran formatting and lint checks on the new test with `uv run ruff format --check tests/test_trusted_bot_autofix_workflow.py` and `uv run ruff check tests/test_trusted_bot_autofix_workflow.py`, which passed.
- Executed the contract test with `python -m pytest tests/test_trusted_bot_autofix_workflow.py -q` and it passed.
- Ran `npm ci --prefix web` and Prettier checks (`npm --prefix web exec prettier -- --check`) during validation and fixed/normalized workflow/README files with Prettier where needed; `git diff --check` reported no remaining whitespace/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62cd325a4883258dc2681c9348ac6a)