### PR TITLE
ci: pin ruff exactly so `ALL` does not silently change policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,12 @@ dev = [
     "pytest-bdd>=7.0.0",
     "pytest-cov>=6.2.1",
     "respx>=0.22.0",
-    "ruff>=0.12.0",
+    # Pinned exactly, not floored. ruff.toml uses select = ["ALL"], so any newly
+    # stabilised rule in a future release silently becomes CI policy — and
+    # uv.lock is gitignored, so nothing else holds the version steady. Moving to
+    # a newer ruff should be a deliberate migration PR that decides which
+    # newly stabilised rules we actually want.
+    "ruff==0.15.22",
     # Runtime of deployment/relay/function/main.py (Cloud Run relay) — needed
     # to import and unit-test it; not used anywhere else in the repo.
     "functions-framework>=3.0.0",


### PR DESCRIPTION
CI `lint` went red on `main` without a code change. The cause is **toolchain drift, not 269 new defects**.

Three things combine:

- `ruff.toml` uses `select = ["ALL"]`;
- `pyproject.toml` floors ruff at `>=0.12.0`;
- `uv.lock` is **gitignored**, so nothing holds the version steady.

CI therefore resolves whatever ruff is newest, and every newly stabilised rule becomes enforced policy the moment upstream ships it. No one decided that.

## Measured on pristine `main`

| ruff | `ruff check .` | `ruff format --check .` |
|---|---|---|
| **0.16.2** (what CI resolves today) | **269 errors** | 3 files would be reformatted |
| **0.15.22** (this pin) | **All checks passed** | 268 files already formatted |

The 269 break down as 260 `CPY001` (missing copyright notice), 5 `ISC004`, 3 `LOG004`, 1 `S310`, 1 `RUF100`.

The formatting difference has the same root cause: **0.15.x does not process markdown at all** — it reports *"No Python files found under the given path(s)"* for `docs/rfc/`. Those three `.md` files only look unformatted under 0.16's new markdown code-block formatting.

## What this PR does not do

- does not add copyright headers to 260 files;
- does not add per-file `CPY001` ignores;
- does not touch any other newly stabilised rule;
- does not change a single line of product code.

## Follow-up, deliberately not bundled

Moving to ruff `>=0.16` should be its own migration PR that decides consciously which newly stabilised rules belong in the policy — `CPY001` in particular, since adopting it means choosing a notice, a holder and a year range for 260 files, and deciding whether tests carry one at all.

Worth considering separately: versioning `uv.lock`, so the linter version is reproducible rather than resolved fresh on every run.

Supersedes #866 — with this pin, those three files are already formatted, so that PR becomes unnecessary. #865 is blocked only by this and needs no changes of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKgoXdgFEf7QbyT5F8CH4P)_