### PR TITLE
chore: apply ruff format to docs code blocks

### DIFF
--- a/docs/planning/consolidation-plan.md
+++ b/docs/planning/consolidation-plan.md
@@ -76,14 +76,14 @@ DuckDB compila e executa como SQL.
 **Errado:**
 ```python
 rows = []
-for record in ndjson_data:       # Python loop → O(n) overhead
+for record in ndjson_data:  # Python loop → O(n) overhead
     rows.append(transform(record))
 ```
 
 **Certo:**
 ```python
-t = con.read_json(path)          # DuckDB lê e transforma em SQL
-result = (t.select(...).filter(...).mutate(...))  # expressão lazy
+t = con.read_json(path)  # DuckDB lê e transforma em SQL
+result = t.select(...).filter(...).mutate(...)  # expressão lazy
 ```
 
 ### 2.3 Delay de materialização — `.execute()` só no `COPY`

--- a/docs/rfc/0004-embeddings-juris-stj.md
+++ b/docs/rfc/0004-embeddings-juris-stj.md
@@ -198,6 +198,7 @@ Criar tabelas `tjro_juris` e `stj_primeira_secao` no LanceDB existente
 class TJROJurisSource:
     """Itera sobre os Parquets do TJRO JURIS e produz (texto, metadados)."""
 
+
 # src/causaganha/analysis/sources/stj_source.py
 class STJSource:
     """Itera sobre o Parquet consolidado do STJ e produz (texto, metadados)."""

--- a/docs/rfc/0005-processo-como-recurso.md
+++ b/docs/rfc/0005-processo-como-recurso.md
@@ -190,6 +190,7 @@ def normalizar_cnj(n: str) -> str:
     d = re.sub(r"\D", "", n or "")
     return d if len(d) == 20 else ""
 
+
 def formatar_cnj(n: str) -> str:
     """20 dígitos → NNNNNNN-DD.AAAA.J.TR.OOOO."""
     if len(n) != 20:


### PR DESCRIPTION
`ruff format --check` fails on `main` as-is — *"3 files would be reformatted, 405 files already formatted"* — so every open PR inherits a red `lint` from the base branch regardless of what it changes.

Verified against pristine `main`, not against any feature branch.

The diff is confined to Python snippets inside documentation:

- `docs/planning/consolidation-plan.md` — comment alignment and one redundant parenthesis pair;
- `docs/rfc/0004-embeddings-juris-stj.md` — blank line between class definitions;
- `docs/rfc/0005-processo-como-recurso.md` — blank line between function definitions.

No prose changed, no semantics changed. Purely what the repository's own formatter mandates.

Opened separately from #865 so a mechanical base-branch fix does not ride along with a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P)_