### PR TITLE
Read manifest consumers from parquet event log

### DIFF
--- a/.github/actions/download-state/action.yml
+++ b/.github/actions/download-state/action.yml
@@ -6,17 +6,11 @@ runs:
     - shell: bash
       run: |
         mkdir -p data
-        HEADER='tribunal,date,ia_status,djen_status,djen_raw,updated_at'
-        # Download the manifest (primary state file). Phase 3: the canonical
-        # source on IA is the parquet — export it to the local CSV that
-        # downstream local-only consumers (append_manifest.py,
-        # generate_catalog.py) still read, unchanged.
-        if curl -sSfL -o data/sync-manifest.parquet \
-          "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"; then
-          uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
-            || echo "$HEADER" > data/sync-manifest.csv
-        else
-          echo "$HEADER" > data/sync-manifest.csv
-        fi
+        # Consumers replay the canonical parquet plus pending log segments.
+        curl -sSfL -o data/sync-manifest.parquet \
+          "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet" || true
+        ia download causaganha-dashboard 'manifest-log/*.csv' --destdir data --no-directories || true
+        mkdir -p data/manifest-log
+        find data -maxdepth 1 -name '*.csv' -exec mv {} data/manifest-log/ \;
         echo "State files:"
         ls -lh data/

--- a/.github/workflows/consolidate-parquet.yml
+++ b/.github/workflows/consolidate-parquet.yml
@@ -77,20 +77,14 @@ jobs:
             || echo '{"current_date":null,"processed_zips":[],"completed_dates":[]}' > data/consolidate-checkpoint.json
           echo "Checkpoint state:"
           cat data/consolidate-checkpoint.json | python3 -m json.tool 2>/dev/null || cat data/consolidate-checkpoint.json
-          # Download sync-manifest.parquet (the canonical source, Phase 3) and
-          # export it to the local CSV so consolidate.py can discover ZIPs
-          # without requiring a fresh manifest.parquet (avoids slow
-          # per-tribunal IA API fallback). No code change needed downstream —
-          # consolidate.py still reads the local CSV.
-          HEADER='tribunal,date,ia_status,djen_status,djen_raw,updated_at'
-          if curl -sSfL -o data/sync-manifest.parquet \
-            "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"; then
-            uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")" \
-              || echo "$HEADER" > data/sync-manifest.csv
-          else
-            echo "$HEADER" > data/sync-manifest.csv
-          fi
-          echo "Sync manifest entries: $(tail -n +2 data/sync-manifest.csv | wc -l)"
+          # The local read path is the compacted parquet plus pending event
+          # segments.  Do not reconstruct the retired CSV.
+          curl -sSfL -o data/sync-manifest.parquet \
+            "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet" || true
+          ia download causaganha-dashboard 'manifest-log/*.csv' --destdir data --no-directories || true
+          mkdir -p data/manifest-log
+          find data -maxdepth 1 -name '*.csv' -exec mv {} data/manifest-log/ \;
+          echo "Manifest parquet downloaded: $(test -f data/sync-manifest.parquet && echo yes || echo no)"
           # Download existing consolidation manifest so update_consolidation_manifest()
           # merges into it rather than overwriting with a single-run snapshot.
           mkdir -p web/public/data

--- a/.github/workflows/roundtrip-check.yml
+++ b/.github/workflows/roundtrip-check.yml
@@ -49,13 +49,14 @@ jobs:
       - name: Download sync-manifest from IA
         run: |
           mkdir -p data
-          # Phase 3: the canonical source on IA is the parquet — download it
-          # and export to the local CSV downstream steps still read. No
-          # fallback (matches prior behavior: fail hard if unavailable).
+          # Read the canonical parquet and un-compacted event segments; the
+          # roundtrip consumer replays them without rebuilding a CSV.
           curl -sSfL -o data/sync-manifest.parquet \
             "https://archive.org/download/causaganha-dashboard/sync-manifest.parquet"
-          uv run --no-dev python -c "import duckdb; duckdb.connect().execute(\"COPY (SELECT * FROM read_parquet('data/sync-manifest.parquet')) TO 'data/sync-manifest.csv' (FORMAT CSV, HEADER)\")"
-          echo "Manifest rows: $(tail -n +2 data/sync-manifest.csv | wc -l)"
+          ia download causaganha-dashboard 'manifest-log/*.csv' --destdir data --no-directories || true
+          mkdir -p data/manifest-log
+          find data -maxdepth 1 -name '*.csv' -exec mv {} data/manifest-log/ \;
+          echo "Manifest parquet downloaded."
 
       - name: Run roundtrip equivalence check
         run: |

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -31,13 +31,15 @@ from pathlib import Path
 
 import structlog
 
+from causaganha.consolidate import manifest_reader
+
 
 logger = structlog.get_logger()
 
 IA_CATALOG_ITEM = "causaganha-catalog"
 FALLBACK_MANIFEST_URL = "https://archive.org/download/causaganha-catalog/manifest.jsonl"
 LOCAL_MANIFEST_PATH = Path("data/manifest.jsonl")
-SYNC_MANIFEST_PATH = Path("data/sync-manifest.csv")
+SYNC_MANIFEST_PATH = Path("data/sync-manifest.parquet")
 
 
 def download_existing_manifest() -> list[dict]:
@@ -61,9 +63,7 @@ def download_existing_manifest() -> list[dict]:
 
 
 def get_new_uploads() -> list[dict]:
-    """Extract uploaded ZIPs from sync-manifest.csv.
-
-    Reads the canonical state file written by djen-backup/engine.py.
+    """Extract uploaded ZIPs from the materialized manifest and event log.
     Returns all entries with ia_status=uploaded, deduplication is handled
     by the caller via (date, tribunal) keying.
     """
@@ -75,22 +75,14 @@ def get_new_uploads() -> list[dict]:
     now_str = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
 
     try:
-        for raw_line in SYNC_MANIFEST_PATH.read_text(encoding="utf-8").splitlines():
-            stripped = raw_line.strip()
-            if not stripped or stripped.startswith("tribunal"):
+        for entry in manifest_reader.entries(SYNC_MANIFEST_PATH):
+            if entry.ia_status != "uploaded":
                 continue
-            parts = stripped.split(",")
-            if len(parts) < 3:
-                continue
-            tribunal = parts[0].upper()
-            date_str = parts[1]
-            ia_status = parts[2]
-            if ia_status != "uploaded":
-                continue
-            updated_at = parts[5] if len(parts) > 5 else now_str
-            year = date_str[:4]
+            tribunal = entry.tribunal
+            date_str = entry.date.isoformat()
+            updated_at = entry.updated_at or now_str
             filename = f"djen-{date_str}-{tribunal}.zip"
-            item_id = f"djen-{tribunal.lower()}-{year}"
+            item_id = f"djen-{tribunal.lower()}-{entry.date.year}"
             rows.append(
                 {
                     "date": date_str,
@@ -117,7 +109,7 @@ def main() -> int:
     logger.info("new_rows_from_state", count=len(new_rows))
 
     # Only entries NOT yet in the existing manifest are truly new.
-    # sync-manifest.csv accumulates all historical uploads, so comparing
+    # The materialized manifest accumulates all historical uploads, so comparing
     # against the existing manifest.jsonl avoids spurious has_new_uploads=true.
     existing_keys = {(r.get("date"), r.get("tribunal")) for r in existing_rows}
     truly_new = [r for r in new_rows if (r.get("date"), r.get("tribunal")) not in existing_keys]

--- a/scripts/append_manifest.py
+++ b/scripts/append_manifest.py
@@ -64,6 +64,7 @@ def download_existing_manifest() -> list[dict]:
 
 def get_new_uploads() -> list[dict]:
     """Extract uploaded ZIPs from the materialized manifest and event log.
+
     Returns all entries with ia_status=uploaded, deduplication is handled
     by the caller via (date, tribunal) keying.
     """

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -60,6 +60,7 @@ import duckdb
 import structlog
 
 from causaganha.config import TRIBUNAIS
+from causaganha.consolidate import manifest_reader
 
 
 logger = structlog.get_logger()
@@ -69,7 +70,7 @@ DJEN_START_DATE = date(2024, 1, 1)
 
 IA_CATALOG_ITEM = "causaganha-catalog"
 
-SYNC_MANIFEST_PATH = Path("data/sync-manifest.csv")
+SYNC_MANIFEST_PATH = Path("data/sync-manifest.parquet")
 
 # Known table names from consolidation output
 KNOWN_TABLE_NAMES = {
@@ -134,30 +135,12 @@ def run_ia_command(args: list[str], timeout: int = 300) -> str:
 def get_items_from_sync_manifest(
     manifest_path: Path = SYNC_MANIFEST_PATH,
 ) -> list[str]:
-    """Get IA item IDs from sync-manifest.csv (uploaded entries only).
-
-    Replaces the old get_items_from_ia_state() which read the deprecated
-    ia-state.json. The new djen-backup engine writes to sync-manifest.csv
-    using the canonical item format djen-{tribunal.lower()}-{year}.
-    """
-    if not manifest_path.exists():
-        logger.info("sync_manifest_not_found", path=str(manifest_path))
-        return []
-
+    """Get uploaded IA item IDs from parquet plus pending manifest-log events."""
     item_ids: set[str] = set()
     try:
-        for raw_line in manifest_path.read_text(encoding="utf-8").splitlines():
-            stripped = raw_line.strip()
-            if not stripped or stripped.startswith("tribunal"):
-                continue
-            parts = stripped.split(",")
-            if len(parts) < 3:
-                continue
-            tribunal = parts[0].lower()
-            date_str = parts[1]
-            ia_status = parts[2]
-            if ia_status == "uploaded" and len(date_str) >= 4:
-                item_ids.add(f"djen-{tribunal}-{date_str[:4]}")
+        for entry in manifest_reader.entries(manifest_path):
+            if entry.ia_status == "uploaded":
+                item_ids.add(f"djen-{entry.tribunal.lower()}-{entry.date.year}")
     except Exception as e:
         logger.warning("failed_to_parse_sync_manifest", error=str(e))
         return []
@@ -293,25 +276,22 @@ def generate_collect_progress(
 ) -> dict:
     """Generate download (collect) progress metrics for dashboard.
 
-    Reads sync-manifest.csv (written by djen-backup/engine.py) instead of the
-    old djen_state.coverage DuckDB table which is no longer populated.
+    Reads the canonical parquet materialization and pending manifest-log
+    segments instead of the retired CSV or old coverage DuckDB table.
     """
     target_start = date(2024, 1, 1)
     target_end = datetime.now(tz=UTC).date()
     target_days = (target_end - target_start).days + 1
 
     uploaded_dates: set[str] = set()
-    if sync_manifest_path.exists():
-        try:
-            for raw_line in sync_manifest_path.read_text(encoding="utf-8").splitlines():
-                stripped = raw_line.strip()
-                if not stripped or stripped.startswith("tribunal"):
-                    continue
-                parts = stripped.split(",")
-                if len(parts) >= 3 and parts[2] == "uploaded":
-                    uploaded_dates.add(parts[1])
-        except Exception as e:
-            logger.warning("collect_progress_manifest_read_failed", error=str(e))
+    try:
+        uploaded_dates = {
+            entry.date.isoformat()
+            for entry in manifest_reader.entries(sync_manifest_path)
+            if entry.ia_status == "uploaded"
+        }
+    except Exception as e:
+        logger.warning("collect_progress_manifest_read_failed", error=str(e))
 
     unique_days = len(uploaded_dates)
     dates_sorted = sorted(uploaded_dates) if uploaded_dates else []

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -20,10 +20,12 @@ Usage:
 
 import argparse
 import asyncio
+import contextlib
 import decimal
 import json
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -45,9 +47,6 @@ from typing import Any
 # which triggers InvalidOperation if traps are enabled.
 decimal.getcontext().traps[decimal.InvalidOperation] = False
 
-import contextlib
-import sys
-
 import duckdb
 import httpx
 import ibis
@@ -60,11 +59,11 @@ from tenacity import (
 )
 
 from causaganha.config import TRIBUNAIS
+from causaganha.consolidate import manifest_reader
 from causaganha.consolidate.consolidation_manifest import (
     collect_table_stats,
     update_consolidation_manifest,
 )
-from causaganha.consolidate import manifest_reader
 from causaganha.consolidate.ndjson_validator import validate_ndjson_sample
 from causaganha.consolidate.schema_registry import (
     CURRENT_VERSION,
@@ -141,7 +140,12 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
             date_str = entry.date.isoformat()
             if entry.ia_status == "uploaded":
                 by_date.setdefault(date_str, []).append(
-                    {"tribunal": entry.tribunal, "item_id": f"djen-{entry.tribunal.lower()}-{entry.date.year}", "filename": f"djen-{date_str}-{entry.tribunal}.zip", "absent": False}
+                    {
+                        "tribunal": entry.tribunal,
+                        "item_id": f"djen-{entry.tribunal.lower()}-{entry.date.year}",
+                        "filename": f"djen-{date_str}-{entry.tribunal}.zip",
+                        "absent": False,
+                    }
                 )
             elif entry.djen_status == "absent":
                 by_date.setdefault(date_str, []).append(

--- a/scripts/pipeline/consolidate.py
+++ b/scripts/pipeline/consolidate.py
@@ -64,6 +64,7 @@ from causaganha.consolidate.consolidation_manifest import (
     collect_table_stats,
     update_consolidation_manifest,
 )
+from causaganha.consolidate import manifest_reader
 from causaganha.consolidate.ndjson_validator import validate_ndjson_sample
 from causaganha.consolidate.schema_registry import (
     CURRENT_VERSION,
@@ -115,11 +116,11 @@ class ConsolidationContext:
 _CHECKPOINT_STATE_FILE = Path("data/consolidate-checkpoint.json")
 
 # Sync manifest path (written by djen-backup/engine.py)
-_SYNC_MANIFEST_FILE = Path("data/sync-manifest.csv")
+_SYNC_MANIFEST_FILE = Path("data/sync-manifest.parquet")
 
 
 def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[str, Any]]]:
-    """Load sync-manifest.csv into a by-date lookup.
+    """Load the materialized manifest into a by-date lookup.
 
     The sync-manifest is the canonical state written by djen-backup/engine.py.
     Using it as an intermediate source avoids the slow IA metadata API fallback
@@ -134,41 +135,17 @@ def load_sync_manifest(path: Path = _SYNC_MANIFEST_FILE) -> dict[str, list[dict[
         as "present" for the completeness check).
         Empty dict if file does not exist.
     """
-    if not path.exists():
-        logger.info("sync_manifest_not_found", path=str(path))
-        return {}
-
     by_date: dict[str, list[dict[str, Any]]] = {}
     try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            stripped_line = line.strip()
-            if not stripped_line or stripped_line.startswith("tribunal"):
-                continue
-            parts = stripped_line.split(",")
-            if len(parts) < 3:
-                continue
-            tribunal = parts[0].upper()
-            date_str = parts[1]
-            ia_status = parts[2]
-            djen_status = parts[3] if len(parts) > 3 else ""
-
-            if ia_status == "uploaded":
-                year = date_str[:4]
-                item_id = f"djen-{tribunal.lower()}-{year}"
-                filename = f"djen-{date_str}-{tribunal}.zip"
+        for entry in manifest_reader.entries(path):
+            date_str = entry.date.isoformat()
+            if entry.ia_status == "uploaded":
                 by_date.setdefault(date_str, []).append(
-                    {
-                        "tribunal": tribunal,
-                        "item_id": item_id,
-                        "filename": filename,
-                        "absent": False,
-                    }
+                    {"tribunal": entry.tribunal, "item_id": f"djen-{entry.tribunal.lower()}-{entry.date.year}", "filename": f"djen-{date_str}-{entry.tribunal}.zip", "absent": False}
                 )
-            elif djen_status == "absent":
-                # Tribunal confirmed no publication on this date — counts as "present"
-                # for the completeness check but produces no ZIP to download.
+            elif entry.djen_status == "absent":
                 by_date.setdefault(date_str, []).append(
-                    {"tribunal": tribunal, "item_id": "", "filename": "", "absent": True}
+                    {"tribunal": entry.tribunal, "item_id": "", "filename": "", "absent": True}
                 )
     except Exception as e:
         logger.warning("sync_manifest_load_failed", path=str(path), error=str(e))

--- a/scripts/roundtrip_check.py
+++ b/scripts/roundtrip_check.py
@@ -308,8 +308,8 @@ def main() -> None:
     parser.add_argument(
         "--manifest",
         type=Path,
-        default=Path("data/sync-manifest.csv"),
-        help="Path to sync-manifest.csv",
+        default=Path("data/sync-manifest.parquet"),
+        help="Path to canonical sync-manifest.parquet (with sibling manifest-log/)",
     )
     args = parser.parse_args()
 

--- a/src/causaganha/consolidate/manifest_reader.py
+++ b/src/causaganha/consolidate/manifest_reader.py
@@ -8,13 +8,18 @@ consumers observe a newly uploaded segment before the next compaction.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from djen_backup.manifest import load_materialized_manifest
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from djen_backup.manifest import ManifestEntry, SyncManifest
 
 
 log = structlog.get_logger()
@@ -23,7 +28,7 @@ DEFAULT_MANIFEST_PATH = Path("data/sync-manifest.parquet")
 DEFAULT_SEGMENT_DIR = Path("data/manifest-log")
 
 
-def _manifest(path: Path, segment_dir: Path | None = None):
+def _manifest(path: Path, segment_dir: Path | None = None) -> SyncManifest:
     """Return the local parquet base with pending segments replayed."""
     segments = segment_dir if segment_dir is not None else path.parent / "manifest-log"
     if not path.exists():
@@ -31,20 +36,22 @@ def _manifest(path: Path, segment_dir: Path | None = None):
     return load_materialized_manifest(path, segments)
 
 
-def entries(path: Path = DEFAULT_MANIFEST_PATH):
+def entries(path: Path = DEFAULT_MANIFEST_PATH) -> list[ManifestEntry]:
     """Return entries from the canonical base with pending segments replayed."""
-    return _manifest(path)._entries.values()
+    return _manifest(path).all_entries()
 
 
 def dates_with_uploads(path: Path = DEFAULT_MANIFEST_PATH) -> Iterator[str]:
     """Yield uploaded dates, newest first, including un-compacted updates."""
-    entries = _manifest(path)._entries.values()
+    entries = _manifest(path).all_entries()
     yield from sorted(
         {entry.date.isoformat() for entry in entries if entry.ia_status == "uploaded"}, reverse=True
     )
 
 
-def uploaded_zips_for_date(date_str: str, path: Path = DEFAULT_MANIFEST_PATH) -> list[dict[str, Any]]:
+def uploaded_zips_for_date(
+    date_str: str, path: Path = DEFAULT_MANIFEST_PATH
+) -> list[dict[str, Any]]:
     """Return uploaded ZIP entries for one date after replaying pending segments."""
     return [
         {
@@ -53,7 +60,7 @@ def uploaded_zips_for_date(date_str: str, path: Path = DEFAULT_MANIFEST_PATH) ->
             "filename": f"djen-{entry.date.isoformat()}-{entry.tribunal}.zip",
             "absent": False,
         }
-        for entry in _manifest(path)._entries.values()
+        for entry in _manifest(path).all_entries()
         if entry.date.isoformat() == date_str and entry.ia_status == "uploaded"
     ]
 
@@ -70,14 +77,14 @@ def uploaded_zips_for_tribunal_year(
             "filename": f"djen-{entry.date.isoformat()}-{tribunal}.zip",
             "absent": False,
         }
-        for entry in _manifest(path)._entries.values()
+        for entry in _manifest(path).all_entries()
         if entry.tribunal == tribunal and entry.date.year == year and entry.ia_status == "uploaded"
     ]
 
 
 def counts_summary(path: Path = DEFAULT_MANIFEST_PATH) -> dict[str, int]:
     """Return manifest status counts after replaying pending segments."""
-    entries = list(_manifest(path)._entries.values())
+    entries = _manifest(path).all_entries()
     return {
         "uploaded": sum(entry.ia_status == "uploaded" for entry in entries),
         "absent": sum(entry.djen_status == "absent" for entry in entries),

--- a/src/causaganha/consolidate/manifest_reader.py
+++ b/src/causaganha/consolidate/manifest_reader.py
@@ -1,159 +1,85 @@
-"""Read sync-manifest.csv via DuckDB — no in-memory Python materialization.
+"""Query the canonical manifest parquet plus pending event-log segments.
 
-Old ``load_sync_manifest()`` built a ``dict[date, list[dict]]`` with 138K+
-nested dicts (2300 dates * ~60 tribunals). That was the cheapest of three
-manifest loaders but still held tens of MB of small Python objects.
-
-Here we query the CSV directly via ``read_csv_auto`` and return iterators
-or scalar counts — no Python dicts, no pandas DataFrames. DuckDB reads the
-CSV with columnar layout and predicate pushdown.
+The dashboard's ``sync-manifest.parquet`` is a compacted base, not a complete
+snapshot while ``manifest-log/*.csv`` exists.  This module deliberately uses
+the same replay implementation as ``SyncManifest.load_from_ia`` so local
+consumers observe a newly uploaded segment before the next compaction.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import duckdb
 import structlog
 
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
+from djen_backup.manifest import load_materialized_manifest
 
 
 log = structlog.get_logger()
 
-DEFAULT_MANIFEST_PATH = Path("data/sync-manifest.csv")
+DEFAULT_MANIFEST_PATH = Path("data/sync-manifest.parquet")
+DEFAULT_SEGMENT_DIR = Path("data/manifest-log")
 
 
-def _connect() -> duckdb.DuckDBPyConnection:
-    """Create a DuckDB in-memory connection for manifest queries."""
-    return duckdb.connect(":memory:")
-
-
-def _csv_source(path: Path) -> str:
-    """Return the SQL fragment for reading the manifest CSV via DuckDB."""
-    # read_csv_auto handles the header automatically; use single-quote escaping.
-    return f"read_csv_auto('{path.as_posix()}')"
-
-
-def dates_with_uploads(
-    path: Path = DEFAULT_MANIFEST_PATH,
-) -> Iterator[str]:
-    """Yield date strings that have at least one ``ia_status='uploaded'`` row.
-
-    Uses DuckDB to do the scan + filter + distinct without bringing the rows
-    into Python. Results yield as strings in ISO format (YYYY-MM-DD).
-    """
+def _manifest(path: Path, segment_dir: Path | None = None):
+    """Return the local parquet base with pending segments replayed."""
+    segments = segment_dir if segment_dir is not None else path.parent / "manifest-log"
     if not path.exists():
-        log.info("sync_manifest_not_found", path=str(path))
-        return
-    con = _connect()
-    try:
-        query = f"""
-            SELECT DISTINCT CAST(date AS VARCHAR) AS date_str
-            FROM {_csv_source(path)}
-            WHERE ia_status = 'uploaded'
-            ORDER BY date_str DESC
-        """
-        for row in con.execute(query).fetchall():
-            yield str(row[0])
-    finally:
-        con.close()
+        log.info("sync_manifest_parquet_not_found", path=str(path))
+    return load_materialized_manifest(path, segments)
 
 
-def uploaded_zips_for_date(
-    date_str: str,
-    path: Path = DEFAULT_MANIFEST_PATH,
-) -> list[dict[str, Any]]:
-    """Return the uploaded ZIP entries for a given date (one per tribunal).
+def entries(path: Path = DEFAULT_MANIFEST_PATH):
+    """Return entries from the canonical base with pending segments replayed."""
+    return _manifest(path)._entries.values()
 
-    This is the only query that returns rows — by design bounded to one date's
-    worth of tribunals (~60 dicts), not the full manifest.
-    """
-    if not path.exists():
-        return []
-    con = _connect()
-    try:
-        query = f"""
-            SELECT tribunal, CAST(date AS VARCHAR)
-            FROM {_csv_source(path)}
-            WHERE date = CAST(? AS DATE) AND ia_status = 'uploaded'
-            ORDER BY tribunal
-        """
-        rows = con.execute(query, [date_str]).fetchall()
-    finally:
-        con.close()
 
+def dates_with_uploads(path: Path = DEFAULT_MANIFEST_PATH) -> Iterator[str]:
+    """Yield uploaded dates, newest first, including un-compacted updates."""
+    entries = _manifest(path)._entries.values()
+    yield from sorted(
+        {entry.date.isoformat() for entry in entries if entry.ia_status == "uploaded"}, reverse=True
+    )
+
+
+def uploaded_zips_for_date(date_str: str, path: Path = DEFAULT_MANIFEST_PATH) -> list[dict[str, Any]]:
+    """Return uploaded ZIP entries for one date after replaying pending segments."""
     return [
         {
-            "tribunal": tribunal,
-            "item_id": f"djen-{tribunal.lower()}-{date_str[:4]}",
-            "filename": f"djen-{date_str}-{tribunal}.zip",
+            "tribunal": entry.tribunal,
+            "item_id": f"djen-{entry.tribunal.lower()}-{entry.date.year}",
+            "filename": f"djen-{entry.date.isoformat()}-{entry.tribunal}.zip",
             "absent": False,
         }
-        for tribunal, _ in rows
+        for entry in _manifest(path)._entries.values()
+        if entry.date.isoformat() == date_str and entry.ia_status == "uploaded"
     ]
 
 
 def uploaded_zips_for_tribunal_year(
-    tribunal: str,
-    year: int,
-    path: Path = DEFAULT_MANIFEST_PATH,
+    tribunal: str, year: int, path: Path = DEFAULT_MANIFEST_PATH
 ) -> list[dict[str, Any]]:
-    """Return all uploaded ZIP entries for a (tribunal, year) pair.
-
-    Rows are bounded to one tribunal-year (~260 business days) so the
-    materialization is small.
-    """
-    if not path.exists():
-        return []
-    con = _connect()
-    try:
-        query = f"""
-            SELECT CAST(date AS VARCHAR) AS date_str
-            FROM {_csv_source(path)}
-            WHERE tribunal = ?
-              AND EXTRACT(year FROM date) = ?
-              AND ia_status = 'uploaded'
-            ORDER BY date
-        """
-        rows = con.execute(query, [tribunal.upper(), year]).fetchall()
-    finally:
-        con.close()
-
-    item_id = f"djen-{tribunal.lower()}-{year}"
+    """Return uploaded ZIP entries for a tribunal-year including pending updates."""
+    tribunal = tribunal.upper()
     return [
         {
-            "tribunal": tribunal.upper(),
-            "item_id": item_id,
-            "filename": f"djen-{row[0]}-{tribunal.upper()}.zip",
+            "tribunal": tribunal,
+            "item_id": f"djen-{tribunal.lower()}-{year}",
+            "filename": f"djen-{entry.date.isoformat()}-{tribunal}.zip",
             "absent": False,
         }
-        for row in rows
+        for entry in _manifest(path)._entries.values()
+        if entry.tribunal == tribunal and entry.date.year == year and entry.ia_status == "uploaded"
     ]
 
 
 def counts_summary(path: Path = DEFAULT_MANIFEST_PATH) -> dict[str, int]:
-    """Return top-level counts (uploaded, absent, total) — for logging only."""
-    if not path.exists():
-        return {"uploaded": 0, "absent": 0, "total": 0}
-    con = _connect()
-    try:
-        query = f"""
-            SELECT
-                SUM(CASE WHEN ia_status = 'uploaded' THEN 1 ELSE 0 END) AS uploaded,
-                SUM(CASE WHEN djen_status = 'absent' THEN 1 ELSE 0 END) AS absent,
-                COUNT(*) AS total
-            FROM {_csv_source(path)}
-        """
-        uploaded, absent, total = con.execute(query).fetchone()
-    finally:
-        con.close()
-
+    """Return manifest status counts after replaying pending segments."""
+    entries = list(_manifest(path)._entries.values())
     return {
-        "uploaded": int(uploaded or 0),
-        "absent": int(absent or 0),
-        "total": int(total or 0),
+        "uploaded": sum(entry.ia_status == "uploaded" for entry in entries),
+        "absent": sum(entry.djen_status == "absent" for entry in entries),
+        "total": len(entries),
     }

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -72,6 +72,33 @@ def _read_parquet_rows(path: str) -> list[tuple]:
         con.close()
 
 
+def load_materialized_manifest(parquet_path: Path, segment_dir: Path) -> "SyncManifest":
+    """Load a local manifest materialization and its pending event segments.
+
+    This is the synchronous counterpart to :meth:`SyncManifest.load_from_ia`.
+    Consumers that have downloaded the dashboard state must use it rather than
+    reconstructing the retired CSV: the base parquet is replayed first and
+    lexically ordered, un-compacted segments are then applied with the same
+    field-level last-write-wins rules as the IA reader.
+    """
+    manifest = SyncManifest()
+    if parquet_path.exists():
+        for tribunal, d, ia_status, djen_status, djen_raw, updated_at in _read_parquet_rows(
+            str(parquet_path)
+        ):
+            manifest.apply_event(
+                tribunal,
+                d,
+                ia_status=ia_status or "",
+                djen_status=djen_status or "",
+                djen_raw=djen_raw or "",
+                updated_at=updated_at or "",
+            )
+    for segment_path in sorted(segment_dir.glob("*.csv")) if segment_dir.exists() else []:
+        manifest.apply_segment_csv(segment_path.read_text(encoding="utf-8"))
+    return manifest
+
+
 class ManifestCounts(NamedTuple):
     """Aggregate counts for progress display."""
 

--- a/src/djen_backup/manifest.py
+++ b/src/djen_backup/manifest.py
@@ -72,7 +72,7 @@ def _read_parquet_rows(path: str) -> list[tuple]:
         con.close()
 
 
-def load_materialized_manifest(parquet_path: Path, segment_dir: Path) -> "SyncManifest":
+def load_materialized_manifest(parquet_path: Path, segment_dir: Path) -> SyncManifest:
     """Load a local manifest materialization and its pending event segments.
 
     This is the synchronous counterpart to :meth:`SyncManifest.load_from_ia`.
@@ -156,6 +156,10 @@ class SyncManifest:
     def __len__(self) -> int:
         """Return number of manifest entries."""
         return len(self._entries)
+
+    def all_entries(self) -> list[ManifestEntry]:
+        """Return a snapshot of every manifest entry."""
+        return list(self._entries.values())
 
     @staticmethod
     def _key(tribunal: str, d: date) -> str:

--- a/tests/consolidate/conftest.py
+++ b/tests/consolidate/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+import duckdb
 
 
 if TYPE_CHECKING:
@@ -13,22 +14,18 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def manifest_path(tmp_path: Path) -> Path:
-    """Path to a disposable sync-manifest.csv file per test."""
-    return tmp_path / "sync-manifest.csv"
+    """Path to a disposable canonical manifest parquet per test."""
+    return tmp_path / "sync-manifest.parquet"
 
 
 def write_manifest(path: Path, rows: list[dict]) -> None:
-    """Write rows to a sync-manifest.csv with the expected header."""
-    header = "tribunal,date,ia_status,djen_status,djen_raw,updated_at"
-    lines = [header]
-    for row in rows:
-        line = (
-            f"{row.get('tribunal', 'TJSP')},"
-            f"{row['date']},"
-            f"{row.get('ia_status', '')},"
-            f"{row.get('djen_status', '')},"
-            f"{row.get('djen_raw', '')},"
-            f"{row.get('updated_at', '')}"
-        )
-        lines.append(line)
-    path.write_text("\n".join(lines) + "\n")
+    """Write a canonical manifest parquet with the expected schema."""
+    con = duckdb.connect()
+    try:
+        con.execute("CREATE TABLE manifest (tribunal VARCHAR, date DATE, ia_status VARCHAR, djen_status VARCHAR, djen_raw VARCHAR, updated_at VARCHAR)")
+        values = [(row.get("tribunal", "TJSP"), row["date"], row.get("ia_status", ""), row.get("djen_status", ""), row.get("djen_raw", ""), row.get("updated_at", "")) for row in rows]
+        if values:
+            con.executemany("INSERT INTO manifest VALUES (?, ?, ?, ?, ?, ?)", values)
+        con.execute("COPY manifest TO ? (FORMAT PARQUET)", [str(path)])
+    finally:
+        con.close()

--- a/tests/consolidate/conftest.py
+++ b/tests/consolidate/conftest.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 import duckdb
+import pytest
 
 
 if TYPE_CHECKING:
@@ -22,8 +22,22 @@ def write_manifest(path: Path, rows: list[dict]) -> None:
     """Write a canonical manifest parquet with the expected schema."""
     con = duckdb.connect()
     try:
-        con.execute("CREATE TABLE manifest (tribunal VARCHAR, date DATE, ia_status VARCHAR, djen_status VARCHAR, djen_raw VARCHAR, updated_at VARCHAR)")
-        values = [(row.get("tribunal", "TJSP"), row["date"], row.get("ia_status", ""), row.get("djen_status", ""), row.get("djen_raw", ""), row.get("updated_at", "")) for row in rows]
+        con.execute(
+            "CREATE TABLE manifest ("
+            "tribunal VARCHAR, date DATE, ia_status VARCHAR, "
+            "djen_status VARCHAR, djen_raw VARCHAR, updated_at VARCHAR)"
+        )
+        values = [
+            (
+                row.get("tribunal", "TJSP"),
+                row["date"],
+                row.get("ia_status", ""),
+                row.get("djen_status", ""),
+                row.get("djen_raw", ""),
+                row.get("updated_at", ""),
+            )
+            for row in rows
+        ]
         if values:
             con.executemany("INSERT INTO manifest VALUES (?, ?, ?, ?, ?, ?)", values)
         con.execute("COPY manifest TO ? (FORMAT PARQUET)", [str(path)])

--- a/tests/consolidate/test_discovery_bdd.py
+++ b/tests/consolidate/test_discovery_bdd.py
@@ -61,14 +61,18 @@ def manifest_with_mixed(tmp_path: Path, count: int) -> Path:
 def append_uploaded(manifest: Path, date_str: str) -> None:
     segment = manifest.parent / "manifest-log" / f"{date_str}-uploaded.csv"
     segment.parent.mkdir(exist_ok=True)
-    segment.write_text(f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},uploaded,,200,{date_str}T00:00:00Z\n")
+    segment.write_text(
+        f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},uploaded,,200,{date_str}T00:00:00Z\n"
+    )
 
 
 @given(parsers.parse('date {date_str} has djen_status="absent" and no ia_status'))
 def append_absent(manifest: Path, date_str: str) -> None:
     segment = manifest.parent / "manifest-log" / f"{date_str}-absent.csv"
     segment.parent.mkdir(exist_ok=True)
-    segment.write_text(f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},,absent,404,{date_str}T00:00:00Z\n")
+    segment.write_text(
+        f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},,absent,404,{date_str}T00:00:00Z\n"
+    )
 
 
 @given("no sync-manifest file exists", target_fixture="manifest")

--- a/tests/consolidate/test_discovery_bdd.py
+++ b/tests/consolidate/test_discovery_bdd.py
@@ -28,7 +28,7 @@ def ctx() -> dict:
     target_fixture="manifest",
 )
 def manifest_with_three_dates(tmp_path: Path, count: int, d1: str, d2: str, d3: str) -> Path:
-    path = tmp_path / "sync-manifest.csv"
+    path = tmp_path / "sync-manifest.parquet"
     write_manifest(
         path,
         [
@@ -52,28 +52,28 @@ def _noop_already_uploaded() -> None:
 )
 def manifest_with_mixed(tmp_path: Path, count: int) -> Path:
     # The following step-defs populate it specifically
-    path = tmp_path / "sync-manifest.csv"
+    path = tmp_path / "sync-manifest.parquet"
     write_manifest(path, [])
     return path
 
 
 @given(parsers.parse('date {date_str} has ia_status="uploaded"'))
 def append_uploaded(manifest: Path, date_str: str) -> None:
-    existing = manifest.read_text().strip().splitlines()
-    existing.append(f"TJSP,{date_str},uploaded,,200,")
-    manifest.write_text("\n".join(existing) + "\n")
+    segment = manifest.parent / "manifest-log" / f"{date_str}-uploaded.csv"
+    segment.parent.mkdir(exist_ok=True)
+    segment.write_text(f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},uploaded,,200,{date_str}T00:00:00Z\n")
 
 
 @given(parsers.parse('date {date_str} has djen_status="absent" and no ia_status'))
 def append_absent(manifest: Path, date_str: str) -> None:
-    existing = manifest.read_text().strip().splitlines()
-    existing.append(f"TJSP,{date_str},,absent,404,")
-    manifest.write_text("\n".join(existing) + "\n")
+    segment = manifest.parent / "manifest-log" / f"{date_str}-absent.csv"
+    segment.parent.mkdir(exist_ok=True)
+    segment.write_text(f"tribunal,date,ia_status,djen_status,djen_raw,updated_at\nTJSP,{date_str},,absent,404,{date_str}T00:00:00Z\n")
 
 
 @given("no sync-manifest file exists", target_fixture="manifest")
 def no_manifest(tmp_path: Path) -> Path:
-    return tmp_path / "absent.csv"
+    return tmp_path / "absent.parquet"
 
 
 @given(
@@ -81,7 +81,7 @@ def no_manifest(tmp_path: Path) -> Path:
     target_fixture="manifest",
 )
 def manifest_with_counts(tmp_path: Path, up: int, ab: int, unk: int) -> Path:
-    path = tmp_path / "sync-manifest.csv"
+    path = tmp_path / "sync-manifest.parquet"
     rows: list[dict] = [
         {"tribunal": "TJSP", "date": f"2026-01-{i + 1:02d}", "ia_status": "uploaded"}
         for i in range(up)

--- a/tests/test_catalog_parsing.py
+++ b/tests/test_catalog_parsing.py
@@ -21,20 +21,37 @@ def test_get_items_from_sync_manifest() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         manifest_file = Path(tmpdir) / "sync-manifest.parquet"
         con = duckdb.connect()
-        con.execute("CREATE TABLE manifest AS SELECT * FROM (VALUES ('TJSP', DATE '2026-01-01', 'uploaded', 'available', '200', '2026-01-01T10:00:00Z'), ('TJMG', DATE '2026-01-02', 'uploaded', 'available', '200', '2026-01-02T10:00:00Z'), ('TJRO', DATE '2025-12-31', 'uploaded', 'available', '200', '2025-12-31T10:00:00Z')) AS t(tribunal, date, ia_status, djen_status, djen_raw, updated_at)")
+        con.execute(
+            "CREATE TABLE manifest AS SELECT * FROM (VALUES "
+            "('TJSP', DATE '2026-01-01', 'uploaded', 'available', '200', "
+            "'2026-01-01T10:00:00Z'), "
+            "('TJMG', DATE '2026-01-02', 'uploaded', 'available', '200', "
+            "'2026-01-02T10:00:00Z'), "
+            "('TJRO', DATE '2025-12-31', 'uploaded', 'available', '200', "
+            "'2025-12-31T10:00:00Z')) AS t("
+            "tribunal, date, ia_status, djen_status, djen_raw, updated_at)"
+        )
         con.execute("COPY manifest TO ? (FORMAT PARQUET)", [str(manifest_file)])
         res = get_items_from_sync_manifest(manifest_file)
         assert sorted(res) == ["djen-tjmg-2026", "djen-tjro-2025", "djen-tjsp-2026"]
 
         # 3. Only non-uploaded entries → empty
-        con.execute("DELETE FROM manifest; INSERT INTO manifest VALUES ('TJSP', DATE '2026-01-01', 'pending', 'available', '200', '2026-01-01T10:00:00Z')")
-        con.execute("COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)])
+        con.execute(
+            "DELETE FROM manifest; INSERT INTO manifest VALUES "
+            "('TJSP', DATE '2026-01-01', 'pending', 'available', '200', "
+            "'2026-01-01T10:00:00Z')"
+        )
+        con.execute(
+            "COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)]
+        )
         res = get_items_from_sync_manifest(manifest_file)
         assert res == []
 
         # 4. Empty file (header only) → empty
         con.execute("DELETE FROM manifest")
-        con.execute("COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)])
+        con.execute(
+            "COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)]
+        )
         con.close()
         res = get_items_from_sync_manifest(manifest_file)
         assert res == []

--- a/tests/test_catalog_parsing.py
+++ b/tests/test_catalog_parsing.py
@@ -2,6 +2,8 @@ import tempfile
 from datetime import date
 from pathlib import Path
 
+import duckdb
+
 from scripts.generate_catalog import (
     calculate_completed_items,
     get_items_from_sync_manifest,
@@ -13,32 +15,27 @@ from scripts.generate_catalog import (
 
 def test_get_items_from_sync_manifest() -> None:
     # 1. Missing file
-    res = get_items_from_sync_manifest(Path("non_existent_sync_manifest.csv"))
+    res = get_items_from_sync_manifest(Path("non_existent_sync_manifest.parquet"))
     assert res == []
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        manifest_file = Path(tmpdir) / "sync-manifest.csv"
-
-        # 2. Valid CSV with multiple uploaded entries across tribunals/years
-        manifest_file.write_text(
-            "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
-            "TJSP,2026-01-01,uploaded,available,200,2026-01-01T10:00:00Z\n"
-            "TJMG,2026-01-02,uploaded,available,200,2026-01-02T10:00:00Z\n"
-            "TJRO,2025-12-31,uploaded,available,200,2025-12-31T10:00:00Z\n"
-        )
+        manifest_file = Path(tmpdir) / "sync-manifest.parquet"
+        con = duckdb.connect()
+        con.execute("CREATE TABLE manifest AS SELECT * FROM (VALUES ('TJSP', DATE '2026-01-01', 'uploaded', 'available', '200', '2026-01-01T10:00:00Z'), ('TJMG', DATE '2026-01-02', 'uploaded', 'available', '200', '2026-01-02T10:00:00Z'), ('TJRO', DATE '2025-12-31', 'uploaded', 'available', '200', '2025-12-31T10:00:00Z')) AS t(tribunal, date, ia_status, djen_status, djen_raw, updated_at)")
+        con.execute("COPY manifest TO ? (FORMAT PARQUET)", [str(manifest_file)])
         res = get_items_from_sync_manifest(manifest_file)
         assert sorted(res) == ["djen-tjmg-2026", "djen-tjro-2025", "djen-tjsp-2026"]
 
         # 3. Only non-uploaded entries → empty
-        manifest_file.write_text(
-            "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
-            "TJSP,2026-01-01,pending,available,200,2026-01-01T10:00:00Z\n"
-        )
+        con.execute("DELETE FROM manifest; INSERT INTO manifest VALUES ('TJSP', DATE '2026-01-01', 'pending', 'available', '200', '2026-01-01T10:00:00Z')")
+        con.execute("COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)])
         res = get_items_from_sync_manifest(manifest_file)
         assert res == []
 
         # 4. Empty file (header only) → empty
-        manifest_file.write_text("tribunal,date,ia_status,djen_status,djen_raw,updated_at\n")
+        con.execute("DELETE FROM manifest")
+        con.execute("COPY manifest TO ? (FORMAT PARQUET, OVERWRITE_OR_IGNORE TRUE)", [str(manifest_file)])
+        con.close()
         res = get_items_from_sync_manifest(manifest_file)
         assert res == []
 

--- a/tests/test_manifest_materialized_consumers.py
+++ b/tests/test_manifest_materialized_consumers.py
@@ -1,0 +1,34 @@
+"""Consumers must observe event-log updates before manifest compaction."""
+
+from pathlib import Path
+
+import duckdb
+
+from scripts.generate_catalog import get_items_from_sync_manifest
+from scripts.pipeline.consolidate import load_sync_manifest
+
+
+def test_consumers_replay_pending_segment_without_csv(tmp_path: Path) -> None:
+    """Catalog and consolidation see an uploaded event absent from the base."""
+    parquet = tmp_path / "sync-manifest.parquet"
+    con = duckdb.connect()
+    try:
+        con.execute(
+            "CREATE TABLE manifest AS SELECT * FROM (VALUES "
+            "('TJSP', DATE '2026-01-01', '', 'available', '200', '2026-01-01T00:00:00Z')) "
+            "AS t(tribunal, date, ia_status, djen_status, djen_raw, updated_at)"
+        )
+        con.execute("COPY manifest TO ? (FORMAT PARQUET)", [str(parquet)])
+    finally:
+        con.close()
+
+    segment_dir = tmp_path / "manifest-log"
+    segment_dir.mkdir()
+    (segment_dir / "20260102T000000Z-engine-1.csv").write_text(
+        "tribunal,date,ia_status,djen_status,djen_raw,updated_at\n"
+        "TJSP,2026-01-01,uploaded,available,200,2026-01-02T00:00:00Z\n",
+        encoding="utf-8",
+    )
+
+    assert get_items_from_sync_manifest(parquet) == ["djen-tjsp-2026"]
+    assert load_sync_manifest(parquet)["2026-01-01"][0]["filename"] == "djen-2026-01-01-TJSP.zip"


### PR DESCRIPTION
### Motivation
- Replace fragile runtime CSV fallbacks with the canonical materialized manifest plus pending immutable `manifest-log/` segments so consumers see pending updates before compaction. 
- Avoid reconstructing the retired `data/sync-manifest.csv` in workflows and scripts, and adopt the same replay semantics used by `SyncManifest.load_from_ia` for local consumers.

### Description
- Added `load_materialized_manifest(parquet_path, segment_dir)` in `src/djen_backup/manifest.py` to synchronously load `sync-manifest.parquet` and replay sorted `manifest-log/*.csv` segments into a `SyncManifest` instance.
- Replaced CSV-based manifest readers with a materialized-reader module at `src/causaganha/consolidate/manifest_reader.py` that exposes `entries()`, `dates_with_uploads()`, `uploaded_zips_for_date()`, `uploaded_zips_for_tribunal_year()`, and `counts_summary()` by replaying the parquet + segment log.
- Updated runtime consumers to use the materialized manifest: `scripts/pipeline/consolidate.py`, `scripts/generate_catalog.py`, `scripts/roundtrip_check.py`, and `scripts/append_manifest.py` now read from the parquet + `manifest-log/` segments instead of `data/sync-manifest.csv`.
- Removed CSV reconstruction steps from workflows and local download actions by changing `.github/workflows/consolidate-parquet.yml`, `.github/workflows/roundtrip-check.yml`, and `.github/actions/download-state/action.yml` to download the parquet base and pull `manifest-log/*.csv` files into `data/manifest-log/`.
- Added a regression test `tests/test_manifest_materialized_consumers.py` and adjusted BDD fixtures/tests to write/read the canonical parquet + segment layout to prove consumers observe an un-compacted segment update without CSV regeneration.

### Testing
- Ran unit/BDD tests for affected areas with `uv run pytest tests/test_catalog_parsing.py tests/consolidate/test_discovery_bdd.py tests/test_manifest_materialized_consumers.py -q`, and the tests passed.
- Verified bytecode build with `uv run python -m compileall -q src scripts`, which completed successfully. 
- Ran `git diff --check` to surface any whitespace/diff issues and resolved the results; no remaining blocking check errors were reported by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62cd2fb19883258b0494de5cad6a87)