### PR TITLE
design: make stats provenance and coverage table semantically explicit

### DIFF
--- a/web/src/lib/data/siteStatus.test.ts
+++ b/web/src/lib/data/siteStatus.test.ts
@@ -7,6 +7,7 @@ import {
   evaluateSourceFreshness,
   freshnessDisplayLabel,
   formatUtcDateTime,
+  utcDateTimeAttr,
   parseTimestamp,
   pctOfTotal,
   STALE_BUILD_LIMIT_MS,
@@ -255,6 +256,22 @@ describe('timestamp display helpers', () => {
   it('formatUtcDateTime: invalid input → null, so pages render an explicit fallback', () => {
     expect(formatUtcDateTime('Invalid Date')).toBeNull();
     expect(formatUtcDateTime(null)).toBeNull();
+  });
+
+  it('utcDateTimeAttr: invalid input → null, so <time> is omitted instead of carrying junk', () => {
+    expect(utcDateTimeAttr('Invalid Date')).toBeNull();
+    expect(utcDateTimeAttr(null)).toBeNull();
+    expect(utcDateTimeAttr(undefined)).toBeNull();
+  });
+
+  it('utcDateTimeAttr: emits ISO 8601 UTC for the same instant the human label shows', () => {
+    const raw = '2026-07-10T08:30:00Z';
+    expect(utcDateTimeAttr(raw)).toBe('2026-07-10T08:30:00.000Z');
+    expect(formatUtcDateTime(raw)).toContain('10/07/2026');
+  });
+
+  it('utcDateTimeAttr: normalises a non-UTC offset to the same instant', () => {
+    expect(utcDateTimeAttr('2026-07-10T05:30:00-03:00')).toBe('2026-07-10T08:30:00.000Z');
   });
 
   it('formatUtcDateTime: valid ISO renders pt-BR UTC, never "Invalid Date UTC"', () => {

--- a/web/src/lib/data/siteStatus.ts
+++ b/web/src/lib/data/siteStatus.ts
@@ -69,6 +69,19 @@ export function parseTimestamp(value: string | null | undefined): number | null 
  * Ausente ou imparseável → null (o chamador exibe um fallback explícito,
  * nunca "Invalid Date UTC").
  */
+/**
+ * Valor para o atributo `datetime` de `<time>`: mesmo instante que
+ * `formatUtcDateTime` renderiza para humanos, em ISO 8601 UTC.
+ *
+ * O texto visível continua em pt-BR; isto existe para que leitores de tela,
+ * feeds e verificações automáticas de frescor consigam ler a data.
+ */
+export function utcDateTimeAttr(value: string | null | undefined): string | null {
+  const ms = parseTimestamp(value);
+  if (ms === null) return null;
+  return new Date(ms).toISOString();
+}
+
 export function formatUtcDateTime(value: string | null | undefined): string | null {
   const ms = parseTimestamp(value);
   if (ms === null) return null;

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -10,6 +10,7 @@ import {
   evaluateSourceFreshness,
   freshnessDisplayLabel,
   formatUtcDateTime,
+  utcDateTimeAttr,
   pctOfTotal,
 } from '../lib/data/siteStatus';
 
@@ -34,6 +35,7 @@ const weeklyPattern = (await loadContract('weekly_pattern')) ?? [];
 // nascer como um novo contrato .qmd, não de um snapshot paralelo.
 const tribunalCoverage = (await loadContract('tribunal_coverage')) ?? [];
 const generatedAtLabel = formatUtcDateTime(siteStatus.generated_at) ?? 'desconhecido';
+const generatedAtIso = utcDateTimeAttr(siteStatus.generated_at);
 
 function coverageTone(pct: number): string {
   if (pct >= 80) return 'success';
@@ -49,6 +51,8 @@ const djenFreshness = evaluateSourceFreshness(djen, Date.now());
 const freshnessLabel = freshnessDisplayLabel(djenFreshness);
 const lastAttempt = formatUtcDateTime(djen.last_attempt_at);
 const lastSuccess = formatUtcDateTime(djen.last_success_at);
+const lastAttemptIso = utcDateTimeAttr(djen.last_attempt_at);
+const lastSuccessIso = utcDateTimeAttr(djen.last_success_at);
 const avgCoverage30 = statsCoverage?.avg_coverage ?? 0;
 const bestCount = statsCoverage?.best_count ?? 0;
 const bestDay = statsCoverage?.best_day ?? null;
@@ -89,7 +93,7 @@ const base = import.meta.env.BASE_URL;
     <article>
       <header>
         <strong>Resumo de Cobertura</strong>
-        <small data-tone="muted">Últimos 30 dias · Fonte DJEN: {freshnessLabel} — última tentativa {lastAttempt ?? 'desconhecida'} · último sucesso {lastSuccess ?? 'desconhecido'}</small>
+        <small data-tone="muted">Últimos 30 dias · Fonte DJEN: {freshnessLabel} — última tentativa {lastAttempt && lastAttemptIso ? (<time datetime={lastAttemptIso}>{lastAttempt}</time>) : 'desconhecida'} · último sucesso {lastSuccess && lastSuccessIso ? (<time datetime={lastSuccessIso}>{lastSuccess}</time>) : 'desconhecido'}</small>
       </header>
       <div class="auto-grid">
         <StatCard
@@ -176,20 +180,23 @@ const base = import.meta.env.BASE_URL;
     <article>
       <header>
         <strong>Cobertura por tribunal</strong>
-        <small data-tone="muted">Contrato tribunal_coverage, renderizado do manifesto canônico (sync-manifest.parquet) · gerado em {generatedAtLabel}</small>
+        <small data-tone="muted">Contrato tribunal_coverage, renderizado do manifesto canônico (sync-manifest.parquet) · gerado em {generatedAtIso ? (<time datetime={generatedAtIso}>{generatedAtLabel}</time>) : generatedAtLabel}</small>
       </header>
       {tribunalCoverage.length > 0 ? (
         <div class="table-wrap">
           <table>
+            <caption class="sr-only">
+              Cobertura por tribunal: ZIPs arquivados no Internet Archive, pendentes, ausentes e desconhecidos, percentual de cobertura e período arquivado para cada tribunal.
+            </caption>
             <thead>
               <tr>
-                <th>Tribunal</th>
-                <th>ZIPs no IA</th>
-                <th>Pendente</th>
-                <th>Ausente</th>
-                <th>Desconhecido</th>
-                <th>Cobertura</th>
-                <th>Período arquivado</th>
+                <th scope="col">Tribunal</th>
+                <th scope="col">ZIPs no IA</th>
+                <th scope="col">Pendente</th>
+                <th scope="col">Ausente</th>
+                <th scope="col">Desconhecido</th>
+                <th scope="col">Cobertura</th>
+                <th scope="col">Período arquivado</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Closes #864.

`/stats` already states provenance more carefully than most surfaces do — it distinguishes *last attempt* from *last success*, which is a real editorial decision. But every timestamp rendered as text only, so the freshness it works hard to communicate was unavailable to assistive technology and to any automated staleness check.

## What changed

- **`utcDateTimeAttr`** next to `formatUtcDateTime`: same instant, ISO 8601 UTC, `null` on invalid input so `<time>` is omitted rather than carrying junk;
- `generated_at`, `last_attempt` and `last_success` wrapped in `<time datetime>`, **visible pt-BR text unchanged**;
- `scope="col"` on the 7 coverage headers;
- a screen-reader `<caption>` naming what the 96-row table actually contains.

## Verified against a real build, not a fixture

The real pipeline was run (`uv run python scripts/render_queries.py`, 18 queries against the archived manifest), then the page was built and inspected in Chromium:

| check | result |
|---|---|
| `<time>` elements | **3**, e.g. `datetime="2026-08-11T03:23:09.000Z"` → *"11/08/2026, 03:23 UTC"* |
| `th[scope="col"]` | **7 / 7** |
| `<caption>` | present, `position: absolute` (visually hidden) |
| `tbody tr` | 96 |

`astro check`: 0 errors. `siteStatus.test.ts`: 27 passed, including three new cases covering invalid input, ISO output matching the human label, and normalisation of a non-UTC offset to the same instant.

No visual change — the rendered page is identical apart from data that moved because the pipeline refreshed.

## Deliberately out of scope

The green/red coverage tinting is untouched. Whether that state needs non-colour redundancy depends on the reading task, and mixing it in here would bundle a judgement call with a mechanical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P)_