### PR TITLE
a11y(stats): expose archived tribunal ranges as time

### DIFF
--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -215,7 +215,15 @@ const base = import.meta.env.BASE_URL;
                     </td>
                     <td>
                       {t.earliest_upload ? (
-                        <small>{t.earliest_upload} → {t.latest_upload}</small>
+                        <small>
+                          <time datetime={t.earliest_upload}>{t.earliest_upload}</time>
+                          {' → '}
+                          {t.latest_upload ? (
+                            <time datetime={t.latest_upload}>{t.latest_upload}</time>
+                          ) : (
+                            <span data-tone="muted">—</span>
+                          )}
+                        </small>
                       ) : (
                         <span data-tone="muted">—</span>
                       )}


### PR DESCRIPTION
Closes #870. Follows the existing incremental Cobogó adoption plan in #861 and upstream `franklinbaldo/cobogo#267/#270`.

This is deliberately one semantic correction on the already-validated `/stats` surface: each present archived-period bound now uses native `<time datetime>` while preserving the exact visible ISO date text and existing arrow/layout. A missing latest bound remains explicit instead of being fabricated.

No CSS, JS, data contract or domain semantics changed.