### PR TITLE
design: map CausaGanha foundations onto Cobogó semantic roles

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,6 +3,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Piazzolla:ital,wght@0,400;0,500;0,700;1,400;1,500&display=swap');
 
 @import './styles/tokens.css';
+@import './styles/cobogo-mapping.css';
 @import './styles/base.css';
 @import './styles/layout.css';
 @import './styles/navigation.css';

--- a/web/src/styles/cobogo-mapping.css
+++ b/web/src/styles/cobogo-mapping.css
@@ -1,0 +1,49 @@
+/* CausaGanha → Cobogó semantic mapping
+ *
+ * This is an adoption bridge, not a copy of Cobogó core. It changes token
+ * authority without changing the product's appearance. The values remain
+ * CausaGanha-owned; the semantic role names are the shared contract.
+ */
+
+:root {
+  /* Shared semantic roles bound to CausaGanha's existing product identity. */
+  --cobogo-canvas: var(--pico-background-color);
+  --cobogo-surface: var(--pico-card-background-color);
+  --cobogo-surface-muted: var(--pico-card-sectioning-background-color);
+  --cobogo-text: var(--pico-color);
+  --cobogo-text-muted: var(--pico-muted-color);
+  --cobogo-border: var(--pico-muted-border-color);
+  --cobogo-accent: var(--accent-gold);
+  --cobogo-focus: var(--pico-primary);
+  --cobogo-info: var(--color-info);
+  --cobogo-success: var(--color-success);
+  --cobogo-warning: var(--color-warning);
+  --cobogo-danger: var(--color-error);
+
+  --cobogo-font-body: var(--font-sans);
+  --cobogo-font-display: var(--font-serif);
+  --cobogo-font-inscription: var(--font-sans);
+  --cobogo-font-data: var(--font-mono);
+
+  --cobogo-space-adjacent: var(--space-2);
+  --cobogo-space-group: var(--space-4);
+  --cobogo-space-section: var(--space-8);
+  --cobogo-space-pause: var(--space-20);
+
+  --cobogo-radius-control: var(--radius-field);
+  --cobogo-radius-surface: var(--radius-box);
+  --cobogo-shadow-raised: var(--shadow-sm);
+  --cobogo-motion-state: var(--transition-base);
+  --cobogo-motion-spatial: var(--transition-slow);
+
+  /* Existing generic aliases now resolve through shared semantic roles. */
+  --color-bg: var(--cobogo-canvas);
+  --color-surface: var(--cobogo-surface);
+  --color-content: var(--cobogo-text);
+  --color-content-tertiary: var(--cobogo-text-muted);
+  --color-border: var(--cobogo-border);
+}
+
+/* Pico remains an adapter. Its theme switch changes the underlying product
+ * values; the Cobogó semantic roles above follow those values automatically.
+ */


### PR DESCRIPTION
## Context

First downstream slice from CausaGanha #861 and Cobogó #263/#266.

This intentionally changes **authority before appearance**. It does not copy Cobogó core and does not add an unreproducible dependency on an unmerged/unreleased branch.

## What changes

- adds `web/src/styles/cobogo-mapping.css`;
- maps existing CausaGanha values to Cobogó semantic roles (`canvas`, `surface`, `text`, `accent`, `focus`, type and spacing relationships);
- keeps green/gold, typography, Pico and dark-mode values product-owned;
- routes existing generic background/surface/text/border aliases through the shared semantic vocabulary;
- Pico remains an adapter rather than source of shared semantics.

## What does not change

- no visual redesign;
- no framework/runtime change;
- no copied Cobogó core CSS;
- no package/lockfile modification;
- no page markup migration yet.

A follow-up PR will import `cobogo/core` and migrate one real data-reading surface once the upstream entrypoint from franklinbaldo/cobogo#283 has a reproducible distribution boundary.

No merge requested.